### PR TITLE
Fix injection of old decorated controller resolver service

### DIFF
--- a/packages/ControllerAutowire/src/DependencyInjection/Compiler/DecorateControllerResolverPass.php
+++ b/packages/ControllerAutowire/src/DependencyInjection/Compiler/DecorateControllerResolverPass.php
@@ -23,6 +23,10 @@ final class DecorateControllerResolverPass implements CompilerPassInterface
      * @var string
      */
     const CONTROLLER_RESOLVER_SERVICE_NAME = 'controller_resolver';
+    /**
+     * @var string
+     */
+    const SERVICE_NAME = 'symplify.controller_resolver';
 
     /**
      * @var ControllerClassMapInterface
@@ -36,19 +40,19 @@ final class DecorateControllerResolverPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $containerBuilder)
     {
-        $controllerResolverServiceName = $this->getCurrentControllerResolverServiceName($containerBuilder);
+        $decoratedControllerResolverServiceName = $this->getCurrentControllerResolverServiceName($containerBuilder);
 
         $definition = new Definition(ControllerResolver::class, [
-            new Reference($controllerResolverServiceName . '.inner'),
+            new Reference(self::SERVICE_NAME . '.inner'),
             new Reference('service_container'),
             new Reference('controller_name_converter'),
         ]);
 
-        $definition->setDecoratedService($controllerResolverServiceName, null, 1);
+        $definition->setDecoratedService($decoratedControllerResolverServiceName, null, 1);
         $definition->addMethodCall('setControllerClassMap', [$this->controllerClassMap->getControllers()]);
         $definition->setAutowiringTypes([ControllerResolverInterface::class]);
 
-        $containerBuilder->setDefinition('symplify.controller_resolver', $definition);
+        $containerBuilder->setDefinition(self::SERVICE_NAME, $definition);
     }
 
     private function getCurrentControllerResolverServiceName(ContainerBuilder $containerBuilder) : string

--- a/packages/ControllerAutowire/tests/DependencyInjection/Compiler/DecorateControllerResolverPassTest.php
+++ b/packages/ControllerAutowire/tests/DependencyInjection/Compiler/DecorateControllerResolverPassTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symplify\ControllerAutowire\tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symplify\ControllerAutowire\DependencyInjection\Compiler\DecorateControllerResolverPass;
+use Symplify\ControllerAutowire\DependencyInjection\ControllerClassMap;
+
+class DecorateControllerResolverPassTest extends TestCase
+{
+    /**
+     * @var ControllerClassMap
+     */
+    private $controllerClassMap;
+
+    protected function setUp()
+    {
+        $this->controllerClassMap = new ControllerClassMap();
+    }
+
+    public function testInjectionOfOldDecoratedService()
+    {
+        $containerBuilder = new ContainerBuilder();
+
+        $resolver = new DecorateControllerResolverPass($this->controllerClassMap);
+        $resolver->process($containerBuilder);
+
+        $definition = $containerBuilder->getDefinition('symplify.controller_resolver');
+        $this->assertSame('symplify.controller_resolver.inner', (string) $definition->getArgument(0));
+    }
+}


### PR DESCRIPTION
There is used bad reference ID when you are injecting old decorated service into decorator. See docs: http://symfony.com/doc/current/service_container/service_decoration.html