### PR TITLE
Remove try-catch from commands

### DIFF
--- a/packages/Statie/src/Console/Command/GenerateCommand.php
+++ b/packages/Statie/src/Console/Command/GenerateCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\Statie\Application\Command\RunCommand;
 use Symplify\Statie\Application\StatieApplication;
-use Throwable;
 
 final class GenerateCommand extends Command
 {
@@ -55,24 +54,16 @@ final class GenerateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        try {
-            $runCommand = new RunCommand(
-                (bool) $input->getOption('server'),
-                $input->getOption('source'),
-                $input->getOption('output')
-            );
+        $runCommand = new RunCommand(
+            (bool) $input->getOption('server'),
+            $input->getOption('source'),
+            $input->getOption('output')
+        );
 
-            $this->statieApplication->runCommand($runCommand);
+        $this->statieApplication->runCommand($runCommand);
 
-            $output->writeln('<info>Website was successfully generated.</info>');
+        $output->writeln('<info>Website was successfully generated.</info>');
 
-            return 0;
-        } catch (Throwable $throwable) {
-            $output->writeln(
-                sprintf('<error>%s</error>', $throwable->getMessage())
-            );
-
-            return 1;
-        }
+        return 0;
     }
 }

--- a/packages/Statie/src/Console/Command/PushToGithubCommand.php
+++ b/packages/Statie/src/Console/Command/PushToGithubCommand.php
@@ -53,29 +53,21 @@ final class PushToGithubCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        try {
-            $this->ensureInputIsValid($input);
+        $this->ensureInputIsValid($input);
 
-            $githubRepository = $this->createGithubRepositoryUrlWithToken(
-                $input->getOption('token'),
-                $input->getArgument('repository-slug')
-            );
+        $githubRepository = $this->createGithubRepositoryUrlWithToken(
+            $input->getOption('token'),
+            $input->getArgument('repository-slug')
+        );
 
-            $this->gihubPublishingProcess->pushDirectoryContentToRepository(
-                $input->getOption('output'),
-                $githubRepository
-            );
+        $this->gihubPublishingProcess->pushDirectoryContentToRepository(
+            $input->getOption('output'),
+            $githubRepository
+        );
 
-            $output->writeln('<info>Website was successfully pushed to Github pages.</info>');
+        $output->writeln('<info>Website was successfully pushed to Github pages.</info>');
 
-            return 0;
-        } catch (Throwable $throwable) {
-            $output->writeln(
-                sprintf('<error>%s</error>', $throwable->getMessage())
-            );
-
-            return 1;
-        }
+        return 0;
     }
 
     private function ensureInputIsValid(InputInterface $input)


### PR DESCRIPTION
@TomasVotruba I just don't see any point in catching the exception - commands from Symfony & Doctrine don't do that either.