### PR TITLE
[Statie] Add: branch option to push-to-github command

### DIFF
--- a/packages/Statie/src/Console/Command/PushToGithubCommand.php
+++ b/packages/Statie/src/Console/Command/PushToGithubCommand.php
@@ -41,6 +41,7 @@ final class PushToGithubCommand extends Command
             'Directory where was output saved TO.',
             getcwd() . DIRECTORY_SEPARATOR . 'output'
         );
+        $this->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Branch to upload to.', 'gh-pages');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
@@ -54,7 +55,8 @@ final class PushToGithubCommand extends Command
 
         $this->gihubPublishingProcess->pushDirectoryContentToRepository(
             $input->getOption('output'),
-            $githubRepository
+            $githubRepository,
+            $input->getOption('branch')
         );
 
         $output->writeln('<info>Website was successfully pushed to Github pages.</info>');

--- a/packages/Statie/src/Github/GihubPublishingProcess.php
+++ b/packages/Statie/src/Github/GihubPublishingProcess.php
@@ -17,8 +17,12 @@ final class GihubPublishingProcess
      */
     private const CONFIG_NAME = 'Travis';
 
-    public function pushDirectoryContentToRepository(string $outputDirectory, string $githubRepository) : void
-    {
+    public function pushDirectoryContentToRepository(
+        string $outputDirectory,
+        string $githubRepository,
+        string $branch
+    ) : void {
+
         FilesystemChecker::ensureDirectoryExists($outputDirectory);
 
         $git = (new GitWrapper)->init($outputDirectory);
@@ -28,13 +32,13 @@ final class GihubPublishingProcess
             $git->config('user.name', self::CONFIG_NAME);
         }
 
-        $git->checkout('gh-pages', [
+        $git->checkout($branch, [
             'orphan' => true,
         ]);
         $git->add('.');
         $git->commit('Regenerate output');
         $git->addRemote('origin', $githubRepository);
-        $git->push('origin', 'gh-pages', [
+        $git->push('origin', $branch, [
             'force' => true,
             'quiet' => true,
         ]);

--- a/packages/Statie/tests/Github/GihubPublishingProcessTest.php
+++ b/packages/Statie/tests/Github/GihubPublishingProcessTest.php
@@ -28,7 +28,7 @@ final class GihubPublishingProcessTest extends TestCase
      */
     public function testPushDirectoryContentToRepositoryForNonExistingRepository()
     {
-        $this->githubPublishingProcess->pushDirectoryContentToRepository('missing directory', '');
+        $this->githubPublishingProcess->pushDirectoryContentToRepository('missing directory', '', '');
     }
 
     /**
@@ -42,7 +42,8 @@ final class GihubPublishingProcessTest extends TestCase
 
         $this->githubPublishingProcess->pushDirectoryContentToRepository(
             $this->outputDirectory,
-            'https://github.com/TomasVotruba/tomasvotruba.cz'
+            'https://github.com/TomasVotruba/tomasvotruba.cz',
+            'gh-pages'
         );
 
         $this->assertFileExists($this->outputDirectory . DIRECTORY_SEPARATOR . '.git');


### PR DESCRIPTION
I'm using GH pages, but I want to have only the base url **example.github.io** . But the output code has to be uploaded in master branch instead of command's default "gh-pages". So I've added a new option to the **push-to-github** command **--branch**. The default value is still "gh-pages", so the change won't affect anything. Sniffer has passed.