### PR TITLE
[SymbioticController] Fixed typo in nette application request event name

### DIFF
--- a/packages/SymbioticController/src/Adapter/Nette/Application/InvokablePresenterAwareApplication.php
+++ b/packages/SymbioticController/src/Adapter/Nette/Application/InvokablePresenterAwareApplication.php
@@ -21,7 +21,7 @@ use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationResponseEvent
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationShutdownEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationStartupEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterCreatedEvent;
-use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestRecievedEvent;
+use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestReceivedEvent;
 use Throwable;
 
 final class InvokablePresenterAwareApplication extends Application
@@ -93,7 +93,7 @@ final class InvokablePresenterAwareApplication extends Application
 
         $this->requests[] = $request;
         $this->eventDispatcher->dispatch(
-            RequestRecievedEvent::class, new RequestRecievedEvent($this, $request)
+            RequestReceivedEvent::class, new RequestReceivedEvent($this, $request)
         );
 
         $this->ensureRequestIsValid($request);

--- a/packages/SymfonyEventDispatcher/src/Adapter/Nette/DI/NetteEventListFactory.php
+++ b/packages/SymfonyEventDispatcher/src/Adapter/Nette/DI/NetteEventListFactory.php
@@ -9,7 +9,7 @@ use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationResponseEvent
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationStartupEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterCreatedEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterShutdownEvent;
-use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestRecievedEvent;
+use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestReceivedEvent;
 
 final class NetteEventListFactory
 {
@@ -33,7 +33,7 @@ final class NetteEventListFactory
         $eventItems[] = new NetteEventItem(
             Application::class,
             'onRequest',
-            RequestRecievedEvent::class
+            RequestReceivedEvent::class
         );
         $eventItems[] = new NetteEventItem(
             Application::class,

--- a/packages/SymfonyEventDispatcher/src/Adapter/Nette/Event/RequestReceivedEvent.php
+++ b/packages/SymfonyEventDispatcher/src/Adapter/Nette/Event/RequestReceivedEvent.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\Event;
  *
  * @see \Nette\Application\Application::$onRequest
  */
-final class RequestRecievedEvent extends Event
+final class RequestReceivedEvent extends Event
 {
     /**
      * @var string

--- a/packages/SymfonyEventDispatcher/tests/Adapter/Nette/NetteEvent/DispatchApplicationTest.php
+++ b/packages/SymfonyEventDispatcher/tests/Adapter/Nette/NetteEvent/DispatchApplicationTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationErrorEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationStartupEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterCreatedEvent;
-use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestRecievedEvent;
+use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestReceivedEvent;
 use Symplify\SymfonyEventDispatcher\Tests\Adapter\Nette\ContainerFactory;
 
 final class DispatchApplicationTest extends TestCase
@@ -35,9 +35,9 @@ final class DispatchApplicationTest extends TestCase
     {
         $this->application->run();
 
-        /** @var RequestRecievedEvent $applicationRequestEvent */
-        $applicationRequestEvent = $this->eventStateStorage->getEventState(RequestRecievedEvent::NAME);
-        $this->assertInstanceOf(RequestRecievedEvent::class, $applicationRequestEvent);
+        /** @var RequestReceivedEvent $applicationRequestEvent */
+        $applicationRequestEvent = $this->eventStateStorage->getEventState(RequestReceivedEvent::NAME);
+        $this->assertInstanceOf(RequestReceivedEvent::class, $applicationRequestEvent);
         $this->assertInstanceOf(Application::class, $applicationRequestEvent->getApplication());
         $this->assertInstanceOf(Request::class, $applicationRequestEvent->getRequest());
     }

--- a/packages/SymfonyEventDispatcher/tests/Adapter/Nette/NetteEvent/EventSubscriber/ApplicationSubscriber.php
+++ b/packages/SymfonyEventDispatcher/tests/Adapter/Nette/NetteEvent/EventSubscriber/ApplicationSubscriber.php
@@ -7,7 +7,7 @@ use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationErrorEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationResponseEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationStartupEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterCreatedEvent;
-use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestRecievedEvent;
+use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\RequestReceivedEvent;
 use Symplify\SymfonyEventDispatcher\Tests\Adapter\Nette\NetteEvent\EventStateStorage;
 
 final class ApplicationSubscriber implements EventSubscriberInterface
@@ -28,7 +28,7 @@ final class ApplicationSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            RequestRecievedEvent::NAME => 'onRequest',
+            RequestReceivedEvent::NAME => 'onRequest',
             ApplicationStartupEvent::NAME => 'onStartup',
             PresenterCreatedEvent::NAME => 'onPresenter',
             ApplicationErrorEvent::NAME => 'onShutdown',
@@ -37,9 +37,9 @@ final class ApplicationSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onRequest(RequestRecievedEvent $applicationRequestEvent): void
+    public function onRequest(RequestReceivedEvent $applicationRequestEvent): void
     {
-        $this->eventStateStorage->addEventState(RequestRecievedEvent::NAME, $applicationRequestEvent);
+        $this->eventStateStorage->addEventState(RequestReceivedEvent::NAME, $applicationRequestEvent);
     }
 
     public function onStartup(ApplicationStartupEvent $applicationEvent): void


### PR DESCRIPTION
I consider this to be a BC break - anyone who is using this event, including me, will need to update all event subscribers listening to this event.