### PR TITLE
[EasyCodingStandard] allow checker with empty configuration [closes #203]

### DIFF
--- a/packages/CodingStandard/composer.json
+++ b/packages/CodingStandard/composer.json
@@ -14,7 +14,8 @@
     "require-dev": {
         "symplify/easy-coding-standard": "^2.0",
         "symplify/package-builder": "^2.0",
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "gecko-packages/gecko-php-unit": "dev-master#b32f1d8 as 2.1"
     },
     "autoload": {
         "psr-4": {

--- a/packages/EasyCodingStandard/easy-coding-standard.neon
+++ b/packages/EasyCodingStandard/easy-coding-standard.neon
@@ -1,2 +1,0 @@
-checkers:
-    - Symplify\CodingStandard\Sniffs\Classes\FinalInterfaceSniff

--- a/packages/EasyCodingStandard/packages/Configuration/src/CheckerConfigurationNormalizer.php
+++ b/packages/EasyCodingStandard/packages/Configuration/src/CheckerConfigurationNormalizer.php
@@ -14,9 +14,11 @@ final class CheckerConfigurationNormalizer
     {
         $configuredClasses = [];
         foreach ($classes as $name => $class) {
-            if (is_array($class)) {
+            if ($class === null) { // checker with commented configuration
+                $config = [];
+            } elseif (is_array($class)) { // checker with configuration
                 $config = $class;
-            } else {
+            } else { // only checker item
                 $name = $class;
                 $config = [];
             }

--- a/packages/EasyCodingStandard/packages/Configuration/src/CheckerConfigurationNormalizer.php
+++ b/packages/EasyCodingStandard/packages/Configuration/src/CheckerConfigurationNormalizer.php
@@ -3,6 +3,7 @@
 namespace Symplify\EasyCodingStandard\Configuration;
 
 use Symplify\EasyCodingStandard\Configuration\Exception\DuplicatedCheckerFoundException;
+use Symplify\EasyCodingStandard\Configuration\Exception\InvalidConfigurationTypeException;
 
 final class CheckerConfigurationNormalizer
 {
@@ -18,9 +19,17 @@ final class CheckerConfigurationNormalizer
                 $config = [];
             } elseif (is_array($class)) { // checker with configuration
                 $config = $class;
-            } else { // only checker item
+            } elseif (! is_string($name)) { // only checker item
                 $name = $class;
                 $config = [];
+            } else {
+                $config = $class;
+                throw new InvalidConfigurationTypeException(sprintf(
+                    'Configuration of "%s" checker has to be array; "%s" given with "%s".',
+                    $name,
+                    gettype($config),
+                    $config
+                ));
             }
 
             $this->ensureThereAreNoDuplications($configuredClasses, $name);

--- a/packages/EasyCodingStandard/packages/Configuration/src/CheckerConfigurationNormalizer.php
+++ b/packages/EasyCodingStandard/packages/Configuration/src/CheckerConfigurationNormalizer.php
@@ -10,7 +10,7 @@ final class CheckerConfigurationNormalizer
      * @param string[]|int[][]|string[][] $classes
      * @return string[][]
      */
-    public static function normalize(array $classes): array
+    public function normalize(array $classes): array
     {
         $configuredClasses = [];
         foreach ($classes as $name => $class) {
@@ -23,7 +23,7 @@ final class CheckerConfigurationNormalizer
                 $config = [];
             }
 
-            self::ensureThereAreNoDuplications($configuredClasses, $name);
+            $this->ensureThereAreNoDuplications($configuredClasses, $name);
             $configuredClasses[$name] = $config;
         }
 
@@ -33,7 +33,7 @@ final class CheckerConfigurationNormalizer
     /**
      * @param string[] $configuredClasses
      */
-    private static function ensureThereAreNoDuplications(array $configuredClasses, string $name): void
+    private function ensureThereAreNoDuplications(array $configuredClasses, string $name): void
     {
         if (! isset($configuredClasses[$name])) {
             return;

--- a/packages/EasyCodingStandard/packages/Configuration/src/Exception/InvalidConfigurationTypeException.php
+++ b/packages/EasyCodingStandard/packages/Configuration/src/Exception/InvalidConfigurationTypeException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Configuration\Exception;
+
+use Exception;
+
+final class InvalidConfigurationTypeException extends Exception
+{
+}

--- a/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
+++ b/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
@@ -21,11 +21,13 @@ final class ConfigurationNormalizerTest extends TestCase
     {
         $normalizedConfiguration = $this->configurationNormalizer->normalize([
             0 => 'sniff',
+            'someSniffWithCommentedConfig' => null,
             'sniffAndItsConfig' => ['key' => 'value'],
         ]);
 
         $this->assertSame([
             'sniff' => [],
+            'someSniffWithCommentedConfig' => [],
             'sniffAndItsConfig' => [
                 'key' => 'value',
             ],

--- a/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
+++ b/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
@@ -4,6 +4,7 @@ namespace Symplify\EasyCodingStandard\Configuration\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symplify\EasyCodingStandard\Configuration\CheckerConfigurationNormalizer;
+use Symplify\EasyCodingStandard\Configuration\Exception\DuplicatedCheckerFoundException;
 
 final class ConfigurationNormalizerTest extends TestCase
 {
@@ -32,5 +33,20 @@ final class ConfigurationNormalizerTest extends TestCase
                 'key' => 'value',
             ],
         ], $normalizedConfiguration);
+    }
+
+    public function testDuplicates(): void
+    {
+        $this->expectException(DuplicatedCheckerFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Checker "%s" is being registered twice. Keep it only once, '
+            . 'so configuration is clear and performance better.',
+            'sniff'
+        ));
+
+        $this->configurationNormalizer->normalize([
+            0 => 'sniff',
+            'sniff' => null,
+        ]);
     }
 }

--- a/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
+++ b/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
@@ -54,7 +54,7 @@ final class ConfigurationNormalizerTest extends TestCase
     {
         $this->expectException(InvalidConfigurationTypeException::class);
         $this->expectExceptionMessage(
-            'Configuration of "sniff" checker has to be array; '.
+            'Configuration of "sniff" checker has to be array; ' .
             '"string" given with "configuration".'
         );
         $this->configurationNormalizer->normalize([

--- a/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
+++ b/packages/EasyCodingStandard/packages/Configuration/tests/ConfigurationNormalizerTest.php
@@ -5,6 +5,7 @@ namespace Symplify\EasyCodingStandard\Configuration\Tests;
 use PHPUnit\Framework\TestCase;
 use Symplify\EasyCodingStandard\Configuration\CheckerConfigurationNormalizer;
 use Symplify\EasyCodingStandard\Configuration\Exception\DuplicatedCheckerFoundException;
+use Symplify\EasyCodingStandard\Configuration\Exception\InvalidConfigurationTypeException;
 
 final class ConfigurationNormalizerTest extends TestCase
 {
@@ -38,15 +39,26 @@ final class ConfigurationNormalizerTest extends TestCase
     public function testDuplicates(): void
     {
         $this->expectException(DuplicatedCheckerFoundException::class);
-        $this->expectExceptionMessage(sprintf(
-            'Checker "%s" is being registered twice. Keep it only once, '
-            . 'so configuration is clear and performance better.',
-            'sniff'
-        ));
+        $this->expectExceptionMessage(
+            'Checker "sniff" is being registered twice. Keep it only once, '
+            . 'so configuration is clear and performance better.'
+        );
 
         $this->configurationNormalizer->normalize([
             0 => 'sniff',
             'sniff' => null,
+        ]);
+    }
+
+    public function testNonArrayConfiguration(): void
+    {
+        $this->expectException(InvalidConfigurationTypeException::class);
+        $this->expectExceptionMessage(
+            'Configuration of "sniff" checker has to be array; '.
+            '"string" given with "configuration".'
+        );
+        $this->configurationNormalizer->normalize([
+            'sniff' => 'configuration',
         ]);
     }
 }

--- a/packages/EasyCodingStandard/src/DependencyInjection/Extension/CheckersExtension.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/Extension/CheckersExtension.php
@@ -45,7 +45,7 @@ final class CheckersExtension extends Extension
             return;
         }
 
-        $checkersConfiguration = $parameterBag->get(self::NAME);
+        $checkersConfiguration = $parameterBag->get(self::NAME) ?? [];
         $checkers = $this->configurationNormalizer->normalize($checkersConfiguration);
         $this->checkerTypeValidator->validate(array_keys($checkers));
 

--- a/packages/EasyCodingStandard/src/DependencyInjection/Extension/CheckersExtension.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/Extension/CheckersExtension.php
@@ -92,6 +92,7 @@ final class CheckersExtension extends Extension
         }
 
         throw new InvalidSniffPropertyException(sprintf(
+            // @todo: add "Did you mean?"
             'Property "%s" was not found on "%s" sniff class. Possible typo in its configuration?',
             $property,
             $sniffClass

--- a/packages/PackageBuilder/composer.json
+++ b/packages/PackageBuilder/composer.json
@@ -10,7 +10,8 @@
         "symfony/dependency-injection": "^3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^6.0",
+        "tracy/tracy": "^2.4"
     },
     "autoload": {
         "psr-4": {

--- a/packages/Statie/composer.json
+++ b/packages/Statie/composer.json
@@ -13,6 +13,7 @@
         "yooper/php-text-analysis": "^1.1",
 
         "latte/latte": "^2.4|^3.0",
+        "lullabot/amp": "^1.1",
 
         "symfony/dependency-injection": "^3.3",
         "symfony/http-kernel": "^3.3",


### PR DESCRIPTION
This now allows more open configuration in `easy-coding-standard.neon`:

```yaml
checkers:
    PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
     # someTemporaryCommentedConfig: value
```

and

```yaml
checkers:
    # CommentedChecker testing
```

and informative Exception for

```yaml
checkers:
    LineLenghtChecker: 120 # oh, I don't know there should be property name in array
```