### PR TITLE
[PackageBuilder] NeonLoader - validate allowed sections feature added

### DIFF
--- a/packages/EasyCodingStandard/src/DependencyInjection/AppKernel.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/AppKernel.php
@@ -29,7 +29,7 @@ final class AppKernel extends AbstractCliKernel
         $loader->load(__DIR__ . '/../config/services.yml');
 
         if ($this->configFile) {
-            $this->registerLocalConfig($loader, $this->configFile);
+            $loader->load($this->configFile, ['parameters', 'checkers', 'includes']);
         }
     }
 

--- a/packages/PackageBuilder/src/Exception/Neon/InvalidSectionException.php
+++ b/packages/PackageBuilder/src/Exception/Neon/InvalidSectionException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\Exception\Neon;
+
+use Exception;
+
+final class InvalidSectionException extends Exception
+{
+}

--- a/packages/PackageBuilder/tests/Neon/Loader/NeonLoaderSource/configWithAllowedSections.neon
+++ b/packages/PackageBuilder/tests/Neon/Loader/NeonLoaderSource/configWithAllowedSections.neon
@@ -1,0 +1,8 @@
+parameters:
+    key: value
+
+checkers:
+
+includes:
+
+services:

--- a/packages/PackageBuilder/tests/Neon/Loader/NeonLoaderSource/configWithUnknownSections.neon
+++ b/packages/PackageBuilder/tests/Neon/Loader/NeonLoaderSource/configWithUnknownSections.neon
@@ -1,2 +1,5 @@
 parameters:
     key: value
+
+
+exclude:

--- a/packages/PackageBuilder/tests/Neon/Loader/NeonLoaderTest.php
+++ b/packages/PackageBuilder/tests/Neon/Loader/NeonLoaderTest.php
@@ -4,6 +4,7 @@ namespace Symplify\PackageBuilder\Tests\Neon\Loader;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symplify\PackageBuilder\Exception\Neon\InvalidSectionException;
 use Symplify\PackageBuilder\Neon\Loader\NeonLoader;
 
 final class NeonLoaderTest extends TestCase
@@ -28,5 +29,24 @@ final class NeonLoaderTest extends TestCase
     {
         $this->neonLoader->load(__DIR__ . '/NeonLoaderSource/someConfig.neon');
         $this->assertSame('value', $this->containerBuilder->getParameter('key'));
+    }
+
+    public function testValidSections(): void
+    {
+        $this->neonLoader->load(
+            __DIR__ . '/NeonLoaderSource/configWithAllowedSections.neon',
+            ['parameters', 'includes', 'services', 'checkers']
+        );
+        $this->assertSame('value', $this->containerBuilder->getParameter('key'));
+    }
+
+    public function testInvalidSections(): void
+    {
+        $this->expectException(InvalidSectionException::class);
+        $this->expectExceptionMessage('Invalid sections found: "exclude". Only "parameters", "services" are allowed.');
+        $this->neonLoader->load(
+            __DIR__ . '/NeonLoaderSource/configWithUnknownSections.neon',
+            ['parameters', 'services']
+        );
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,7 @@ parameters:
         - "#does not call parent constructor from PHP_CodeSniffer#"
         - "#Constant #"
         - "#addLoader()#"
+        - "#[$]type of method Symfony#"
     excludes_analyse:
         - *packages/CodingStandard/tests/**/correct*
         - *packages/CodingStandard/tests/**/wrong*


### PR DESCRIPTION
Closes #213 

Solution invalid sections in config, as mentioned in https://github.com/Symplify/Symplify/issues/202#issuecomment-311943605

Use in `AppKernel` like this: https://github.com/Symplify/Symplify/pull/223/files#diff-9440496cf7711249c9897be866c8b3daR32

What do you think @dg?
