### PR TITLE
[CheckersExtension] uses PHP_EOL for line-ending 

### DIFF
--- a/packages/EasyCodingStandard/src/DependencyInjection/Extension/CheckersExtension.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/Extension/CheckersExtension.php
@@ -154,7 +154,7 @@ final class CheckersExtension extends Extension
             $indentation = '	';
         }
 
-        $whitespacesFixerConfigDefinition = new Definition(WhitespacesFixerConfig::class, [$indentation]);
+        $whitespacesFixerConfigDefinition = new Definition(WhitespacesFixerConfig::class, [$indentation, PHP_EOL]);
         $containerBuilder->setDefinition('fixerWhitespaceConfig', $whitespacesFixerConfigDefinition);
 
         $this->isWhitespaceFixerConfigRegistered = true;

--- a/packages/EasyCodingStandard/tests/Indentation/IndentationTest.php
+++ b/packages/EasyCodingStandard/tests/Indentation/IndentationTest.php
@@ -19,7 +19,7 @@ final class IndentationTest extends TestCase
         /** @var IndentationTypeFixer $indentationFixer */
         $indentationFixer = $container->get(IndentationTypeFixer::class);
 
-        $spacesConfig = new WhitespacesFixerConfig('    ', "\n");
+        $spacesConfig = new WhitespacesFixerConfig('    ', PHP_EOL);
         $this->assertEquals($spacesConfig, Assert::getObjectAttribute($indentationFixer, 'whitespacesConfig'));
     }
 
@@ -32,7 +32,7 @@ final class IndentationTest extends TestCase
         /** @var IndentationTypeFixer $indentationFixer */
         $indentationFixer = $container->get(IndentationTypeFixer::class);
 
-        $tabsConfig = new WhitespacesFixerConfig('	', "\n");
+        $tabsConfig = new WhitespacesFixerConfig('	', PHP_EOL);
         $this->assertEquals($tabsConfig, Assert::getObjectAttribute($indentationFixer, 'whitespacesConfig'));
     }
 }


### PR DESCRIPTION
… because nothing else has sense

How to test it?