### PR TITLE
[EasyCodingStandard] error is propagated to exit code

### DIFF
--- a/packages/EasyCodingStandard/bin/easy-coding-standard.php
+++ b/packages/EasyCodingStandard/bin/easy-coding-standard.php
@@ -44,4 +44,5 @@ try {
 } catch (Throwable $throwable) {
     $symfonyStyle = SymfonyStyleFactory::create();
     $symfonyStyle->error($throwable->getMessage());
+    exit(1);
 }


### PR DESCRIPTION
For errors like "missing configuration file" etc.