### PR TITLE
[CodingStandard] ClassStringToClassCosntantFixer init

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -81,6 +81,9 @@ checkers:
     - Symplify\CodingStandard\Sniffs\Namespaces\ClassNamesWithoutPreSlashSniff
     - PhpCsFixer\Fixer\NamespaceNotation\SingleBlankLineBeforeNamespaceFixer
     - PhpCsFixer\Fixer\NamespaceNotation\BlankLineAfterNamespaceFixer
+    - PhpCsFixer\Fixer\Import\OrderedImportsFixer
+    - PhpCsFixer\Fixer\Import\SingleImportPerStatementFixer
+    - PhpCsFixer\Fixer\Import\SingleLineAfterImportsFixer
 
     # Naming
     - Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff
@@ -130,7 +133,6 @@ checkers:
     - PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer
     - PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer
     - PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer
-    - PhpCsFixer\Fixer\Import\OrderedImportsFixer
     - PhpCsFixer\Fixer\LanguageConstruct\CombineConsecutiveUnsetsFixer
     - PhpCsFixer\Fixer\Strict\StrictComparisonFixer
     - PhpCsFixer\Fixer\Alias\EregToPregFixer
@@ -159,8 +161,6 @@ checkers:
     - PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer
     PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer:
         - property
-    - PhpCsFixer\Fixer\Import\SingleImportPerStatementFixer
-    - PhpCsFixer\Fixer\Import\SingleLineAfterImportsFixer
     - PhpCsFixer\Fixer\ControlStructure\SwitchCaseSemicolonToColonFixer
     - PhpCsFixer\Fixer\ControlStructure\SwitchCaseSpaceFixer
 

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -1,4 +1,5 @@
 checkers:
+    - Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer
     - Symplify\CodingStandard\Fixer\Property\ArrayPropertyDefaultValueFixer
 
     # Classes

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -283,3 +283,13 @@ parameters:
         PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer:
             # bugged fixer
             - packages/CodingStandard/src/Fixer/DependencyInjection/InjectToConstructorInjectionFixer.php
+
+        Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer:
+            # optional package, interface might not exist
+            - packages/CodingStandard/src/Sniffs/Classes/EqualInterfaceImplementationSniff.php
+            # "Exception" is string part of the name
+            - packages/CodingStandard/src/Sniffs/Naming/ExceptionNameSniff.php
+            # "Error" is a name of Presenter
+            - packages/SymbioticController/tests/Adapter/Nette/Application/PresenterFactoryTest.php
+            # class is only for tested cases, it doesn't exist
+            - packages/SymbioticController/tests/Adapter/Nette/Routing/PresenterMapperTest.php

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -49,6 +49,25 @@ class SomeClass
 ```
 
 
+### `SomeClass::class` references should be used over string
+ 
+ 
+- [Php/ClassStringToClassConstantFixer](/src/Fixer/Php/ClassStringToClassConstantFixer.php)
+- This checker uses *[PHP-CS-Fixer](https://github.com/friendsofphp/php-cs-fixer)*
+
+:x:
+
+```php
+$className = 'DateTime';
+```
+
+:+1:
+
+```php
+$className = DateTime::class;
+```
+
+
 
 ### Array property should have default value, to prevent undefined array issues
 
@@ -77,6 +96,7 @@ class SomeClass
 
 
 :+1:
+
 
 ``` php
 class SomeClass

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -49,7 +49,7 @@ class SomeClass
 ```
 
 
-### `SomeClass::class` references should be used over string
+### `::class` references should be used over string for classes and interfaces
  
  
 - [Php/ClassStringToClassConstantFixer](/src/Fixer/Php/ClassStringToClassConstantFixer.php)

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -29,20 +29,25 @@ $className = "DateTime";
 
 $interfaceName = "DateTimeInterface";  
                 '),
+                new CodeSample(
+'<?php      
+
+$interfaceName = "Nette\Utils\DateTime";  
+                '),
             ]
         );
     }
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return true;
+        return $tokens->isTokenKindFound(T_CONSTANT_ENCAPSED_STRING);
     }
 
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         foreach (array_reverse($tokens->toArray(), true) as $index => $token) {
             /** @var Token $token */
-            if (! $this->isStringToken($token)) {
+            if (! $token->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {
                 continue;
             }
 
@@ -78,11 +83,5 @@ $interfaceName = "DateTimeInterface";
     public function supports(SplFileInfo $file): bool
     {
         return true;
-    }
-
-    private function isStringToken(Token $token): bool
-    {
-        return Strings::startsWith($token->getContent(), "'")
-            && Strings::endsWith($token->getContent(), "'");
     }
 }

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -54,12 +54,12 @@ $interfaceName = "Nette\Utils\DateTime";
             $potentialClassOrInterfaceName = trim($token->getContent(), "'");
             if (class_exists($potentialClassOrInterfaceName) || interface_exists($potentialClassOrInterfaceName)) {
                 $token->clear(); // overrideAt() fails on "Illegal offset type"
-                $tokens->insertAt($index, [
-                    new Token([T_NS_SEPARATOR, '\\']),
-                    new Token([T_STRING, $potentialClassOrInterfaceName]),
+
+                $classOrInterfaceTokens = $this->convertClassOrInterfaceNameToTokens($potentialClassOrInterfaceName);
+                $tokens->insertAt($index, array_merge($classOrInterfaceTokens, [
                     new Token([T_DOUBLE_COLON, '::']),
                     new Token([CT::T_CLASS_CONSTANT, 'class']),
-                ]);
+                ]));
             }
         }
     }
@@ -83,5 +83,21 @@ $interfaceName = "Nette\Utils\DateTime";
     public function supports(SplFileInfo $file): bool
     {
         return true;
+    }
+
+    /**
+     * @return Token[]
+     */
+    private function convertClassOrInterfaceNameToTokens(string $potentialClassOrInterfaceName): array
+    {
+        $tokens = [];
+        $nameParts = explode('\\', $potentialClassOrInterfaceName);
+
+        foreach ($nameParts as $namePart) {
+            $tokens[] = new Token([T_NS_SEPARATOR, '\\']);
+            $tokens[] = new Token([T_STRING, $namePart]);
+        }
+
+        return $tokens;
     }
 }

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -93,6 +93,11 @@ $interfaceName = "Nette\Utils\DateTime";
 
     private function isClassOrInterface(string $potentialClassOrInterface): bool
     {
+        // exception for often used "error" string; because class_exists() is case-insensitive
+        if ($potentialClassOrInterface === 'error') {
+            return false;
+        }
+
         return class_exists($potentialClassOrInterface)
             || interface_exists($potentialClassOrInterface)
             || (bool) preg_match(self::CLASS_OR_INTERFACE_PATTERN, $potentialClassOrInterface);

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -2,7 +2,6 @@
 
 namespace Symplify\CodingStandard\Fixer\Php;
 
-use Nette\Utils\Strings;
 use PhpCsFixer\Fixer\DefinedFixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
@@ -14,7 +13,6 @@ use SplFileInfo;
 
 final class ClassStringToClassConstantFixer implements DefinedFixerInterface
 {
-
     /**
      * @var string
      */
@@ -23,7 +21,7 @@ final class ClassStringToClassConstantFixer implements DefinedFixerInterface
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            '"SomeClass::class" references should be used over string.',
+            '`::class` references should be used over string for classes and interfaces.',
             [
                 new CodeSample(
 '<?php      

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\Php;
+
+use Nette\Utils\Strings;
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class ClassStringToClassConstantFixer implements DefinedFixerInterface
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            '::class refences should be used over string.',
+            [
+                new CodeSample(
+'<?php      
+
+$className = "DateTime";  
+                '),
+                new CodeSample(
+'<?php      
+
+$interfaceName = "DateTimeInterface";  
+                '),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach (array_reverse($tokens->toArray(), true) as $index => $token) {
+            /** @var Token $token */
+            if (! $this->isStringToken($token)) {
+                continue;
+            }
+
+            $potentialClassOrInterfaceName = trim($token->getContent(), "'");
+            if (class_exists($potentialClassOrInterfaceName) || interface_exists($potentialClassOrInterfaceName)) {
+                $token->clear(); // overrideAt() fails on "Illegal offset type"
+                $tokens->insertAt($index, [
+                    new Token([T_NS_SEPARATOR, '\\']),
+                    new Token([T_STRING, $potentialClassOrInterfaceName]),
+                    new Token([T_DOUBLE_COLON, '::']),
+                    new Token([CT::T_CLASS_CONSTANT, 'class']),
+                ]);
+            }
+        }
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function getName(): string
+    {
+        return self::class;
+    }
+
+    public function getPriority(): int
+    {
+        // @todo combine with namespace import fixer/sniff
+        return 0;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+
+    private function isStringToken(Token $token): bool
+    {
+        return Strings::startsWith($token->getContent(), "'")
+            && Strings::endsWith($token->getContent(), "'");
+    }
+}

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -16,7 +16,7 @@ final class ClassStringToClassConstantFixer implements DefinedFixerInterface
     /**
      * @var string
      */
-    private const CLASS_OR_INTERFACE_PATTERN = '#^[A-Z]\w*[a-z]\w*(\\\\[A-Z]\w*[a-z]\w*)*\z#';
+    private const CLASS_OR_INTERFACE_PATTERN = '#^[A-Z]\w*[a-z]\w*(\\\\[A-Z]\w*[a-z]\w*)+\z#';
 
     public function getDefinition(): FixerDefinitionInterface
     {
@@ -82,8 +82,8 @@ $interfaceName = "Nette\Utils\DateTime";
 
     public function getPriority(): int
     {
-        // @todo combine with namespace import fixer/sniff
-        return 0;
+        // should be run before the OrderedImportsFixer, after the NoLeadingImportSlashFixer
+        return -25;
     }
 
     public function supports(SplFileInfo $file): bool
@@ -93,7 +93,9 @@ $interfaceName = "Nette\Utils\DateTime";
 
     private function isClassOrInterface(string $potentialClassOrInterface): bool
     {
-        return (bool) preg_match(self::CLASS_OR_INTERFACE_PATTERN, $potentialClassOrInterface);
+        return class_exists($potentialClassOrInterface)
+            || interface_exists($potentialClassOrInterface)
+            || (bool) preg_match(self::CLASS_OR_INTERFACE_PATTERN, $potentialClassOrInterface);
     }
 
     /**

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -17,7 +17,7 @@ final class ClassStringToClassConstantFixer implements DefinedFixerInterface
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            '::class refences should be used over string.',
+            '"SomeClass::class" references should be used over string.',
             [
                 new CodeSample(
 '<?php      

--- a/packages/CodingStandard/src/Sniffs/Namespaces/ClassNamesWithoutPreSlashSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Namespaces/ClassNamesWithoutPreSlashSniff.php
@@ -2,8 +2,11 @@
 
 namespace Symplify\CodingStandard\Sniffs\Namespaces;
 
+use DateTime;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use splFileInfo;
+use stdClass;
 
 /**
  * Rules:
@@ -15,7 +18,7 @@ final class ClassNamesWithoutPreSlashSniff implements Sniff
      * @var string[]
      */
     private $excludedClassNames = [
-        'DateTime', 'stdClass', 'splFileInfo', 'Exception',
+        DateTime::class, stdClass::class, splFileInfo::class, Throwable::class,
     ];
 
     /**

--- a/packages/CodingStandard/src/Sniffs/Namespaces/ClassNamesWithoutPreSlashSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Namespaces/ClassNamesWithoutPreSlashSniff.php
@@ -5,8 +5,9 @@ namespace Symplify\CodingStandard\Sniffs\Namespaces;
 use DateTime;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use splFileInfo;
+use SplFileInfo;
 use stdClass;
+use Throwable;
 
 /**
  * Rules:
@@ -18,7 +19,7 @@ final class ClassNamesWithoutPreSlashSniff implements Sniff
      * @var string[]
      */
     private $excludedClassNames = [
-        DateTime::class, stdClass::class, splFileInfo::class, Throwable::class,
+        DateTime::class, stdClass::class, SplFileInfo::class, Throwable::class,
     ];
 
     /**

--- a/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixerTest.php
@@ -30,6 +30,10 @@ final class ClassStringToClassConstantFixerTest extends AbstractFixerTestCase
                 file_get_contents(__DIR__ . '/fixed/fixed2.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong2.php.inc'),
             ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed3.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong3.php.inc'),
+            ],
         ];
     }
 

--- a/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixerTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Php;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Test\AbstractFixerTestCase;
+use Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer;
+
+final class ClassStringToClassConstantFixerTest extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases()
+     */
+    public function testFix(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideFixCases(): array
+    {
+        return [
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong.php.inc'),
+            ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed2.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong2.php.inc'),
+            ],
+        ];
+    }
+
+    protected function createFixer(): FixerInterface
+    {
+        return new ClassStringToClassConstantFixer;
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Php/fixed/fixed.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Php/fixed/fixed.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$classType = \DateTime::class;

--- a/packages/CodingStandard/tests/Fixer/Php/fixed/fixed2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Php/fixed/fixed2.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$classType = \DateTimeInterface::class;

--- a/packages/CodingStandard/tests/Fixer/Php/fixed/fixed3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Php/fixed/fixed3.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+class SomeClass
+{
+    public function getSomeData($className = \Nette\Utils\DateTime::class)
+    {
+
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Php/wrong/wrong.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Php/wrong/wrong.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$classType = 'DateTime';

--- a/packages/CodingStandard/tests/Fixer/Php/wrong/wrong2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Php/wrong/wrong2.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+$classType = 'DateTimeInterface';

--- a/packages/CodingStandard/tests/Fixer/Php/wrong/wrong3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Php/wrong/wrong3.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+class SomeClass
+{
+    public function getSomeData($className = 'Nette\Utils\DateTime')
+    {
+
+    }
+}

--- a/packages/EasyCodingStandard/packages/SniffRunner/tests/Error/ErrorSorterTest.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/tests/Error/ErrorSorterTest.php
@@ -35,11 +35,11 @@ final class ErrorSorterTest extends AbstractContainerAwareTestCase
     {
         return [
             'filePath' => [
-                new Error(5, 'error', 'SomeClass', false),
+                new Error(5, 'error message', 'SomeClass', false),
             ],
             'anotherFilePath' => [
-                new Error(15, 'error', 'SomeClass', false),
-                new Error(5, 'error', 'SomeClass', false),
+                new Error(15, 'error message', 'SomeClass', false),
+                new Error(5, 'error message', 'SomeClass', false),
             ],
         ];
     }

--- a/packages/SymbioticController/tests/Adapter/Nette/Application/PresenterFactoryTest.php
+++ b/packages/SymbioticController/tests/Adapter/Nette/Application/PresenterFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace Symplify\SymbioticController\Tests\Adapter\Nette\Application;
 
-use Error;
 use Nette\Application\IPresenter;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\UI\Presenter;
@@ -65,12 +64,9 @@ final class PresenterFactoryTest extends TestCase
 
     public function testCreateErrorPresenter(): void
     {
-        $this->assertTrue(class_exists('Error'));
-
         $this->setupPresenterFactoryMapping();
 
         $errorPresenter = $this->presenterFactory->createPresenter('Error');
-        $this->assertNotInstanceOf(Error::class, $errorPresenter);
         $this->assertInstanceOf(ErrorPresenter::class, $errorPresenter);
 
         /* @var Presenter $somePresenter */


### PR DESCRIPTION
Closes #260 

Converts: `SomeClass` => `\SomeClass::class`