### PR TITLE
[EasyCodingStandard] fix empty file error add FinderSanitizer, makes SourceFinder error proof

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "symplify/symplify",
     "description": "Main repository for Symplify packages development.",
     "license": "MIT",
-
     "require": {
         "php": "^7.1",
         "contributte/event-application-bridge": "^0.1",

--- a/packages/EasyCodingStandard/README.md
+++ b/packages/EasyCodingStandard/README.md
@@ -221,15 +221,12 @@ final class PhpAndPhptFilesProvider implements CustomSourceProviderInterface
 {
     /**
      * @param string[] $source
-     * @return SplFileInfo[]
      */
-    public function find(array $source): array
+    public function find(array $source): Finder
     {
         # $source is "source" argument passed in CLI
         # inc CLI: "vendor/bin/ecs check /src" => here: ['/src']
-        $finder = Finder::find('*.php', '*.phpt')->in($source);
-
-        return iterator_to_array($finder->getIterator());
+        return Finder::find('*.php', '*.phpt')->in($source);
     }
 }
 ```
@@ -238,7 +235,7 @@ final class PhpAndPhptFilesProvider implements CustomSourceProviderInterface
 
 **Use any Finder you like**
 
-You can use [Nette\Finder](https://doc.nette.org/en/finder), [Symfony\Finder](https://symfony.com/doc/current/components/finder.html), [`glob`](http://php.net/manual/en/function.glob.php) or anything else you prefer. All you need to do is return array of [`SplFileInfo` objects](http://php.net/manual/en/class.splfileinfo.php).
+You can use [Nette\Finder](https://doc.nette.org/en/finder) or [Symfony\Finder](https://symfony.com/doc/current/components/finder.html).
 
 
 ## Contributing

--- a/packages/EasyCodingStandard/README.md
+++ b/packages/EasyCodingStandard/README.md
@@ -213,6 +213,7 @@ The `PhpAndPhptFilesProvider` might look like this:
 ```php
 namespace App\Finder;
 
+use IteratorAggregate;
 use Nette\Utils\Finder;
 use SplFileInfo;
 use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;
@@ -222,7 +223,7 @@ final class PhpAndPhptFilesProvider implements CustomSourceProviderInterface
     /**
      * @param string[] $source
      */
-    public function find(array $source): Finder
+    public function find(array $source): IteratorAggregate
     {
         # $source is "source" argument passed in CLI
         # inc CLI: "vendor/bin/ecs check /src" => here: ['/src']

--- a/packages/EasyCodingStandard/src/Contract/Finder/CustomSourceProviderInterface.php
+++ b/packages/EasyCodingStandard/src/Contract/Finder/CustomSourceProviderInterface.php
@@ -2,15 +2,12 @@
 
 namespace Symplify\EasyCodingStandard\Contract\Finder;
 
-use Nette\Utils\Finder as NetteFinder;
-use SplFileInfo;
-use Symfony\Component\Finder\Finder as SymfonyFinder;
+use IteratorAggregate;
 
 interface CustomSourceProviderInterface
 {
     /**
      * @param string[]
-     * @return NetteFinder|SplFileInfo[]|SymfonyFinder
      */
-    public function find(array $source);
+    public function find(array $source): IteratorAggregate;
 }

--- a/packages/EasyCodingStandard/src/Contract/Finder/CustomSourceProviderInterface.php
+++ b/packages/EasyCodingStandard/src/Contract/Finder/CustomSourceProviderInterface.php
@@ -10,7 +10,7 @@ interface CustomSourceProviderInterface
 {
     /**
      * @param string[]
-     * @return SplFileInfo[]|SymfonyFinder|NetteFinder
+     * @return NetteFinder|SplFileInfo[]|SymfonyFinder
      */
     public function find(array $source);
 }

--- a/packages/EasyCodingStandard/src/Contract/Finder/CustomSourceProviderInterface.php
+++ b/packages/EasyCodingStandard/src/Contract/Finder/CustomSourceProviderInterface.php
@@ -2,13 +2,15 @@
 
 namespace Symplify\EasyCodingStandard\Contract\Finder;
 
+use Nette\Utils\Finder as NetteFinder;
 use SplFileInfo;
+use Symfony\Component\Finder\Finder as SymfonyFinder;
 
 interface CustomSourceProviderInterface
 {
     /**
      * @param string[]
-     * @return SplFileInfo[]
+     * @return SplFileInfo[]|SymfonyFinder|NetteFinder
      */
-    public function find(array $source): array;
+    public function find(array $source);
 }

--- a/packages/EasyCodingStandard/src/Exception/Finder/InvalidSourceTypeException.php
+++ b/packages/EasyCodingStandard/src/Exception/Finder/InvalidSourceTypeException.php
@@ -6,5 +6,4 @@ use Exception;
 
 final class InvalidSourceTypeException extends Exception
 {
-
 }

--- a/packages/EasyCodingStandard/src/Exception/Finder/InvalidSourceTypeException.php
+++ b/packages/EasyCodingStandard/src/Exception/Finder/InvalidSourceTypeException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Exception\Finder;
+
+use Exception;
+
+final class InvalidSourceTypeException extends Exception
+{
+
+}

--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -12,6 +12,7 @@ use Symplify\EasyCodingStandard\Exception\Finder\InvalidSourceTypeException;
 final class FinderSanitizer
 {
     /**
+     * @param IteratorAggregate|mixed $finder
      * @return SplFileInfo[]
      */
     public function sanitize($finder): array
@@ -53,7 +54,8 @@ final class FinderSanitizer
             is_array($finder) ? gettype($finder) : $finder;
 
         throw new InvalidSourceTypeException(sprintf(
-            '%s is not valid source type, probably in your %s class in "find()" method. Return "%s", "%s" or %s instance.',
+            '%s is not valid source type, probably in your %s class in "find()" method. '
+                . 'Return "%s", "%s" or %s instance.',
             $sourceType,
             CustomSourceProviderInterface::class,
             NetteFinder::class,

--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -9,22 +9,18 @@ use Symfony\Component\Finder\Finder as SymfonyFinder;
 final class FinderSanitizer
 {
     /**
-     * @param NetteFinder|SymfonyFinder|SplFileInfo[] $finder
+     * @param NetteFinder|SplFileInfo[]|SymfonyFinder $finder
      * @return SplFileInfo[]
      */
     public function sanitize($finder): array
     {
-        if ($finder instanceof SymfonyFinder) {
-            $finder->size('> 0');
-        } elseif ($finder instanceof NetteFinder) {
-            $finder->size('>=', 1);
-        }
+        $finder = $this->filterOutEmptyFiles($finder);
 
         return $this->turnToSplFilesIfFinder($finder);
     }
 
     /**
-     * @param NetteFinder|SymfonyFinder|SplFileInfo[] $finder
+     * @param NetteFinder|SplFileInfo[]|SymfonyFinder $finder
      * @return SplFileInfo[]
      */
     private function turnToSplFilesIfFinder($finder): array
@@ -34,5 +30,26 @@ final class FinderSanitizer
         }
 
         return iterator_to_array($finder->getIterator());
+    }
+
+    /**
+     * @param NetteFinder|SplFileInfo[]|SymfonyFinder $finder
+     * @return NetteFinder|SplFileInfo[]|SymfonyFinder
+     */
+    private function filterOutEmptyFiles($finder)
+    {
+        if ($finder instanceof SymfonyFinder) {
+            $finder->size('> 0');
+
+            return $finder;
+        }
+
+        if ($finder instanceof NetteFinder) {
+            $finder->size('> 0');
+
+            return $finder;
+        }
+
+        return array_filter($finder, 'filesize');
     }
 }

--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -3,7 +3,6 @@
 namespace Symplify\EasyCodingStandard\Finder;
 
 use Nette\Utils\Finder as NetteFinder;
-use Nette\Utils\Json;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
 use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;
@@ -21,14 +20,14 @@ final class FinderSanitizer
 
         $finder = $this->filterOutEmptyFiles($finder);
 
-        return $this->turnToSplFilesIfFinder($finder);
+        return $this->turnToSplFiles($finder);
     }
 
     /**
      * @param NetteFinder|SymfonyFinder $finder
      * @return SplFileInfo[]
      */
-    private function turnToSplFilesIfFinder($finder): array
+    private function turnToSplFiles($finder): array
     {
         return iterator_to_array($finder->getIterator());
     }
@@ -50,8 +49,6 @@ final class FinderSanitizer
 
             return $finder;
         }
-
-        return $finder;
     }
 
     /**

--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -11,16 +11,16 @@ use Symplify\EasyCodingStandard\Exception\Finder\InvalidSourceTypeException;
 final class FinderSanitizer
 {
     /**
-     * @param NetteFinder|SplFileInfo[]|SymfonyFinder $finder
+     * @param NetteFinder|SymfonyFinder $finder
      * @return SplFileInfo[]
      */
     public function sanitize($finder): array
     {
         $this->ensureIsFinder($finder);
 
-        $finder = $this->filterOutEmptyFiles($finder);
+        $splFiles = $this->turnToSplFiles($finder);
 
-        return $this->turnToSplFiles($finder);
+        return $this->filterOutEmptyFiles($splFiles);
     }
 
     /**
@@ -33,22 +33,12 @@ final class FinderSanitizer
     }
 
     /**
-     * @param NetteFinder|SymfonyFinder $finder
-     * @return NetteFinder|SymfonyFinder
+     * @param SplFileInfo[] $splFiles
+     * @return SplFileInfo[]
      */
-    private function filterOutEmptyFiles($finder)
+    private function filterOutEmptyFiles(array $splFiles): array
     {
-        if ($finder instanceof SymfonyFinder) {
-            $finder->size('> 0');
-
-            return $finder;
-        }
-
-        if ($finder instanceof NetteFinder) {
-            $finder->size('> 0');
-
-            return $finder;
-        }
+        return array_filter($splFiles, 'filesize');
     }
 
     /**
@@ -64,7 +54,7 @@ final class FinderSanitizer
             is_array($finder) ? gettype($finder) : $finder;
 
         throw new InvalidSourceTypeException(sprintf(
-            '%s is not valid source type, probably in your %s class. Return "%s" or "%s"',
+            '%s is not valid source type, probably in your %s class in "find()" method. Return "%s" or "%s"',
             $sourceType,
             CustomSourceProviderInterface::class,
             NetteFinder::class,

--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Finder;
+
+use Nette\Utils\Finder as NetteFinder;
+use SplFileInfo;
+use Symfony\Component\Finder\Finder as SymfonyFinder;
+
+final class FinderSanitizer
+{
+    /**
+     * @param NetteFinder|SymfonyFinder|SplFileInfo[] $finder
+     * @return SplFileInfo[]
+     */
+    public function sanitize($finder): array
+    {
+        if ($finder instanceof SymfonyFinder) {
+            $finder->size('> 0');
+        } elseif ($finder instanceof NetteFinder) {
+            $finder->size('>=', 1);
+        }
+
+        return $this->turnToSplFilesIfFinder($finder);
+    }
+
+    /**
+     * @param NetteFinder|SymfonyFinder|SplFileInfo[] $finder
+     * @return SplFileInfo[]
+     */
+    private function turnToSplFilesIfFinder($finder): array
+    {
+        if (! $finder instanceof NetteFinder && ! $finder instanceof SymfonyFinder) {
+            return $finder;
+        }
+
+        return iterator_to_array($finder->getIterator());
+    }
+}

--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -2,6 +2,7 @@
 
 namespace Symplify\EasyCodingStandard\Finder;
 
+use IteratorAggregate;
 use Nette\Utils\Finder as NetteFinder;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
@@ -11,7 +12,6 @@ use Symplify\EasyCodingStandard\Exception\Finder\InvalidSourceTypeException;
 final class FinderSanitizer
 {
     /**
-     * @param NetteFinder|SymfonyFinder $finder
      * @return SplFileInfo[]
      */
     public function sanitize($finder): array
@@ -24,12 +24,11 @@ final class FinderSanitizer
     }
 
     /**
-     * @param NetteFinder|SymfonyFinder $finder
      * @return SplFileInfo[]
      */
-    private function turnToSplFiles($finder): array
+    private function turnToSplFiles(IteratorAggregate $finder): array
     {
-        return iterator_to_array($finder->getIterator());
+        return iterator_to_array($finder);
     }
 
     /**
@@ -46,7 +45,7 @@ final class FinderSanitizer
      */
     private function ensureIsFinder($finder): void
     {
-        if ($finder instanceof NetteFinder || $finder instanceof SymfonyFinder) {
+        if ($finder instanceof IteratorAggregate) {
             return;
         }
 
@@ -54,11 +53,12 @@ final class FinderSanitizer
             is_array($finder) ? gettype($finder) : $finder;
 
         throw new InvalidSourceTypeException(sprintf(
-            '%s is not valid source type, probably in your %s class in "find()" method. Return "%s" or "%s"',
+            '%s is not valid source type, probably in your %s class in "find()" method. Return "%s", "%s" or %s instance.',
             $sourceType,
             CustomSourceProviderInterface::class,
             NetteFinder::class,
-            SymfonyFinder::class
+            SymfonyFinder::class,
+            IteratorAggregate::class
         ));
     }
 }

--- a/packages/EasyCodingStandard/src/Finder/SourceFinder.php
+++ b/packages/EasyCodingStandard/src/Finder/SourceFinder.php
@@ -34,13 +34,12 @@ final class SourceFinder
      */
     public function find(array $source): array
     {
-        $files = [];
-
         if ($this->customSourceProvider) {
             $finder = $this->customSourceProvider->find($source);
             return $this->finderSanitizer->sanitize($finder);
         }
 
+        $files = [];
         foreach ($source as $singleSource) {
             if (is_file($singleSource)) {
                 $files = $this->processFile($files, $singleSource);
@@ -65,17 +64,16 @@ final class SourceFinder
 
     /**
      * @param SplFileInfo[] $files
-     * @param string $file
      * @return SplFileInfo[]
      */
     private function processDirectory(array $files, string $directory): array
     {
         $finder = (new Finder)->files()
             ->name('*.php')
-            ->in($directory)
-            ->size('> 0');
+            ->in($directory);
 
         $newFiles = $this->finderSanitizer->sanitize($finder);
+
         return array_merge($files, $newFiles);
     }
 }

--- a/packages/EasyCodingStandard/src/Finder/SourceFinder.php
+++ b/packages/EasyCodingStandard/src/Finder/SourceFinder.php
@@ -23,7 +23,7 @@ final class SourceFinder
         $this->finderSanitizer = $finderSanitizer;
     }
 
-    public function setCustomSourceProvider(?CustomSourceProviderInterface $customSourceProvider = null): void
+    public function setCustomSourceProvider(CustomSourceProviderInterface $customSourceProvider): void
     {
         $this->customSourceProvider = $customSourceProvider;
     }

--- a/packages/EasyCodingStandard/src/Finder/SourceFinder.php
+++ b/packages/EasyCodingStandard/src/Finder/SourceFinder.php
@@ -13,6 +13,16 @@ final class SourceFinder
      */
     private $customSourceProvider;
 
+    /**
+     * @var FinderSanitizer
+     */
+    private $finderSanitizer;
+
+    public function __construct(FinderSanitizer $finderSanitizer)
+    {
+        $this->finderSanitizer = $finderSanitizer;
+    }
+
     public function setCustomSourceProvider(?CustomSourceProviderInterface $customSourceProvider = null): void
     {
         $this->customSourceProvider = $customSourceProvider;
@@ -27,7 +37,8 @@ final class SourceFinder
         $files = [];
 
         if ($this->customSourceProvider) {
-            return $this->customSourceProvider->find($source);
+            $finder = $this->customSourceProvider->find($source);
+            return $this->finderSanitizer->sanitize($finder);
         }
 
         foreach ($source as $singleSource) {
@@ -64,6 +75,7 @@ final class SourceFinder
             ->in($directory)
             ->size('> 0');
 
-        return array_merge($files, iterator_to_array($finder->getIterator()));
+        $newFiles = $this->finderSanitizer->sanitize($finder);
+        return array_merge($files, $newFiles);
     }
 }

--- a/packages/EasyCodingStandard/tests/Finder/FinderSanitizerSource/FileWithClass.php
+++ b/packages/EasyCodingStandard/tests/Finder/FinderSanitizerSource/FileWithClass.php
@@ -1,0 +1,1 @@
+<?php declare(strict_types=1);

--- a/packages/EasyCodingStandard/tests/Finder/FinderSanitizerTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/FinderSanitizerTest.php
@@ -6,6 +6,7 @@ use Nette\Utils\Finder as NetteFinder;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
+use Symplify\EasyCodingStandard\Exception\Finder\InvalidSourceTypeException;
 use Symplify\EasyCodingStandard\Finder\FinderSanitizer;
 
 final class FinderSanitizerTest extends TestCase
@@ -20,13 +21,11 @@ final class FinderSanitizerTest extends TestCase
         $this->finderSanitizer = new FinderSanitizer;
     }
 
-    public function testSplFiles(): void
+    public function testValidTypes(): void
     {
-        $files[] = new SplFileInfo(__DIR__ . '/FinderSanitizerSource/EmptyFile.php');
-        $files[] = new SplFileInfo(__DIR__ . '/FinderSanitizerSource/FileWithClass.php');
-
-        $files = $this->finderSanitizer->sanitize($files);
-        $this->assertCount(1, $files);
+        $this->expectException(InvalidSourceTypeException::class);
+        $files = [new SplFileInfo(__DIR__ . '/FinderSanitizerSource/FileWithClass.php')];
+        $this->finderSanitizer->sanitize($files);
     }
 
     public function testSymfonyFinder(): void

--- a/packages/EasyCodingStandard/tests/Finder/FinderSanitizerTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/FinderSanitizerTest.php
@@ -4,6 +4,7 @@ namespace Symplify\EasyCodingStandard\Tests\Finder;
 
 use Nette\Utils\Finder as NetteFinder;
 use PHPUnit\Framework\TestCase;
+use SplFileInfo;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
 use Symplify\EasyCodingStandard\Finder\FinderSanitizer;
 
@@ -17,6 +18,15 @@ final class FinderSanitizerTest extends TestCase
     protected function setUp(): void
     {
         $this->finderSanitizer = new FinderSanitizer;
+    }
+
+    public function testSplFiles(): void
+    {
+        $files[] = new SplFileInfo(__DIR__ . '/FinderSanitizerSource/EmptyFile.php');
+        $files[] = new SplFileInfo(__DIR__ . '/FinderSanitizerSource/FileWithClass.php');
+
+        $files = $this->finderSanitizer->sanitize($files);
+        $this->assertCount(1, $files);
     }
 
     public function testSymfonyFinder(): void
@@ -37,6 +47,6 @@ final class FinderSanitizerTest extends TestCase
         $this->assertCount(2, iterator_to_array($finder->getIterator()));
 
         $files = $this->finderSanitizer->sanitize($finder);
-//        $this->assertCount(1, $files);
+        $this->assertCount(1, $files);
     }
 }

--- a/packages/EasyCodingStandard/tests/Finder/FinderSanitizerTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/FinderSanitizerTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Tests\Finder;
+
+use Nette\Utils\Finder as NetteFinder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder as SymfonyFinder;
+use Symplify\EasyCodingStandard\Finder\FinderSanitizer;
+
+final class FinderSanitizerTest extends TestCase
+{
+    /**
+     * @var FinderSanitizer
+     */
+    private $finderSanitizer;
+
+    protected function setUp(): void
+    {
+        $this->finderSanitizer = new FinderSanitizer;
+    }
+
+    public function testSymfonyFinder(): void
+    {
+        $finder = SymfonyFinder::create()->files()
+            ->in(__DIR__ . '/FinderSanitizerSource');
+
+        $this->assertCount(2, iterator_to_array($finder->getIterator()));
+
+        $files = $this->finderSanitizer->sanitize($finder);
+        $this->assertCount(1, $files);
+    }
+
+    public function testNetteFinder(): void
+    {
+        $finder = NetteFinder::find('*')->in(__DIR__ . '/FinderSanitizerSource');
+
+        $this->assertCount(2, iterator_to_array($finder->getIterator()));
+
+        $files = $this->finderSanitizer->sanitize($finder);
+//        $this->assertCount(1, $files);
+    }
+}

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/PhpAndIncFilesSourceProvider.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/PhpAndIncFilesSourceProvider.php
@@ -3,19 +3,15 @@
 namespace Symplify\EasyCodingStandard\Tests\Finder\SourceFinderSource;
 
 use Nette\Utils\Finder;
-use SplFileInfo;
 use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;
 
 final class PhpAndIncFilesSourceProvider implements CustomSourceProviderInterface
 {
     /**
      * @param string[] $source
-     * @return SplFileInfo[]
      */
-    public function find(array $source): array
+    public function find(array $source): Finder
     {
-        $finder = Finder::find('*.php.inc')->in($source);
-
-        return iterator_to_array($finder->getIterator());
+        return Finder::find('*.php.inc')->in($source);
     }
 }

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/PhpAndIncFilesSourceProvider.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/PhpAndIncFilesSourceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Symplify\EasyCodingStandard\Tests\Finder\SourceFinderSource;
 
+use IteratorAggregate;
 use Nette\Utils\Finder;
 use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;
 
@@ -10,7 +11,7 @@ final class PhpAndIncFilesSourceProvider implements CustomSourceProviderInterfac
     /**
      * @param string[] $source
      */
-    public function find(array $source): Finder
+    public function find(array $source): IteratorAggregate
     {
         return Finder::find('*.php.inc')->in($source);
     }

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
@@ -4,13 +4,14 @@ namespace Symplify\EasyCodingStandard\Tests\Finder;
 
 use PHPUnit\Framework\TestCase;
 use Symplify\EasyCodingStandard\DependencyInjection\ContainerFactory;
+use Symplify\EasyCodingStandard\Finder\FinderSanitizer;
 use Symplify\EasyCodingStandard\Finder\SourceFinder;
 
 final class SourceFinderTest extends TestCase
 {
     public function test(): void
     {
-        $sourceFinder = new SourceFinder;
+        $sourceFinder = new SourceFinder(new FinderSanitizer);
         $foundFiles = $sourceFinder->find([__DIR__ . '/SourceFinderSource/Source']);
         $this->assertCount(1, $foundFiles);
 

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
@@ -2,16 +2,15 @@
 
 namespace Symplify\EasyCodingStandard\Tests\Finder;
 
-use PHPUnit\Framework\TestCase;
 use Symplify\EasyCodingStandard\DependencyInjection\ContainerFactory;
-use Symplify\EasyCodingStandard\Finder\FinderSanitizer;
 use Symplify\EasyCodingStandard\Finder\SourceFinder;
+use Symplify\EasyCodingStandard\Tests\AbstractContainerAwareTestCase;
 
-final class SourceFinderTest extends TestCase
+final class SourceFinderTest extends AbstractContainerAwareTestCase
 {
     public function test(): void
     {
-        $sourceFinder = new SourceFinder(new FinderSanitizer);
+        $sourceFinder = $this->container->get(SourceFinder::class);
         $foundFiles = $sourceFinder->find([__DIR__ . '/SourceFinderSource/Source']);
         $this->assertCount(1, $foundFiles);
 


### PR DESCRIPTION
**Empty files were causing bugs**, because PHP-CS-Fixer excluded them in own Finder and not in the fixer code itself, for more info see: https://github.com/nette/coding-standard/issues/12#issuecomment-319102644


### Related Changes

Allow `CustomSourceProviderInterface` to be more error proof by using sanitizer service and more DX friendly requiring only iterator to return.

This is less WTF to `Finder` users, because `iterator_to_array` is never used in their context in common cases.

#### Before

```php
final class PhpAndIncFilesSourceProvider implements CustomSourceProviderInterface
{
    /**
     * @param string[] $source
     * @return mixed[]|SymfonyFinder|NetteFinder
     */
    public function find(array $source)
    {
        $finder = Finder::find('*.php.inc')->in($source);

        return iterator_to_array($finder->getIterator());
    }
}
```

#### After

```php
final class PhpAndIncFilesSourceProvider implements CustomSourceProviderInterface
{
    /**
     * @param string[] $source
     */
    public function find(array $source): IteratorAggregator
    {
        return Finder::find('*.php.inc')->in($source);
    }
}
```
