### PR TITLE
[Statie] removed hardcoded path from github filter

### DIFF
--- a/packages/Statie/src/Latte/Filter/GithubPrLinkFilterProvider.php
+++ b/packages/Statie/src/Latte/Filter/GithubPrLinkFilterProvider.php
@@ -28,8 +28,8 @@ final class GithubPrLinkFilterProvider implements FilterProviderInterface
             'githubEditPostUrl' => function (AbstractFile $file) {
                 return 'https://github.com/'
                     . $this->configuration->getGithubRepositorySlug()
-                    . '/edit/master/source/'
-                    . $file->getRelativeSource();
+                    . '/edit/master/'
+                    . $file->getFilePath();
             },
         ];
     }

--- a/packages/Statie/tests/Latte/Filter/GithubPrLinkFilterProviderTest.php
+++ b/packages/Statie/tests/Latte/Filter/GithubPrLinkFilterProviderTest.php
@@ -31,8 +31,8 @@ final class GithubPrLinkFilterProviderTest extends TestCase
         $githubEditPostUrlFilter = $githubPrLinkFilterProvider->provide()['githubEditPostUrl'];
 
         $abstractFileMock = $this->createMock(AbstractFile::class);
-        $abstractFileMock->method('getRelativeSource')
-            ->willReturn('_post/2017/2017-12-31-happy-new-years.md');
+        $abstractFileMock->method('getFilePath')
+            ->willReturn('source/_post/2017/2017-12-31-happy-new-years.md');
 
         $this->assertSame(
             'https://github.com/Organization/Repository/edit/master/source/_post/2017/2017-12-31-happy-new-years.md',


### PR DESCRIPTION
It is possible to define source directory in generate command via an argument, but in Github latte filter the path to a file is hardcoded though couldn't be changed. This change fixes it.