### PR TITLE
ArrayPropertyDefaultValueFixer: allow single-lined anotations

### DIFF
--- a/packages/CodingStandard/src/Fixer/Property/ArrayPropertyDefaultValueFixer.php
+++ b/packages/CodingStandard/src/Fixer/Property/ArrayPropertyDefaultValueFixer.php
@@ -44,14 +44,34 @@ public $property;'
 
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
-        for ($index = count($tokens) - 1; $index > 1; --$index) {
+        $blockLevel = 0;
+        $classOrTraitLevel = 0;
+
+        for ($index = 0; $index < count($tokens) - 1; ++$index) {
             $token = $tokens[$index];
+
+            if ($token->isGivenKind([T_CLASS, T_TRAIT])) {
+                $classOrTraitLevel = $blockLevel + 1;
+                continue;
+            }
+
+            if ($token->equals('{')) {
+                ++$blockLevel;
+                continue;
+            } elseif ($token->equals('}')) {
+                --$blockLevel;
+                continue;
+            }
 
             if (! $token->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
 
             if (! $this->isArrayPropertyDocComment($token)) {
+                continue;
+            }
+
+            if ($blockLevel !== $classOrTraitLevel) {
                 continue;
             }
 

--- a/packages/CodingStandard/src/Fixer/Property/ArrayPropertyDefaultValueFixer.php
+++ b/packages/CodingStandard/src/Fixer/Property/ArrayPropertyDefaultValueFixer.php
@@ -91,10 +91,6 @@ public $property;'
 
         $docBlock = new DocBlock($token->getContent());
 
-        if (count($docBlock->getLines()) === 1) {
-            return false;
-        }
-
         if (! $docBlock->getAnnotationsOfType('var')) {
             return false;
         }

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/Test.php
@@ -30,6 +30,10 @@ final class Test extends AbstractFixerTestCase
                 file_get_contents(__DIR__ . '/fixed/fixed2.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong2.php.inc'),
             ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed3.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong3.php.inc'),
+            ],
         ];
     }
 

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/fixed/fixed3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/fixed/fixed3.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+class SomeClass
+{
+    /** @var int[] */
+    public $property = [];
+}

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/fixed/fixed3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/fixed/fixed3.php.inc
@@ -4,4 +4,10 @@ class SomeClass
 {
     /** @var int[] */
     public $property = [];
+
+    public function method()
+    {
+        /** @var string[] $notAProperty */
+        $notAProperty;
+    }
 }

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/wrong/wrong3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/wrong/wrong3.php.inc
@@ -4,4 +4,10 @@ class SomeClass
 {
     /** @var int[] */
     public $property;
+
+    public function method()
+    {
+        /** @var string[] $notAProperty */
+        $notAProperty;
+    }
 }

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/wrong/wrong3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/wrong/wrong3.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+class SomeClass
+{
+    /** @var int[] */
+    public $property;
+}


### PR DESCRIPTION
A single-lined annotation is a valid annotation. In my opinion, deciding that they are errors or not should be matter of another fixer.