### PR TITLE
[CodingStandard] add RequireFollowedByAbsolutePathFixer

### DIFF
--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -163,7 +163,7 @@ require 'vendor/autoload.php';
 :+1:
 
 ```php
-require __DIR__.'vendor/autoload.php';
+require __DIR__.'/vendor/autoload.php';
 ```
 
 

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -120,7 +120,6 @@ checkers:
 
 ### Variables created with `$container->get(SomeService::class)` should have annotation, so every IDE supports autocomplete without any plugins
 
-
 - class: [`Symplify\CodingStandard\Fixer\Commenting\AnnotateMagicContainerGetterFixer`](/src/Fixer/Commenting/AnnotateMagicContainerGetterFixer.php)
 
 :x:
@@ -148,6 +147,23 @@ class SomeTest extends ContainerAwareTestCase
         $someService->knownMethod();
     }
 }
+```
+
+
+### Include/Require should be followed by absolute path
+
+- class: [`Symplify\CodingStandard\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer`](/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php)
+
+:x:
+
+```php
+require 'vendor/autoload.php';
+```
+
+:+1:
+
+```php
+require __DIR__.'vendor/autoload.php';
 ```
 
 

--- a/packages/CodingStandard/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php
+++ b/packages/CodingStandard/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php
@@ -1,0 +1,81 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\ControlStructure;
+
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class RequireFollowedByAbsolutePathFixer implements DefinedFixerInterface
+{
+    /**
+     * @var int[]
+     */
+    private const INCLUDY_TOKEN_KINDS = [T_REQUIRE, T_REQUIRE_ONCE, T_INCLUDE, T_INCLUDE_ONCE];
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Include/Require should be followed by absolute path.',
+            [
+                new CodeSample('require "vendor/autoload.php"'),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound(self::INCLUDY_TOKEN_KINDS);
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
+            $token = $tokens[$index];
+
+            if (! $token->isGivenKind(self::INCLUDY_TOKEN_KINDS)) {
+                continue;
+            }
+
+            $nextTokenPosition = $tokens->getNextNonWhitespace($index);
+            $nextToken = $tokens[$nextTokenPosition];
+
+            if (! $nextToken->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {
+                continue;
+            }
+
+            $tokens->insertAt($nextTokenPosition, [
+                new Token([T_DIR, '__DIR__']),
+                new Token('.'),
+            ]);
+        }
+    }
+
+    public function getName(): string
+    {
+        return self::class;
+    }
+
+    /**
+     * Must run before @see ConcatSpaceFixer.
+     */
+    public function getPriority(): int
+    {
+        return 5;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/packages/CodingStandard/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php
+++ b/packages/CodingStandard/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php
@@ -34,11 +34,6 @@ final class RequireFollowedByAbsolutePathFixer implements DefinedFixerInterface
         return $tokens->isAnyTokenKindsFound(self::INCLUDY_TOKEN_KINDS);
     }
 
-    public function isRisky(): bool
-    {
-        return false;
-    }
-
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         for ($index = $tokens->count() - 1; 0 <= $index; --$index) {
@@ -55,6 +50,10 @@ final class RequireFollowedByAbsolutePathFixer implements DefinedFixerInterface
 
             $nextToken = $tokens[$nextTokenPosition];
             if (! $nextToken->isGivenKind(T_CONSTANT_ENCAPSED_STRING)) {
+                continue;
+            }
+
+            if ($this->startsWithPhar($nextToken)) {
                 continue;
             }
 
@@ -75,6 +74,11 @@ final class RequireFollowedByAbsolutePathFixer implements DefinedFixerInterface
         }
     }
 
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
     public function getName(): string
     {
         return self::class;
@@ -91,6 +95,11 @@ final class RequireFollowedByAbsolutePathFixer implements DefinedFixerInterface
     public function supports(SplFileInfo $file): bool
     {
         return true;
+    }
+
+    private function startsWithPhar(Token $nextToken): bool
+    {
+        return Strings::startsWith($nextToken->getContent(), "'phar://");
     }
 
     private function startsWithSlash(Token $nextToken): bool

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/Test.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RequireFollowedByAbsolutePathFixer;
+namespace Symplify\CodingStandard\Tests\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer;
 
 use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
@@ -25,6 +25,10 @@ final class Test extends AbstractFixerTestCase
             [
                 file_get_contents(__DIR__ . '/fixed/fixed.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong.php.inc'),
+            ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed2.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong2.php.inc'),
             ],
         ];
     }

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/Test.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RequireFollowedByAbsolutePathFixer;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use Symplify\CodingStandard\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer;
+
+final class Test extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases()
+     */
+    public function testFix(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideFixCases(): array
+    {
+        return [
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong.php.inc'),
+            ],
+        ];
+    }
+
+    protected function createFixer(): FixerInterface
+    {
+        return new RequireFollowedByAbsolutePathFixer;
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+require __DIR__.'autoload.php';
+
+require_once __DIR__.'autoload.php';
+
+include __DIR__.'autoload.php';
+
+include_once __DIR__.'autoload.php';
+
+
+require $variable;
+
+require __DIR__ . $variable;
+
+require __DIR__ . 'string';

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed.php.inc
@@ -1,12 +1,12 @@
 <?php
 
-require __DIR__.'autoload.php';
+require __DIR__.'/autoload.php';
 
-require_once __DIR__.'autoload.php';
+require_once __DIR__.'/autoload.php';
 
-include __DIR__.'autoload.php';
+include __DIR__.'/autoload.php';
 
-include_once __DIR__.'autoload.php';
+include_once __DIR__.'/autoload.php';
 
 
 require $variable;

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed2.php.inc
@@ -1,0 +1,4 @@
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+require __DIR__.'/vendor/autoload.php';

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/fixed/fixed2.php.inc
@@ -2,3 +2,5 @@
 
 require __DIR__.'/vendor/autoload.php';
 require __DIR__.'/vendor/autoload.php';
+
+require 'phar://vendor/autoload.php';

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/wrong/wrong.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/wrong/wrong.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+require 'autoload.php';
+
+require_once 'autoload.php';
+
+include 'autoload.php';
+
+include_once 'autoload.php';
+
+
+require $variable;
+
+require __DIR__ . $variable;
+
+require __DIR__ . 'string';

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/wrong/wrong2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/wrong/wrong2.php.inc
@@ -1,0 +1,4 @@
+<?php
+
+require 'vendor/autoload.php';
+require '/vendor/autoload.php';

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/wrong/wrong2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/wrong/wrong2.php.inc
@@ -2,3 +2,5 @@
 
 require 'vendor/autoload.php';
 require '/vendor/autoload.php';
+
+require 'phar://vendor/autoload.php';

--- a/packages/EasyCodingStandard/bin/easy-coding-standard.php
+++ b/packages/EasyCodingStandard/bin/easy-coding-standard.php
@@ -41,7 +41,7 @@ try {
     // 3. Run Console Application
     /** @var Application $application */
     $application = $container->get(Application::class);
-    $application->run();
+    exit($application->run());
 } catch (Throwable $throwable) {
     $symfonyStyle = SymfonyStyleFactory::create();
     $symfonyStyle->error($throwable->getMessage());

--- a/packages/EasyCodingStandard/config/symplify-checkers.neon
+++ b/packages/EasyCodingStandard/config/symplify-checkers.neon
@@ -8,6 +8,7 @@ checkers:
     - Symplify\CodingStandard\Sniffs\ControlStructures\NewClassSniff
     - Symplify\CodingStandard\Fixer\Property\ArrayPropertyDefaultValueFixer
     - Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer
+    - Symplify\CodingStandard\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer
 
     # Spaces
     - Symplify\CodingStandard\Fixer\ClassNotation\PropertyAndConstantSeparationFixer

--- a/packages/Statie/bin/statie.php
+++ b/packages/Statie/bin/statie.php
@@ -23,7 +23,6 @@ foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
     }
 }
 
-
 try {
     // 1. Detect configuration
     ConfigFilePathHelper::detectFromInput('statie', new ArgvInput);

--- a/packages/Statie/bin/statie.php
+++ b/packages/Statie/bin/statie.php
@@ -3,6 +3,7 @@
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symplify\PackageBuilder\Configuration\ConfigFilePathHelper;
+use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
 use Symplify\Statie\DependencyInjection\ContainerFactory;
 
 // performance boost
@@ -22,19 +23,27 @@ foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
     }
 }
 
-// 1. Detect configuration
-ConfigFilePathHelper::detectFromInput('statie', new ArgvInput);
 
-// 2. Build DI container
-$containerFactory = new ContainerFactory;
-$configFile = ConfigFilePathHelper::provide('statie', 'statie.neon');
-if ($configFile) {
-    $container = $containerFactory->createWithConfig($configFile);
-} else {
-    $container = $containerFactory->create();
+try {
+    // 1. Detect configuration
+    ConfigFilePathHelper::detectFromInput('statie', new ArgvInput);
+
+    // 2. Build DI container
+    $containerFactory = new ContainerFactory;
+    $configFile = ConfigFilePathHelper::provide('statie', 'statie.neon');
+
+    if ($configFile) {
+        $container = $containerFactory->createWithConfig($configFile);
+    } else {
+        $container = $containerFactory->create();
+    }
+
+    // 3. Run Console Application
+    /** @var Application $application */
+    $application = $container->get(Application::class);
+    exit($application->run());
+} catch (Throwable $throwable) {
+    $symfonyStyle = SymfonyStyleFactory::create();
+    $symfonyStyle->error($throwable->getMessage());
+    exit(1);
 }
-
-// 3. Run Console Application
-/** @var Application $application */
-$application = $container->get(Application::class);
-$application->run();


### PR DESCRIPTION
### Todo

Cover cases like:

```php
require 'vendor/autoload.php';
require '/vendor/autoload.php';
```

=>

```php
require __DIR__ . '/vendor/autoload.php';
require __DIR__ . '/vendor/autoload.php';
````

---

```php
require 'phar://' . __FILE__ . '/tracy.php';
```