### PR TITLE
[CodingStandard] Fix ArrayPropertyDefaultValueFixer

### DIFF
--- a/packages/CodingStandard/src/Tokenizer/DocBlockAnalyzer.php
+++ b/packages/CodingStandard/src/Tokenizer/DocBlockAnalyzer.php
@@ -18,7 +18,8 @@ final class DocBlockAnalyzer
 
         $varAnnotation = $docBlock->getAnnotationsOfType('var')[0];
 
-        return Strings::contains($varAnnotation->getContent(), '[]');
+        return Strings::contains($varAnnotation->getContent(), '[]')
+            && ! Strings::contains($varAnnotation->getContent(), '|');
     }
 
     /**

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/Test.php
@@ -11,7 +11,7 @@ final class Test extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases()
      */
-    public function testFix(string $expected, string $input): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -37,6 +37,9 @@ final class Test extends AbstractFixerTestCase
             [
                 file_get_contents(__DIR__ . '/fixed/fixed4.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong4.php.inc'),
+            ],
+            [
+                file_get_contents(__DIR__ . '/correct/correct.php.inc'),
             ],
         ];
     }

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/correct/correct.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/correct/correct.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+class SomeClass
+{
+	/**
+	 * @var ArrayObject|int[]
+	 */
+	public $property;
+}

--- a/packages/PackageBuilder/src/HttpKernel/AbstractCliKernel.php
+++ b/packages/PackageBuilder/src/HttpKernel/AbstractCliKernel.php
@@ -13,7 +13,7 @@ abstract class AbstractCliKernel extends Kernel
     public function __construct()
     {
         // random_int is used to prevent container name duplication during tests
-        parent::__construct(random_int(1, 10000), true);
+        parent::__construct(random_int(1, 1000000), true);
     }
 
     /**


### PR DESCRIPTION
For Doctrine collections Slevomat coding standard forces me to define them like this:

```php
/**
 * @var Collection|Foo[]
 */
private $foo;
```

This confuses ArrayPropertyDefaultValueFixer to think it's an array property and should be initialized with `= []` while it is in fact a collection and should be initialized with `new ArrayCollection()` in constructor instead.