### PR TITLE
[CodingStandard] no extra doc block Fixer

### DIFF
--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -150,6 +150,35 @@ class SomeTest extends ContainerAwareTestCase
 ```
 
 
+### Block comment should only contain useful information about types
+
+- class: [`Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer`](/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php)
+
+:x:
+
+```php
+/**
+ * @param int $value
+ * @param $anotherValue
+ * @param SomeType $someService
+ * @return array
+ */
+public function setCount(int $value, $anotherValue, SomeType $someService): array
+{
+}
+```
+
+:+1:
+
+```php
+/**
+ */
+public function setCount(int $value, $anotherValue, SomeType $someService): array
+{
+}
+```
+
+
 ### Include/Require should be followed by absolute path
 
 - class: [`Symplify\CodingStandard\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer`](/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php)

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -151,7 +151,6 @@ class SomeTest extends ContainerAwareTestCase
 
 
 ### Block comment should only contain useful information about types
-
 - class: [`Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer`](/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php)
 
 :x:

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/AbstractVariableWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/AbstractVariableWrapper.php
@@ -3,6 +3,7 @@
 namespace Symplify\CodingStandard\FixerTokenWrapper;
 
 use Nette\Utils\Strings;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symplify\CodingStandard\FixerTokenWrapper\Naming\ClassFqnResolver;
@@ -51,7 +52,8 @@ abstract class AbstractVariableWrapper
     {
         $previousTokenPosition = $this->tokens->getPrevMeaningfulToken($this->index);
         $previousToken = $this->tokens[$previousTokenPosition];
-        if (! $previousToken->isGivenKind(T_STRING)) {
+
+        if (! $previousToken->isGivenKind([T_STRING, CT::T_ARRAY_TYPEHINT])) {
             return null;
         }
 

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -8,6 +8,7 @@ use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\WhitespacesFixerConfig;
+use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 
 final class DocBlockWrapper
 {
@@ -59,6 +60,25 @@ final class DocBlockWrapper
         }
 
         return $this->resolveAnnotationContent($returnAnnotations[0], 'return');
+    }
+
+    public function getReturnTypeDescription(): ?string
+    {
+        $returnAnnotations = $this->docBlock->getAnnotationsOfType('return');
+        if (! $returnAnnotations) {
+            return null;
+        }
+
+        $returnAnnotation = $returnAnnotations[0];
+
+        $annotationParts = explode(' ', $this->resolveAnnotationContent($returnAnnotation, 'return'));
+        if (count($annotationParts) < 2) {
+            return null;
+        }
+
+        [, $description] = $annotationParts;
+
+        return $description;
     }
 
     public function getArgumentType(string $name): ?string

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -71,8 +71,9 @@ final class DocBlockWrapper
         foreach ($paramAnnotations as $paramAnnotation) {
             if (Strings::contains($paramAnnotation->getContent(), '$' . $name)) {
                 $types = $this->resolveAnnotationContent($paramAnnotation, 'param');
+                [$type, ] = explode(' $' . $name, $types);
 
-                return rtrim($types, ' $' . $name);
+                return $type;
             }
         }
 

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -8,7 +8,6 @@ use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use PhpCsFixer\WhitespacesFixerConfig;
-use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 
 final class DocBlockWrapper
 {

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -90,7 +90,12 @@ final class DocBlockWrapper
         foreach ($paramAnnotations as $paramAnnotation) {
             if (Strings::contains($paramAnnotation->getContent(), '$' . $name)) {
                 $types = $this->resolveAnnotationContent($paramAnnotation, 'param');
-                [$type, ] = explode(' $' . $name, $types);
+                $typeParts = explode(' $' . $name, $types);
+                if (count($typeParts) < 2) {
+                    return null;
+                }
+
+                [$type, ] = $typeParts;
 
                 return trim($type);
             }

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -49,6 +49,31 @@ final class DocBlockWrapper
         return count($this->docBlock->getLines()) === 1;
     }
 
+    public function getReturnType(): ?string
+    {
+        $returnAnnotations = $this->docBlock->getAnnotationsOfType('return');
+        if (! $returnAnnotations) {
+            return null;
+        }
+
+        $content = $returnAnnotations[0]->getContent();
+        [, $content] = explode('@return', $content);
+        $content = ltrim($content, ' *');
+        $content = trim($content);
+
+        return $content;
+    }
+
+    public function removeReturnType(): void
+    {
+        $returnAnnotations = $this->docBlock->getAnnotationsOfType('return');
+        foreach ($returnAnnotations as $returnAnnotation) {
+            $returnAnnotation->remove();
+        }
+
+        $this->tokens[$this->docBlockPosition] = new Token([T_DOC_COMMENT, $this->docBlock->getContent()]);
+    }
+
     public function changeToMultiLine(): void
     {
         $indent = $this->whitespacesFixerConfig->getIndent();

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -72,7 +72,7 @@ final class DocBlockWrapper
             if (Strings::contains($paramAnnotation->getContent(), '$' . $name)) {
                 $types = $this->resolveAnnotationContent($paramAnnotation, 'param');
 
-                return rtrim($types , ' $' . $name);
+                return rtrim($types, ' $' . $name);
             }
         }
 
@@ -95,6 +95,7 @@ final class DocBlockWrapper
         foreach ($paramAnnotations as $paramAnnotation) {
             if (Strings::contains($paramAnnotation, '$' . $name)) {
                 $paramAnnotation->remove();
+
                 break;
             }
         }
@@ -129,7 +130,7 @@ final class DocBlockWrapper
     private function resolveAnnotationContent(Annotation $annotation, string $name): string
     {
         $content = $annotation->getContent();
-        [, $content] = explode('@'. $name, $content);
+        [, $content] = explode('@' . $name, $content);
 
         $content = ltrim($content, ' *');
         $content = trim($content);

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -99,6 +99,29 @@ final class DocBlockWrapper
         return null;
     }
 
+    public function getArgumentTypeDescription(string $name): ?string
+    {
+        $paramAnnotations = $this->docBlock->getAnnotationsOfType('param');
+        if (! $paramAnnotations) {
+            return null;
+        }
+
+        foreach ($paramAnnotations as $paramAnnotation) {
+            if (Strings::contains($paramAnnotation->getContent(), '$' . $name)) {
+                $annotationParts = explode(' ', $this->resolveAnnotationContent($paramAnnotation, 'param'));
+                if (count($annotationParts) < 3) {
+                    return null;
+                }
+
+                $annotationParts = array_slice($annotationParts, 2);
+
+                return implode(' ', $annotationParts);
+            }
+        }
+
+        return null;
+    }
+
     public function removeReturnType(): void
     {
         $returnAnnotations = $this->docBlock->getAnnotationsOfType('return');

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/DocBlockWrapper.php
@@ -92,7 +92,7 @@ final class DocBlockWrapper
                 $types = $this->resolveAnnotationContent($paramAnnotation, 'param');
                 [$type, ] = explode(' $' . $name, $types);
 
-                return $type;
+                return trim($type);
             }
         }
 
@@ -108,14 +108,13 @@ final class DocBlockWrapper
 
         foreach ($paramAnnotations as $paramAnnotation) {
             if (Strings::contains($paramAnnotation->getContent(), '$' . $name)) {
-                $annotationParts = explode(' ', $this->resolveAnnotationContent($paramAnnotation, 'param'));
-                if (count($annotationParts) < 3) {
+                $annotationParts = explode('$' . $name, $this->resolveAnnotationContent($paramAnnotation, 'param'));
+
+                if (count($annotationParts) < 2) {
                     return null;
                 }
 
-                $annotationParts = array_slice($annotationParts, 2);
-
-                return implode(' ', $annotationParts);
+                return $annotationParts[1];
             }
         }
 

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/MethodWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/MethodWrapper.php
@@ -104,4 +104,22 @@ final class MethodWrapper
             $docBlock
         );
     }
+
+    public function getReturnType(): ?string
+    {
+        for ($i = $this->index; $i < count($this->tokens); ++$i) {
+            $token = $this->tokens[$i];
+            if ($token->getContent() === '{') {
+                return null;
+            }
+
+            if ($token->getContent() === ':') {
+                $typeToken = $this->tokens[$this->tokens->getNextMeaningfulToken($i)];
+
+                return $typeToken->getContent();
+            }
+        }
+
+        return null;
+    }
 }

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/MethodWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/MethodWrapper.php
@@ -3,9 +3,11 @@
 namespace Symplify\CodingStandard\FixerTokenWrapper;
 
 use Nette\Utils\Strings;
+use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symplify\CodingStandard\FixerTokenWrapper\Guard\TokenTypeGuard;
+use Symplify\CodingStandard\Tokenizer\DocBlockFinder;
 
 final class MethodWrapper
 {
@@ -85,5 +87,21 @@ final class MethodWrapper
 
             $this->tokens[$i] = new Token([T_VARIABLE, $newName]);
         }
+    }
+
+    public function getDocBlockWrapper(): ?DocBlockWrapper
+    {
+        $docBlockToken = DocBlockFinder::findPrevious($this->tokens, $this->index);
+        if ($docBlockToken === null) {
+            return null;
+        }
+
+        $docBlock = new DocBlock($docBlockToken->getContent());
+
+        return DocBlockWrapper::createFromTokensPositionAndDocBlock(
+            $this->tokens,
+            DocBlockFinder::findPreviousPosition($this->tokens, $this->index),
+            $docBlock
+        );
     }
 }

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/PropertyWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/PropertyWrapper.php
@@ -10,7 +10,6 @@ use PhpCsFixer\Tokenizer\Tokens;
 use Symplify\CodingStandard\FixerTokenWrapper\Exception\MissingDocBlockException;
 use Symplify\CodingStandard\FixerTokenWrapper\Guard\TokenTypeGuard;
 use Symplify\CodingStandard\FixerTokenWrapper\Naming\ClassFqnResolver;
-use Symplify\CodingStandard\Tokenizer\DocBlockAnalyzer;
 use Symplify\CodingStandard\Tokenizer\DocBlockFinder;
 use Symplify\CodingStandard\Tokenizer\PropertyAnalyzer;
 
@@ -65,27 +64,6 @@ final class PropertyWrapper
     public static function createFromTokensAndPosition(Tokens $tokens, int $position): self
     {
         return new self($tokens, $position);
-    }
-
-    public function isInjectProperty(): bool
-    {
-        if ($this->visibilityToken === null) {
-            return false;
-        }
-
-        if (! $this->visibilityToken->isGivenKind(T_PUBLIC)) {
-            return false;
-        }
-
-        if ($this->docBlock === null) {
-            return false;
-        }
-
-        if (! DocBlockAnalyzer::hasAnnotations($this->docBlock, ['inject', 'var'])) {
-            return false;
-        }
-
-        return true;
     }
 
     public function removeAnnotation(string $annotationType): void

--- a/packages/CodingStandard/packages/FixerTokenWrapper/src/PropertyWrapper.php
+++ b/packages/CodingStandard/packages/FixerTokenWrapper/src/PropertyWrapper.php
@@ -26,11 +26,6 @@ final class PropertyWrapper
     private $docBlock;
 
     /**
-     * @var Token
-     */
-    private $visibilityToken;
-
-    /**
      * @var int
      */
     private $visibilityPosition;
@@ -58,7 +53,6 @@ final class PropertyWrapper
         }
 
         $this->visibilityPosition = PropertyAnalyzer::findVisibilityPosition($tokens, $index);
-        $this->visibilityToken = $tokens[$this->visibilityPosition];
     }
 
     public static function createFromTokensAndPosition(Tokens $tokens, int $position): self
@@ -75,11 +69,6 @@ final class PropertyWrapper
         }
 
         $this->tokens[$this->docBlockPosition] = new Token([T_DOC_COMMENT, $this->docBlock->getContent()]);
-    }
-
-    public function makePrivate(): void
-    {
-        $this->tokens[$this->visibilityPosition] = new Token([T_PRIVATE, 'private']);
     }
 
     public function getName(): string

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\Commenting;
+
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+use Symplify\CodingStandard\Tokenizer\ClassTokensAnalyzer;
+use Symplify\CodingStandard\Tokenizer\DocBlockFinder;
+
+final class RemoveUselessDocBlockFixer implements FixerInterface, DefinedFixerInterface
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Block comment should only contain useful information.',
+            [
+                new CodeSample('<?php
+/**
+ * @return int 
+ */
+public function getCount(): int
+{
+}
+'),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAllTokenKindsFound([T_FUNCTION, T_DOC_COMMENT]);
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = count($tokens) - 1; $index > 1; --$index) {
+            $token = $tokens[$index];
+
+            if (! $token->isGivenKind(T_CLASS)) {
+                continue;
+            }
+
+            $classTokensAnalyzer = ClassTokensAnalyzer::createFromTokensArrayStartPosition($tokens, $index);
+            foreach ($classTokensAnalyzer->getMethodWrappers() as $methodWrapper) {
+                $methodWrapper->getDocBlockWrapper()
+                dump($methodWrapper);
+
+                die;
+            }
+
+//            if (! $token->isGivenKind(T_FUNCTION)) {
+//                continue;
+//            }
+//
+//            $methodDocBlock = DocBlockFinder::findPrevious($tokens, $index);
+//            if ($methodDocBlock === null) {
+//                continue;
+//            }
+//
+//
+//
+//            dump($methodDocBlock);
+//            die;
+        }
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function getName(): string
+    {
+        return self::class;
+    }
+
+    public function getPriority(): int
+    {
+        // before empty doc block cleaner
+        return 0;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -53,6 +53,12 @@ public function getCount(): int
                 }
 
                 // 2. process param tag
+                foreach ($methodWrapper->getArguments() as $argumentWrapper) {
+                    $argumentType = $docBlockWrapper->getArgumentType($argumentWrapper->getName());
+                    if ($argumentType === $argumentWrapper->getType()) {
+                        $docBlockWrapper->removeParamType($argumentWrapper->getName());
+                    }
+                }
             }
         }
     }

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -95,6 +95,7 @@ public function getCount(): int
     {
         foreach ($methodWrapper->getArguments() as $argumentWrapper) {
             $argumentType = $docBlockWrapper->getArgumentType($argumentWrapper->getName());
+
             if ($argumentType === $argumentWrapper->getType()) {
                 if ($docBlockWrapper->getArgumentTypeDescription($argumentWrapper->getName())) {
                     continue;

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -9,6 +9,8 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
+use Symplify\CodingStandard\FixerTokenWrapper\DocBlockWrapper;
+use Symplify\CodingStandard\FixerTokenWrapper\MethodWrapper;
 use Symplify\CodingStandard\Tokenizer\ClassTokensAnalyzer;
 
 final class RemoveUselessDocBlockFixer implements FixerInterface, DefinedFixerInterface
@@ -51,22 +53,8 @@ public function getCount(): int
                     continue;
                 }
 
-                // 1. process return tag
-                if ($methodWrapper->getReturnType() === $docBlockWrapper->getReturnType()) {
-                    if ($docBlockWrapper->getReturnTypeDescription()) {
-                        continue;
-                    }
-
-                    $docBlockWrapper->removeReturnType();
-                }
-
-                // 2. process param tag
-                foreach ($methodWrapper->getArguments() as $argumentWrapper) {
-                    $argumentType = $docBlockWrapper->getArgumentType($argumentWrapper->getName());
-                    if ($argumentType === $argumentWrapper->getType()) {
-                        $docBlockWrapper->removeParamType($argumentWrapper->getName());
-                    }
-                }
+                $this->processReturnTag($methodWrapper, $docBlockWrapper);
+                $this->processParamTag($methodWrapper, $docBlockWrapper);
             }
         }
     }
@@ -90,5 +78,30 @@ public function getCount(): int
     public function supports(SplFileInfo $file): bool
     {
         return true;
+    }
+
+    private function processReturnTag(MethodWrapper $methodWrapper, DocBlockWrapper $docBlockWrapper): void
+    {
+        if ($methodWrapper->getReturnType() === $docBlockWrapper->getReturnType()) {
+            if ($docBlockWrapper->getReturnTypeDescription()) {
+                return;
+            }
+
+            $docBlockWrapper->removeReturnType();
+        }
+    }
+
+    private function processParamTag(MethodWrapper $methodWrapper, DocBlockWrapper $docBlockWrapper): void
+    {
+        foreach ($methodWrapper->getArguments() as $argumentWrapper) {
+            $argumentType = $docBlockWrapper->getArgumentType($argumentWrapper->getName());
+            if ($argumentType === $argumentWrapper->getType()) {
+                if ($docBlockWrapper->getArgumentTypeDescription($argumentWrapper->getName())) {
+                    continue;
+                }
+
+                $docBlockWrapper->removeParamType($argumentWrapper->getName());
+            }
+        }
     }
 }

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -69,10 +69,12 @@ public function getCount(): int
         return self::class;
     }
 
+    /**
+     * Runs before @see \PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer
+     */
     public function getPriority(): int
     {
-        // before empty doc block cleaner
-        return 0;
+        return 10;
     }
 
     public function supports(SplFileInfo $file): bool
@@ -96,8 +98,16 @@ public function getCount(): int
         foreach ($methodWrapper->getArguments() as $argumentWrapper) {
             $argumentType = $docBlockWrapper->getArgumentType($argumentWrapper->getName());
 
+            $argumentDescription = $docBlockWrapper->getArgumentTypeDescription($argumentWrapper->getName());
+
+            if ($argumentType === null && $argumentDescription === null) {
+                $docBlockWrapper->removeParamType($argumentWrapper->getName());
+                continue;
+
+            }
+
             if ($argumentType === $argumentWrapper->getType()) {
-                if ($docBlockWrapper->getArgumentTypeDescription($argumentWrapper->getName())) {
+                if ($argumentDescription) {
                     continue;
                 }
 

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -70,7 +70,7 @@ public function getCount(): int
     }
 
     /**
-     * Runs before @see \PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer
+     * Runs before @see \PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer.
      */
     public function getPriority(): int
     {
@@ -102,8 +102,8 @@ public function getCount(): int
 
             if ($argumentType === null && $argumentDescription === null) {
                 $docBlockWrapper->removeParamType($argumentWrapper->getName());
-                continue;
 
+                continue;
             }
 
             if ($argumentType === $argumentWrapper->getType()) {

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -53,6 +53,10 @@ public function getCount(): int
 
                 // 1. process return tag
                 if ($methodWrapper->getReturnType() === $docBlockWrapper->getReturnType()) {
+                    if ($docBlockWrapper->getReturnTypeDescription()) {
+                        continue;
+                    }
+
                     $docBlockWrapper->removeReturnType();
                 }
 

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -10,7 +10,6 @@ use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 use Symplify\CodingStandard\Tokenizer\ClassTokensAnalyzer;
-use Symplify\CodingStandard\Tokenizer\DocBlockFinder;
 
 final class RemoveUselessDocBlockFixer implements FixerInterface, DefinedFixerInterface
 {
@@ -47,25 +46,11 @@ public function getCount(): int
 
             $classTokensAnalyzer = ClassTokensAnalyzer::createFromTokensArrayStartPosition($tokens, $index);
             foreach ($classTokensAnalyzer->getMethodWrappers() as $methodWrapper) {
-                $methodWrapper->getDocBlockWrapper()
-                dump($methodWrapper);
+                $docBlockWrapper = $methodWrapper->getDocBlockWrapper();
 
-                die;
+                // 1. process return tag
+                // 2. process param tag
             }
-
-//            if (! $token->isGivenKind(T_FUNCTION)) {
-//                continue;
-//            }
-//
-//            $methodDocBlock = DocBlockFinder::findPrevious($tokens, $index);
-//            if ($methodDocBlock === null) {
-//                continue;
-//            }
-//
-//
-//
-//            dump($methodDocBlock);
-//            die;
         }
     }
 

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -46,9 +46,12 @@ public function getCount(): int
 
             $classTokensAnalyzer = ClassTokensAnalyzer::createFromTokensArrayStartPosition($tokens, $index);
             foreach ($classTokensAnalyzer->getMethodWrappers() as $methodWrapper) {
-                $docBlockWrapper = $methodWrapper->getDocBlockWrapper();
-
                 // 1. process return tag
+                $docBlockWrapper = $methodWrapper->getDocBlockWrapper();
+                if ($methodWrapper->getReturnType() === $docBlockWrapper->getReturnType()) {
+                    $docBlockWrapper->removeReturnType();
+                }
+
                 // 2. process param tag
             }
         }

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -18,7 +18,7 @@ final class RemoveUselessDocBlockFixer implements FixerInterface, DefinedFixerIn
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Block comment should only contain useful information.',
+            'Block comment should only contain useful information about types.',
             [
                 new CodeSample('<?php
 /**

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveUselessDocBlockFixer.php
@@ -46,8 +46,12 @@ public function getCount(): int
 
             $classTokensAnalyzer = ClassTokensAnalyzer::createFromTokensArrayStartPosition($tokens, $index);
             foreach ($classTokensAnalyzer->getMethodWrappers() as $methodWrapper) {
-                // 1. process return tag
                 $docBlockWrapper = $methodWrapper->getDocBlockWrapper();
+                if ($docBlockWrapper === null) {
+                    continue;
+                }
+
+                // 1. process return tag
                 if ($methodWrapper->getReturnType() === $docBlockWrapper->getReturnType()) {
                     $docBlockWrapper->removeReturnType();
                 }

--- a/packages/CodingStandard/src/Sniffs/Debug/CommentedOutCodeSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Debug/CommentedOutCodeSniff.php
@@ -51,7 +51,6 @@ final class CommentedOutCodeSniff implements Sniff
     }
 
     /**
-     * @param int $position
      * @param mixed[] $tokens
      */
     private function turnCommentedCodeIntoPhpCode(File $file, int $position, array $tokens): string

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDocBlockFixer;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Tests\Test\AbstractFixerTestCase;
+use Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer;
+
+final class Test extends AbstractFixerTestCase
+{
+    /**
+     * @dataProvider provideFixCases()
+     */
+    public function testFix(string $expected, string $input): void
+    {
+        $this->doTest($expected, $input);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideFixCases(): array
+    {
+        return [
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong.php.inc'),
+            ],
+        ];
+    }
+
+    protected function createFixer(): FixerInterface
+    {
+        return new RemoveUselessDocBlockFixer;
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
@@ -30,6 +30,10 @@ final class Test extends AbstractFixerTestCase
                 file_get_contents(__DIR__ . '/fixed/fixed2.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong2.php.inc'),
             ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed3.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong3.php.inc'),
+            ],
         ];
     }
 

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
@@ -11,7 +11,7 @@ final class Test extends AbstractFixerTestCase
     /**
      * @dataProvider provideFixCases()
      */
-    public function testFix(string $expected, string $input): void
+    public function testFix(string $expected, ?string $input = null): void
     {
         $this->doTest($expected, $input);
     }
@@ -22,6 +22,9 @@ final class Test extends AbstractFixerTestCase
     public function provideFixCases(): array
     {
         return [
+            [
+                file_get_contents(__DIR__ . '/correct/correct.php.inc'),
+            ],
             [
                 file_get_contents(__DIR__ . '/fixed/fixed.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong.php.inc'),

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
@@ -37,6 +37,10 @@ final class Test extends AbstractFixerTestCase
                 file_get_contents(__DIR__ . '/fixed/fixed3.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong3.php.inc'),
             ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed4.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong4.php.inc'),
+            ],
         ];
     }
 

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/Test.php
@@ -26,6 +26,10 @@ final class Test extends AbstractFixerTestCase
                 file_get_contents(__DIR__ . '/fixed/fixed.php.inc'),
                 file_get_contents(__DIR__ . '/wrong/wrong.php.inc'),
             ],
+            [
+                file_get_contents(__DIR__ . '/fixed/fixed2.php.inc'),
+                file_get_contents(__DIR__ . '/wrong/wrong2.php.inc'),
+            ],
         ];
     }
 

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/correct/correct.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/correct/correct.php.inc
@@ -1,0 +1,12 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * @param Fixer $fixer some useful comment
+     */
+    public function __construct(Fixer $fixer)
+    {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed.php.inc
@@ -1,0 +1,12 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     */
+    public function getCount(): int
+    {
+
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed2.php.inc
@@ -5,7 +5,7 @@ class SomeClass
 {
     /**
      */
-    public function setCount(int $value)
+    public function setCount(int $value, $anotherValue)
     {
     }
 }

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed2.php.inc
@@ -1,0 +1,11 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     */
+    public function setCount(int $value)
+    {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed3.php.inc
@@ -1,0 +1,19 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * @param array[] $tokens
+     */
+    public function __construct(
+        string $path,
+        array $tokens,
+        Fixer $fixer,
+        ErrorCollector $errorCollector,
+        bool $isFixer,
+        CurrentSniffProvider $currentSniffProvider,
+        Skipper $skipper
+    ) {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed4.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed4.php.inc
@@ -9,4 +9,11 @@ class SomeClass
     public static function getColumnTypes(array $samples) : array
     {
     }
+
+    /**
+     */
+    private function getAxis(int $column, array $currentSample) : array
+    {
+
+    }
 }

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed4.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/fixed/fixed4.php.inc
@@ -1,0 +1,12 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     *
+     */
+    public static function getColumnTypes(array $samples) : array
+    {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong.php.inc
@@ -1,0 +1,13 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong2.php.inc
@@ -5,8 +5,9 @@ class SomeClass
 {
     /**
      * @param int $value
+     * @param $anotherValue
      */
-    public function setCount(int $value)
+    public function setCount(int $value, $anotherValue)
     {
     }
 }

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong2.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong2.php.inc
@@ -1,0 +1,12 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * @param int $value
+     */
+    public function setCount(int $value)
+    {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong3.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong3.php.inc
@@ -1,0 +1,21 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * @param array[] $tokens
+     * @param Fixer $fixer
+     * @param ErrorCollector $errorCollector
+     */
+    public function __construct(
+        string $path,
+        array $tokens,
+        Fixer $fixer,
+        ErrorCollector $errorCollector,
+        bool $isFixer,
+        CurrentSniffProvider $currentSniffProvider,
+        Skipper $skipper
+    ) {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong4.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong4.php.inc
@@ -1,0 +1,14 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * @param array $samples
+     *
+     * @return array
+     */
+    public static function getColumnTypes(array $samples) : array
+    {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong4.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/wrong/wrong4.php.inc
@@ -11,4 +11,14 @@ class SomeClass
     public static function getColumnTypes(array $samples) : array
     {
     }
+
+    /**
+     * @param int   $column
+     * @param array $currentSample
+     * @return array
+     */
+    private function getAxis(int $column, array $currentSample) : array
+    {
+
+    }
 }

--- a/packages/EasyCodingStandard/README.md
+++ b/packages/EasyCodingStandard/README.md
@@ -95,15 +95,20 @@ Cache stores all files without errors that haven't changed. It's handled by [`Ch
 There are several common sets you can use. You find all in [/config](/config) directory:
 
 ```bash
+vendor/symplify/easy-coding-standard/config/clean-code.neon
+vendor/symplify/easy-coding-standard/config/clean-docs.neon
+vendor/symplify/easy-coding-standard/config/common.neon
+
+# php
 vendor/symplify/easy-coding-standard/config/php54-checkers.neon
 vendor/symplify/easy-coding-standard/config/php70-checkers.neon
 vendor/symplify/easy-coding-standard/config/php71-checkers.neon
+
 vendor/symplify/easy-coding-standard/config/psr2-checkers.neon
+vendor/symplify/easy-coding-standard/config/spaces.neon
 vendor/symplify/easy-coding-standard/config/symfony-checkers.neon
 vendor/symplify/easy-coding-standard/config/symfony-risky-checkers.neon
 vendor/symplify/easy-coding-standard/config/symplify-checkers.neon
-vendor/symplify/easy-coding-standard/config/spaces.neon
-vendor/symplify/easy-coding-standard/config/common.neon
 ```
 
 You [pick single config in CLI](#pick-config-in-cli):

--- a/packages/EasyCodingStandard/config/clean-docblock.neon
+++ b/packages/EasyCodingStandard/config/clean-docblock.neon
@@ -1,0 +1,12 @@
+checkers:
+    # remove redundant lines in phpdocs
+    - Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer
+
+    # remove empty phpdocs
+    - PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer
+
+    # remove empty spaces in phpdoc
+    - PhpCsFixer\Fixer\Comment\NoTrailingWhitespaceInCommentFixer
+
+    # remove empty lines in phpdoc
+    - PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer

--- a/packages/EasyCodingStandard/packages/SniffRunner/src/File/File.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/File/File.php
@@ -42,11 +42,7 @@ final class File extends BaseFile
     private $skipper;
 
     /**
-     * @param string $path
      * @param array[] $tokens
-     * @param Fixer $fixer
-     * @param ErrorCollector $errorCollector
-     * @param bool $isFixer
      */
     public function __construct(
         string $path,


### PR DESCRIPTION
Closes #416 

### Related Changes

- add `clean-docblock.neon` set to ECS