### PR TITLE
[CodingStandard] add RemoveSuperfluousDocBlockWhitespaceFixer

### DIFF
--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -208,6 +208,39 @@ public function setCount(int $value, $anotherValue, SomeType $someService): arra
 ```
 
 
+
+### Block comment should not have 2 empty lines in a row
+
+- class: [`Symplify\CodingStandard\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer`](/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php)
+
+:x:
+
+```php
+/**
+ * @param int $value
+ *
+ *
+ * @return array
+ */
+public function setCount($value)
+{
+}
+```
+
+:+1:
+
+```php
+/**
+ * @param int $value
+ *
+ * @return array
+ */
+public function setCount($value)
+{
+}
+```
+
+
 ### Include/Require should be followed by absolute path
 
 - class: [`Symplify\CodingStandard\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer`](/src/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer.php)

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\Commenting;
+
+use Nette\Utils\Strings;
+use PhpCsFixer\Fixer\DefinedFixerInterface;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\WhitespacesFixerConfig;
+use SplFileInfo;
+
+final class RemoveSuperfluousDocBlockWhitespaceFixer implements FixerInterface, DefinedFixerInterface
+{
+    /**
+     * @var string
+     */
+    private const EMPTY_LINE_PATTERN = '#(?<oneLine>[\t ]+\*\n){2,}#';
+
+    /**
+     * @var WhitespacesFixerConfig
+     */
+    private $whitespacesFixerConfig;
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Block comment should not have 2 empty lines in a row.',
+            [
+                new CodeSample('<?php
+/**
+ * Description
+ *
+ *
+ * @return int 
+ */
+public function getCount()
+{
+}
+'),
+            ]
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAllTokenKindsFound([T_FUNCTION, T_DOC_COMMENT]);
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = count($tokens) - 1; $index > 1; --$index) {
+            $token = $tokens[$index];
+
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $newContent = Strings::replace($token->getContent(), self::EMPTY_LINE_PATTERN, function (array $match) {
+                return $match['oneLine'];
+            });
+
+            $tokens[$index] = new Token([T_DOC_COMMENT, $newContent]);
+        }
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function getName(): string
+    {
+        return self::class;
+    }
+
+    /**
+     * Runs before @see \PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer.
+     */
+    public function getPriority(): int
+    {
+        return 10;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php
@@ -10,7 +10,6 @@ use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
-use PhpCsFixer\WhitespacesFixerConfig;
 use SplFileInfo;
 
 final class RemoveSuperfluousDocBlockWhitespaceFixer implements FixerInterface, DefinedFixerInterface
@@ -19,11 +18,6 @@ final class RemoveSuperfluousDocBlockWhitespaceFixer implements FixerInterface, 
      * @var string
      */
     private const EMPTY_LINE_PATTERN = '#(?<oneLine>[\t ]+\*\n){2,}#';
-
-    /**
-     * @var WhitespacesFixerConfig
-     */
-    private $whitespacesFixerConfig;
 
     public function getDefinition(): FixerDefinitionInterface
     {

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php
@@ -41,7 +41,7 @@ public function getCount()
 
     public function isCandidate(Tokens $tokens): bool
     {
-        return $tokens->isAllTokenKindsFound([T_FUNCTION, T_DOC_COMMENT]);
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
     }
 
     public function fix(SplFileInfo $file, Tokens $tokens): void

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/RemoveSuperfluousDocBlockWhitespaceFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/RemoveSuperfluousDocBlockWhitespaceFixerTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use Symplify\CodingStandard\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer;
+use Symplify\TokenRunner\Testing\AbstractSimpleFixerTestCase;
+
+final class RemoveSuperfluousDocBlockWhitespaceFixerTest extends AbstractSimpleFixerTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedCases()
+     */
+    public function testWrongToFixedCases(string $wrongFile, string $correctFile): void
+    {
+        $this->doTestWrongToFixedFile($wrongFile, $correctFile);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideWrongToFixedCases(): array
+    {
+        return [
+            [__DIR__ . '/wrong/wrong.php.inc', __DIR__ . '/fixed/fixed.php.inc'],
+        ];
+    }
+
+    protected function createFixer(): FixerInterface
+    {
+        return new RemoveSuperfluousDocBlockWhitespaceFixer();
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/fixed/fixed.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/fixed/fixed.php.inc
@@ -1,0 +1,14 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * Creates a `TypeError` with a standardized error message.
+     *
+     * @internal
+     */
+    public function getAnotherCount(): int
+    {
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/wrong/wrong.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/wrong/wrong.php.inc
@@ -1,0 +1,15 @@
+<?php
+namespace SomeNamespace;
+
+class SomeClass
+{
+    /**
+     * Creates a `TypeError` with a standardized error message.
+     *
+     *
+     * @internal
+     */
+    public function getAnotherCount(): int
+    {
+    }
+}

--- a/packages/EasyCodingStandard/config/symplify.neon
+++ b/packages/EasyCodingStandard/config/symplify.neon
@@ -21,6 +21,7 @@ checkers:
     - Symplify\CodingStandard\Sniffs\Commenting\VarConstantCommentSniff
     - Symplify\CodingStandard\Fixer\Commenting\AnnotateMagicContainerGetterFixer
     - Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer
+    - Symplify\CodingStandard\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer
 
     # Naming
     - Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,7 @@ parameters:
 
         # intentional stricter phpDocumentor\Reflection\Types\This
         - '#Method Symplify\\[A-Za-z\\]+\\ContainerFactory::(create|createWithConfig)\(\) should return Symfony\\Component\\DependencyInjection\\Container but returns Symfony\\Component\\DependencyInjection\\ContainerInterface#'
+        - '#Symplify\\TokenRunner\\Wrapper\\FixerWrapper\\DocBlockWrapper::getParamTags\(\) should return array<phpDocumentor\\Reflection\\DocBlock\\Tags\\Param> but returns array<phpDocumentor\\Reflection\\DocBlock\\Tag>#'
 
         # Token Runner
         - '#Parameter \#2 \$docBlockPosition of static method Symplify\\TokenRunner\\Wrapper\\FixerWrapper\\DocBlockWrapper::createFromTokensPositionAndDocBlock\(\) expects int, int\|null given#'


### PR DESCRIPTION
### Block comment should not have 2 empty lines in a row

- class: [`Symplify\CodingStandard\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer`](/src/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer.php)

:x:

```php
/**
 * @param int $value
 *
 *
 * @return array
 */
public function setCount($value)
{
}
```

:+1:

```php
/**
 * @param int $value
 *
 * @return array
 */
public function setCount($value)
{
}
```
