### PR TITLE
Allow Symfony 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         "phpdocumentor/reflection-docblock": "^4.2",
         "slevomat/coding-standard": "^4.0",
         "squizlabs/php_codesniffer": "^3.1",
-        "symfony/config": "^4.0",
-        "symfony/console": "^4.0",
-        "symfony/dependency-injection": "^4.0",
+        "symfony/config": "^3.4|^4.0",
+        "symfony/console": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.0",
         "symfony/event-dispatcher": "^3.4|^4.0",
-        "symfony/finder": "^4.0",
-        "symfony/http-kernel": "^4.0",
-        "symfony/yaml": "^4.0"
+        "symfony/finder": "^3.4|^4.0",
+        "symfony/http-kernel": "^3.4|^4.0",
+        "symfony/yaml": "^3.4|^4.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.9",


### PR DESCRIPTION
Is there some reason to not allow installation with Symfony 3.4? Afaik it's the same as 4.0 just with some deprecated code so it should work fine. If there is a reason to disallow it then why is event-dispatcher 3.4 allowed?