### PR TITLE
[Statie] blank route_prefix

### DIFF
--- a/packages/Statie/src/Renderable/RouteFileDecorator.php
+++ b/packages/Statie/src/Renderable/RouteFileDecorator.php
@@ -46,7 +46,9 @@ final class RouteFileDecorator implements FileDecoratorInterface
     public function decorateFilesWithGeneratorElement(array $files, GeneratorElement $generatorElement): array
     {
         foreach ($files as $file) {
-            $outputPath = $generatorElement->getRoutePrefix() . DIRECTORY_SEPARATOR;
+            $outputPath = $generatorElement->getRoutePrefix()
+                ? $generatorElement->getRoutePrefix() . DIRECTORY_SEPARATOR
+                : '';
             $outputPath = $this->prefixWithDateIfFound($file, $outputPath);
             $outputPath .= $file->getFilenameWithoutDate();
             $outputPath = $this->pathNormalizer->normalize($outputPath);


### PR DESCRIPTION
Since the introduction of Generators the possibility of not having a `route_prefix` is not working anymore. When it's set:

```yml
parameters:
    generators:
        posts:
            route_prefix: ''
```

there is one `DIRECTORY_SEPARATOR` in the beginning of the relative url.

This simple change will allow to have no prefix.

