### PR TITLE
[Symplify] Create clear_readmes.sh

### DIFF
--- a/build/clear_readmes.sh
+++ b/build/clear_readmes.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# trailing whitespaces
+sed -i -E 's/\s+$//g' packages/*/README.md
+
+# remove extra lines
+sed -i -E ':a;$!N;s/^\s*\n\s*$//;ta;P;D' packages/*/README.md

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,10 @@
             "@phpstan"
         ],
         "check-cs": "packages/EasyCodingStandard/bin/ecs check packages",
-        "fix-cs": "packages/EasyCodingStandard/bin/ecs check packages --fix",
+        "fix-cs": [
+            "packages/EasyCodingStandard/bin/ecs check packages --fix",
+            "build/clear_readmes.sh"
+        ],
         "phpstan": "vendor/bin/phpstan analyse packages --level max --configuration phpstan.neon"
     },
     "config": {

--- a/packages/ChangelogLinker/README.md
+++ b/packages/ChangelogLinker/README.md
@@ -10,7 +10,7 @@ Turn your `CHANGELOG.md` from a machine readable text to a **rich text that make
 
 ```bash
 composer require symplify/changelog-linker
-```  
+```
 
 ## Usage
 
@@ -29,7 +29,7 @@ vendor/bin/changelog-linker CHANGELOG.md --repository https://github.com/symplif
 ```markdown
 ### Added
 
-- #123 Cool new without detailed description wanting me to see PR  
+- #123 Cool new without detailed description wanting me to see PR
 ```
 
 :+1:
@@ -38,7 +38,6 @@ vendor/bin/changelog-linker CHANGELOG.md --repository https://github.com/symplif
 ### Added
 
 - [#123] Cool new without detailed description wanting me to see PR
-
 
 [#123]: https://github.com/Symplify/Symplify/pull/123
 ```

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -284,7 +284,6 @@ checkers:
  namespace SomeNamespace;
 ```
 
-
 ### `in_array()` should use 3rd param for strict comparison
 
 - class: [`Symplify\CodingStandard\Fixer\Strict\InArrayStrictFixer`](src/Fixer/Strict/InArrayStrictFixer.php)
@@ -295,7 +294,6 @@ checkers:
 -in_array('value', $listOfValues);
 +in_array('value', $listOfValues, true);
 ```
-
 
 ### Non-abstract class that implements interface should be final :wrench:
 

--- a/packages/PackageBuilder/README.md
+++ b/packages/PackageBuilder/README.md
@@ -128,7 +128,7 @@ Symplify\PackageBuilder\Configuration\ConfigFilePathHelper::detectFromInput('sta
 # exception if no file is found
 ```
 
-Where "statie" is key to save the location under. Later you'll use it get the config.  
+Where "statie" is key to save the location under. Later you'll use it get the config.
 
 With `--config` you can set config via CLI.
 
@@ -154,7 +154,7 @@ This is common practise in CLI applications, e.g. [PHPUnit](https://phpunit.de/)
 
 ### 5. Use SymfonyStyle for Console Output Anywhere You Need
 
-Another use case for `bin/<app-name>`, when you need to output before building Dependency Injection Container. E.g. when ContainerFactory fails on exception that you need to report nicely.    
+Another use case for `bin/<app-name>`, when you need to output before building Dependency Injection Container. E.g. when ContainerFactory fails on exception that you need to report nicely.
 
 ```php
 # bin/statie


### PR DESCRIPTION
As [suggested](https://github.com/Symplify/Symplify/pull/546#issuecomment-354517267) by @TomasVotruba, we should have a `.sh` to help us keep our `README.md` cleans :sunglasses: