### PR TITLE
[EasyCodingStandard] Add UnnecessaryStringConcatSniff to clean-code

### DIFF
--- a/packages/EasyCodingStandard/config/clean-code.neon
+++ b/packages/EasyCodingStandard/config/clean-code.neon
@@ -23,3 +23,6 @@ checkers:
 
     # { echo 'hi'; }
     - PhpCsFixer\Fixer\ControlStructure\NoUnneededCurlyBracesFixer
+    
+    # 'foo' . 'bar'
+    - PHP_CodeSniffer\Standards\Generic\Sniffs\Strings\UnnecessaryStringConcatSniff


### PR DESCRIPTION
Closing as this usually conflicts with `PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff`