### PR TITLE
Properly quote regex contents

### DIFF
--- a/packages/Statie/src/FileSystem/FileFinder.php
+++ b/packages/Statie/src/FileSystem/FileFinder.php
@@ -35,7 +35,7 @@ final class FileFinder
     public function findInDirectoryForGenerator(string $directoryPath): array
     {
         $directoryInfo = new NativeSplFileInfo($directoryPath);
-        $pathPattern = '#' . $directoryInfo->getFilename() . DIRECTORY_SEPARATOR . '#';
+        $pathPattern = '#' . preg_quote($directoryInfo->getFilename() . DIRECTORY_SEPARATOR, '#') . '#';
 
         $finder = Finder::create()->files()
             ->in($directoryInfo->getPath())


### PR DESCRIPTION
On windows DIRECTORY_SEPARATOR is backslash, escaping the ending hash.