### PR TITLE
Remove PHP codesniffer rules from symfony.neon

### DIFF
--- a/packages/EasyCodingStandard/config/symfony.neon
+++ b/packages/EasyCodingStandard/config/symfony.neon
@@ -1,5 +1,5 @@
 includes:
-    - psr2.neon
+    - php_cs_fixer/psr2.neon
 
 checkers:
     - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer


### PR DESCRIPTION
fixes #586