### PR TITLE
Don't use unstable dependencies

### DIFF
--- a/packages/EasyCodingStandard/composer.json
+++ b/packages/EasyCodingStandard/composer.json
@@ -48,6 +48,5 @@
             "Symplify\\EasyCodingStandard\\SniffRunner\\Tests\\": "packages/SniffRunner/tests",
             "Symplify\\EasyCodingStandard\\Tests\\": "tests"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
This configuration causes to install dev-master dependencies by default