### PR TITLE
php70 ReturnTypeDeclarationFixer -> TypeHintDeclarationSniff

### DIFF
--- a/packages/EasyCodingStandard/config/php70.neon
+++ b/packages/EasyCodingStandard/config/php70.neon
@@ -17,7 +17,6 @@ checkers:
     - PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer
 
     # typehints
-    - PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer
     SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
         enableEachParameterAndReturnInspection: true
         enableVoidTypeHint: false


### PR DESCRIPTION
SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff.MissingReturnTypeHin does the same thing