### PR TITLE
[Monorepo] PackageSplitter - remove async

### DIFF
--- a/monorepo.yml
+++ b/monorepo.yml
@@ -4,8 +4,8 @@ parameters:
          'git@github.com:shopsys/product-feed-heureka.git': 'packages/ProductFeedHeureka'
 
     split:
-        packages/Monorepo: 'git@github.com:Symplify/Monorepo.git'
         packages/PackageBuilder: 'git@github.com:Symplify/PackageBuilder.git'
+        packages/Monorepo: 'git@github.com:Symplify/Monorepo.git'
         packages/TokenRunner: 'git@github.com:Symplify/TokenRunner.git'
         packages/BetterReflectionDocBlock: 'git@github.com:Symplify/BetterReflectionDocBlock.git'
         packages/EasyCodingStandard: 'git@github.com:Symplify/EasyCodingStandard.git'

--- a/packages/ChangelogLinker/.travis.yml
+++ b/packages/ChangelogLinker/.travis.yml
@@ -8,6 +8,7 @@ install:
   - composer install --prefer-source
 
 script:
+  - bin/changelog-linker
   - vendor/bin/phpunit
 
 notifications:

--- a/packages/EasyCodingStandard/.travis.yml
+++ b/packages/EasyCodingStandard/.travis.yml
@@ -8,6 +8,7 @@ install:
   - composer install --prefer-source
 
 script:
+  - bin/ecs
   - vendor/bin/phpunit
 
 notifications:

--- a/packages/Monorepo/.travis.yml
+++ b/packages/Monorepo/.travis.yml
@@ -8,6 +8,7 @@ install:
   - composer install --prefer-source
 
 script:
+  - bin/monorepo
   - vendor/bin/phpunit
 
 notifications:

--- a/packages/Monorepo/bin/monorepo
+++ b/packages/Monorepo/bin/monorepo
@@ -10,6 +10,7 @@ use Symplify\PackageBuilder\Configuration\ConfigFilePathHelper;
 
 // Detect configuration
 $configFile = ConfigFilePathHelper::provide('monorepo', ConfigurationOptions::MONOREPO_CONFIG_FILE);
+
 $containerFactory = new ContainerFactory();
 if ($configFile) {
     $container = $containerFactory->createWithConfig($configFile);

--- a/packages/Monorepo/src/Console/Command/SplitCommand.php
+++ b/packages/Monorepo/src/Console/Command/SplitCommand.php
@@ -86,7 +86,7 @@ final class SplitCommand extends Command
             ));
         }
 
-        $this->packageToRepositorySplitter->splitDirectoriesToRepositories($gitWorkingCopy, $splitConfig);
+        $this->packageToRepositorySplitter->splitDirectoriesToRepositories($splitConfig);
 
         $this->filesystem->deleteDirectory($this->getSubsplitDirectory());
         $this->symfonyStyle->success(sprintf('Directory "%s" cleaned', $this->getSubsplitDirectory()));

--- a/packages/Monorepo/src/Exception/Worker/PackageToRepositorySplitException.php
+++ b/packages/Monorepo/src/Exception/Worker/PackageToRepositorySplitException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Monorepo\Exception\Worker;
+
+use Exception;
+
+final class PackageToRepositorySplitException extends Exception
+{
+}

--- a/packages/Monorepo/src/PackageToRepositorySplitter.php
+++ b/packages/Monorepo/src/PackageToRepositorySplitter.php
@@ -23,10 +23,16 @@ final class PackageToRepositorySplitter
      */
     private $repositoryGuard;
 
+    /**
+     * @var Pool
+     */
+    private $pool;
+
     public function __construct(SymfonyStyle $symfonyStyle, RepositoryGuard $repositoryGuard)
     {
         $this->symfonyStyle = $symfonyStyle;
         $this->repositoryGuard = $repositoryGuard;
+        $this->pool = Pool::create();
     }
 
     /**
@@ -35,8 +41,6 @@ final class PackageToRepositorySplitter
     public function splitDirectoriesToRepositories(GitWorkingCopy $gitWorkingCopy, array $splitConfig): void
     {
         $theMostRecentTag = $this->getMostRecentTag($gitWorkingCopy);
-
-        $pool = Pool::create();
 
         $i = 0;
         foreach ($splitConfig as $localSubdirectory => $remoteRepository) {
@@ -56,10 +60,10 @@ final class PackageToRepositorySplitter
                 $this->symfonyStyle->success($output);
             });
 
-            $pool->add($parallelProcess);
+            $this->pool->add($parallelProcess);
         }
 
-        $pool->wait();
+        $this->pool->wait();
     }
 
     private function getMostRecentTag(GitWorkingCopy $gitWorkingCopy): string

--- a/packages/Monorepo/src/PackageToRepositorySplitter.php
+++ b/packages/Monorepo/src/PackageToRepositorySplitter.php
@@ -44,6 +44,15 @@ final class PackageToRepositorySplitter
 
         $i = 0;
         foreach ($splitConfig as $localSubdirectory => $remoteRepository) {
+
+            if ($this->symfonyStyle->isDebug()) {
+                $this->symfonyStyle->note(sprintf(
+                    'Checking if split for "%s" is needed for "%s" repository',
+                    $localSubdirectory,
+                    $remoteRepository
+                ));
+            }
+
             // @todo: check is split is needed! - check tag and check commit publish
 
             $process = $this->createProcess($theMostRecentTag, $localSubdirectory, $remoteRepository);
@@ -83,7 +92,7 @@ final class PackageToRepositorySplitter
     ): Process {
         $this->repositoryGuard->ensureIsRepository($remoteRepository);
 
-        return new Process(sprintf(
+        $process = new Process(sprintf(
             'git subsplit publish --heads=master %s %s',
             $this->hasRepositoryTag(
                 $remoteRepository,
@@ -91,6 +100,12 @@ final class PackageToRepositorySplitter
             ) ? '' : sprintf('--tags=%s', $theMostRecentTag),
             sprintf('%s:%s', $localSubdirectory, $remoteRepository)
         ));
+
+        if ($this->symfonyStyle->isDebug()) {
+            $this->symfonyStyle->note($process->getCommandLine());
+        }
+
+        return $process;
     }
 
     private function hasRepositoryTag(string $remoteRepository, string $theMostRecentTag): bool

--- a/packages/Monorepo/src/PackageToRepositorySplitter.php
+++ b/packages/Monorepo/src/PackageToRepositorySplitter.php
@@ -5,9 +5,12 @@ namespace Symplify\Monorepo;
 use GitWrapper\GitWorkingCopy;
 use Spatie\Async\Pool;
 use Spatie\Async\Process\ParallelProcess;
+use Spatie\Async\Process\SynchronousProcess;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Stopwatch\Stopwatch;
 use Symplify\Monorepo\Configuration\RepositoryGuard;
+use Throwable;
 
 /**
  * @wip
@@ -38,29 +41,45 @@ final class PackageToRepositorySplitter
     {
         $theMostRecentTag = $this->getMostRecentTag($gitWorkingCopy);
 
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('one');
+
         $pool = Pool::create();
 
         $i = 0;
         foreach ($splitConfig as $localSubdirectory => $remoteRepository) {
             $process = $this->createProcess($theMostRecentTag, $localSubdirectory, $remoteRepository);
+
             $parallelProcess = ParallelProcess::create($process, ++$i);
 
-            $pool->add($parallelProcess)
-                ->then(function () use ($localSubdirectory, $remoteRepository): void {
-                    $this->symfonyStyle->success(sprintf(
-                        'Package "%s" was split to "%s" repository',
-                        $localSubdirectory,
-                        $remoteRepository
-                    ));
-                });
+            // error
+            $parallelProcess->catch(function (Throwable $throwable) {
+                // @todo: false positive - often success
+                $this->symfonyStyle->error($throwable->getMessage());
+            });
+
+            // success
+            $parallelProcess->then(function ($output) use ($localSubdirectory, $remoteRepository): void {
+                $this->symfonyStyle->success($output);
+//                $this->symfonyStyle->success(sprintf(
+//                    'Package "%s" was split to "%s" repository',
+//                    $localSubdirectory,
+//                    $remoteRepository
+//                ));
+            });
+
+            $pool->add($parallelProcess);
         }
 
         $pool->wait();
+
+        $time = $stopwatch->stop('one');
+        $this->symfonyStyle->comment($time);
     }
 
     private function getMostRecentTag(GitWorkingCopy $gitWorkingCopy): string
     {
-        $tags = $gitWorkingCopy->tag('-l');
+        $tags = $gitWorkingCopy->tag('-l', '--sort=committerdate');
         $tagList = explode(PHP_EOL, trim($tags));
 
         return (string) array_pop($tagList);
@@ -75,8 +94,16 @@ final class PackageToRepositorySplitter
 
         return new Process(sprintf(
             'git subsplit publish --heads=master %s %s',
-            sprintf('--tags=%s', $theMostRecentTag),
+            $this->hasRepositoryTag($remoteRepository, $theMostRecentTag) ? '' : sprintf('--tags=%s', $theMostRecentTag),
             sprintf('%s:%s', $localSubdirectory, $remoteRepository)
         ));
+    }
+
+    private function hasRepositoryTag(string $remoteRepository, string $theMostRecentTag): bool
+    {
+        $process = new Process(sprintf('git ls-remote %s refs/tags/%s', $remoteRepository, $theMostRecentTag));
+        $process->run();
+
+        return (bool) $process->getOutput();
     }
 }

--- a/packages/Monorepo/src/PackageToRepositorySplitter.php
+++ b/packages/Monorepo/src/PackageToRepositorySplitter.php
@@ -38,9 +38,9 @@ final class PackageToRepositorySplitter
     /**
      * @param mixed[] $splitConfig
      */
-    public function splitDirectoriesToRepositories(GitWorkingCopy $gitWorkingCopy, array $splitConfig): void
+    public function splitDirectoriesToRepositories(array $splitConfig): void
     {
-        $theMostRecentTag = $this->getMostRecentTag($gitWorkingCopy);
+        $theMostRecentTag = $this->getMostRecentTag();
 
         $i = 0;
         foreach ($splitConfig as $localSubdirectory => $remoteRepository) {
@@ -66,9 +66,11 @@ final class PackageToRepositorySplitter
         $this->pool->wait();
     }
 
-    private function getMostRecentTag(GitWorkingCopy $gitWorkingCopy): string
+    private function getMostRecentTag(): string
     {
-        $tags = $gitWorkingCopy->tag('-l', '--sort=committerdate');
+        $process = new Process('git tag -l --sort=committerdate');
+        $process->run();
+        $tags = $process->getOutput();
         $tagList = explode(PHP_EOL, trim($tags));
 
         return (string) array_pop($tagList);

--- a/packages/Monorepo/src/PackageToRepositorySplitter.php
+++ b/packages/Monorepo/src/PackageToRepositorySplitter.php
@@ -2,7 +2,6 @@
 
 namespace Symplify\Monorepo;
 
-use Spatie\Async\Pool;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
 use Symplify\Monorepo\Configuration\RepositoryGuard;
@@ -20,16 +19,10 @@ final class PackageToRepositorySplitter
      */
     private $repositoryGuard;
 
-    /**
-     * @var Pool
-     */
-    private $pool;
-
     public function __construct(SymfonyStyle $symfonyStyle, RepositoryGuard $repositoryGuard)
     {
         $this->symfonyStyle = $symfonyStyle;
         $this->repositoryGuard = $repositoryGuard;
-        $this->pool = Pool::create();
     }
 
     /**

--- a/packages/Monorepo/src/PackageToRepositorySplitter.php
+++ b/packages/Monorepo/src/PackageToRepositorySplitter.php
@@ -2,12 +2,10 @@
 
 namespace Symplify\Monorepo;
 
-use GitWrapper\GitWorkingCopy;
 use Spatie\Async\Pool;
 use Spatie\Async\Process\ParallelProcess;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Stopwatch\Stopwatch;
 use Symplify\Monorepo\Configuration\RepositoryGuard;
 use Throwable;
 
@@ -44,7 +42,6 @@ final class PackageToRepositorySplitter
 
         $i = 0;
         foreach ($splitConfig as $localSubdirectory => $remoteRepository) {
-
             if ($this->symfonyStyle->isDebug()) {
                 $this->symfonyStyle->note(sprintf(
                     'Checking if split for "%s" is needed for "%s" repository',
@@ -52,6 +49,15 @@ final class PackageToRepositorySplitter
                     $remoteRepository
                 ));
             }
+
+            // local hash...:
+            $localSubdirectoryLastCommitHash = $this->localSubdirectoryLastCommitHash($localSubdirectory);
+            dump($localSubdirectory);
+            dump($localSubdirectoryLastCommitHash);
+            # todo: validate with remote
+            # https://stackoverflow.com/questions/27611995/removing-invalid-git-subtree-split-hash
+            # https://www.google.cz/search?ei=UUpzWu24NYLyUNv-ibAH&q=validate+subtree+split+commit+hash&oq=validate+subtree+split+commit+hash&gs_l=psy-ab.3..33i160k1.6870.7304.0.7440.5.4.0.0.0.0.106.347.3j1.4.0.crnk_dmh...0...1.1.64.psy-ab..1.3.240...33i21k1.0.8ajFE3MF8mk
+            die;
 
             // @todo: check is split is needed! - check tag and check commit publish
 
@@ -114,5 +120,13 @@ final class PackageToRepositorySplitter
         $process->run();
 
         return (bool) $process->getOutput();
+    }
+
+    private function localSubdirectoryLastCommitHash(string $localSubdirectory): string
+    {
+        $process = new Process(sprintf('git log -n 1 --pretty=format:"%%H" %s', $localSubdirectory));
+        $process->run();
+
+        return trim($process->getOutput());
     }
 }

--- a/packages/Statie/.travis.yml
+++ b/packages/Statie/.travis.yml
@@ -8,6 +8,7 @@ install:
   - composer install --prefer-source
 
 script:
+  - bin/statie
   - vendor/bin/phpunit
 
 notifications:


### PR DESCRIPTION
There is been speed improvement for split, but spatie/async return error codes on success process. No idea how/why. Also the fluent API has some flaws that break autocomplete and provide missing types and vice versa.

The priority now is working tool, so it needed to be removed for `split` command.
Remains for history rename, where works fine.