### PR TITLE
[Monorepo] improve reporting messages, decrease reporting at mv-history

### DIFF
--- a/packages/Monorepo/src/Console/Command/BuildCommand.php
+++ b/packages/Monorepo/src/Console/Command/BuildCommand.php
@@ -58,7 +58,7 @@ final class BuildCommand extends Command
         $this->configurationGuard->ensureConfigSectionIsFilled($build, 'build');
 
         $monorepoDirectory = $input->getArgument(self::MONOREPO_DIRECTORY);
-        $this->configurationGuard->ensureDirectoryIsEmpty($monorepoDirectory);
+//        $this->configurationGuard->ensureDirectoryIsEmpty($monorepoDirectory);
 
         foreach ($build as $repositoryUrl => $packagesSubdirectory) {
             $this->repositoryToPackageMerger->mergeRepositoryToPackage(

--- a/packages/Monorepo/src/Console/Command/BuildCommand.php
+++ b/packages/Monorepo/src/Console/Command/BuildCommand.php
@@ -58,7 +58,7 @@ final class BuildCommand extends Command
         $this->configurationGuard->ensureConfigSectionIsFilled($build, 'build');
 
         $monorepoDirectory = $input->getArgument(self::MONOREPO_DIRECTORY);
-//        $this->configurationGuard->ensureDirectoryIsEmpty($monorepoDirectory);
+        $this->configurationGuard->ensureDirectoryIsEmpty($monorepoDirectory);
 
         foreach ($build as $repositoryUrl => $packagesSubdirectory) {
             $this->repositoryToPackageMerger->mergeRepositoryToPackage(

--- a/packages/Monorepo/src/Filesystem/Filesystem.php
+++ b/packages/Monorepo/src/Filesystem/Filesystem.php
@@ -48,10 +48,11 @@ final class Filesystem
     {
         $this->excludedDirectories[] = $excludeDirectory;
 
+        $directoriesToExclude = array_merge(self::EXCLUDED_LOCAL_DIRS, $this->excludedDirectories);
+
         $finder = Finder::create()
             ->in($directory)
-            ->exclude(self::EXCLUDED_LOCAL_DIRS)
-            ->exclude($this->excludedDirectories)
+            ->exclude($directoriesToExclude)
             // include .gitignore, .travis etc
             ->ignoreDotFiles(false);
 

--- a/packages/Monorepo/src/RepositoryToPackageMerger.php
+++ b/packages/Monorepo/src/RepositoryToPackageMerger.php
@@ -67,12 +67,13 @@ final class RepositoryToPackageMerger
         $gitWorkingCopy = $this->getGitWorkingCopyForDirectory($monorepoDirectory);
 
         // add repository as remote and merge
-        $this->repositoryWorker->mergeRepositoryToMonorepoDirectory($repositoryUrl, $gitWorkingCopy);
-        $this->symfonyStyle->success(sprintf(
-            'Repository "%s" was added as remote and merged in "%s"',
+        $this->symfonyStyle->note(sprintf(
+            'Adding and merging "%s" remote repository to "%s" directory',
             $repositoryUrl,
             $monorepoDirectory
         ));
+//        $this->repositoryWorker->mergeRepositoryToMonorepoDirectory($repositoryUrl, $gitWorkingCopy);
+        $this->symfonyStyle->success('Repository was merged');
 
         // copy files into package subdirectory
         $absolutePackageDirectory = $monorepoDirectory . '/' . $packageSubdirectory;
@@ -92,10 +93,10 @@ final class RepositoryToPackageMerger
 
         // prepend history
         $this->moveHistoryWorker->prependHistoryToNewPackageFiles($finder, $monorepoDirectory, $packageSubdirectory);
-        $this->symfonyStyle->success(sprintf('History added for files in "%s"', $packageSubdirectory));
+        $this->symfonyStyle->success('History added');
 
         // clear old repository files if moved
-        $this->filesystem->deleteMergedPackage($monorepoDirectory);
+        $this->filesystem->deleteMergedPackage($monorepoDirectory, $packageSubdirectory);
     }
 
     private function getGitWorkingCopyForDirectory(string $directory): GitWorkingCopy

--- a/packages/Monorepo/src/RepositoryToPackageMerger.php
+++ b/packages/Monorepo/src/RepositoryToPackageMerger.php
@@ -72,7 +72,8 @@ final class RepositoryToPackageMerger
             $repositoryUrl,
             $monorepoDirectory
         ));
-//        $this->repositoryWorker->mergeRepositoryToMonorepoDirectory($repositoryUrl, $gitWorkingCopy);
+
+        $this->repositoryWorker->mergeRepositoryToMonorepoDirectory($repositoryUrl, $gitWorkingCopy);
         $this->symfonyStyle->success('Repository was merged');
 
         // copy files into package subdirectory
@@ -82,7 +83,11 @@ final class RepositoryToPackageMerger
         $this->filesystem->copyFinderFilesToDirectory($finder, $absolutePackageDirectory);
         if ($gitWorkingCopy->hasChanges()) {
             $gitWorkingCopy->add('.');
-            $gitWorkingCopy->commit(sprintf('merge remove repository "%s"', $repositoryUrl));
+            $gitWorkingCopy->commit(sprintf(
+                'Merge move repository "%s" to subdirectory "%s"',
+                $repositoryUrl,
+                $packageSubdirectory
+            ));
         }
 
         $this->symfonyStyle->success(sprintf(
@@ -97,6 +102,12 @@ final class RepositoryToPackageMerger
 
         // clear old repository files if moved
         $this->filesystem->deleteMergedPackage($monorepoDirectory, $packageSubdirectory);
+        if ($gitWorkingCopy->hasChanges()) {
+            $gitWorkingCopy->add('.');
+            $gitWorkingCopy->commit(sprintf('Remove original files for "%s"', $repositoryUrl));
+        }
+
+        $this->symfonyStyle->newLine(2);
     }
 
     private function getGitWorkingCopyForDirectory(string $directory): GitWorkingCopy

--- a/packages/Monorepo/src/Worker/MoveHistoryWorker.php
+++ b/packages/Monorepo/src/Worker/MoveHistoryWorker.php
@@ -12,7 +12,7 @@ final class MoveHistoryWorker
     /**
      * @var int
      */
-    private const CHUNK_SIZE = 50;
+    private const CHUNK_SIZE = 60;
 
     /**
      * @var string
@@ -39,19 +39,15 @@ final class MoveHistoryWorker
         // this is needed due to long CLI arguments overflow error
         $fileInfosChunks = array_chunk($fileInfos, self::CHUNK_SIZE, true);
 
+        $this->symfonyStyle->note(sprintf('Rewriting history for %d files to "%s" directory',
+            count($fileInfos),
+            $packageSubdirectory
+        ));
+
         foreach ($fileInfosChunks as $fileInfosChunk) {
             $processInput = $this->createGitMoveWithHistoryProcessInput($fileInfosChunk, $packageSubdirectory);
             $process = new Process($processInput, $monorepoDirectory, null, null, null);
-
             $process->start();
-            while ($process->isRunning()) {
-                // waiting for process to finish
-                $output = trim($process->getOutput());
-                if ($output) {
-                    $output = preg_replace('#(\r?\n){2,}#', PHP_EOL, $output);
-                    $this->symfonyStyle->writeln($output);
-                }
-            }
         }
     }
 

--- a/packages/Monorepo/src/Worker/MoveHistoryWorker.php
+++ b/packages/Monorepo/src/Worker/MoveHistoryWorker.php
@@ -39,7 +39,8 @@ final class MoveHistoryWorker
         // this is needed due to long CLI arguments overflow error
         $fileInfosChunks = array_chunk($fileInfos, self::CHUNK_SIZE, true);
 
-        $this->symfonyStyle->note(sprintf('Rewriting history for %d files to "%s" directory',
+        $this->symfonyStyle->note(sprintf(
+            'Rewriting history for %d files to "%s" directory',
             count($fileInfos),
             $packageSubdirectory
         ));


### PR DESCRIPTION
Reasons for this changes:

- outputting every commit for history of 5000 files was compute time demaning and memory leaking
- informattie message would do you just fine and speed up process from hours to minutes

Reported by @Miroslav-Stopka