### PR TITLE
Allow PHP-CS-Fixer 2.10.x

### DIFF
--- a/packages/EasyCodingStandard/composer.json
+++ b/packages/EasyCodingStandard/composer.json
@@ -25,7 +25,7 @@
         "symplify/package-builder": "^3.2",
         "symplify/token-runner": "^3.2",
         "slevomat/coding-standard": "^4.1",
-        "friendsofphp/php-cs-fixer": "2.10",
+        "friendsofphp/php-cs-fixer": "~2.10.0",
         "squizlabs/php_codesniffer": "^3.2",
         "jean85/pretty-package-versions": "^1.0"
     },


### PR DESCRIPTION
I know you locked it to prevent BC breaks. That's why I changed it to `~2.10.0` instead of `^2.10`.