### PR TITLE
[EasyCodingStandard] Fix required php-cs-fixer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "cpliakas/git-wrapper": "^2.0",
         "erusev/parsedown-extra": "^0.7",
-        "friendsofphp/php-cs-fixer": "~2.10.2",
+        "friendsofphp/php-cs-fixer": "~2.10.3",
         "jean85/pretty-package-versions": "^1.0",
         "latte/latte": "^2.4",
         "nette/caching": "^2.5",

--- a/packages/EasyCodingStandard/composer.json
+++ b/packages/EasyCodingStandard/composer.json
@@ -25,7 +25,7 @@
         "symplify/package-builder": "^3.2",
         "symplify/token-runner": "^3.2",
         "slevomat/coding-standard": "^4.1",
-        "friendsofphp/php-cs-fixer": "~2.10.0",
+        "friendsofphp/php-cs-fixer": "~2.10.3",
         "squizlabs/php_codesniffer": "^3.2",
         "jean85/pretty-package-versions": "^1.0"
     },


### PR DESCRIPTION
The findBlockStart method was added in v2.10.3.

```
In FixerFileProcessor.php line 125:
                                                                                                                                                                                                        
  Fixing of "src/ContactAdministration/DomainModel/Address/UpdateAddressInformation/AddressInformationUpdated.php" file by "Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArray  
  Fixer" failed: Call to undefined method PhpCsFixer\Tokenizer\Tokens::findBlockStart() in file .../vendor/symplify/token-runner/src/Analyzer/FixerAnalyzer/TokenSkipper.php on line 39     
```