### PR TITLE
Adjust priority of BlockPropertyCommentFixer

### DIFF
--- a/packages/CodingStandard/src/Fixer/Commenting/BlockPropertyCommentFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/BlockPropertyCommentFixer.php
@@ -76,9 +76,12 @@ private $property;
         return self::class;
     }
 
+    /**
+     * Must run before @see \PhpCsFixer\Fixer\Phpdoc\PhpdocVarWithoutNameFixer
+     */
     public function getPriority(): int
     {
-        return 0;
+        return 1;
     }
 
     public function supports(SplFileInfo $file): bool


### PR DESCRIPTION
This fixer needs to be run before PhpCsFixer\Fixer\Phpdoc\PhpdocVarWithoutNameFixer to avoid this situation

first run
```diff
-    /** @var Delete $delete */
+    /**
+     * @var Delete $delete
+     */
     private $delete;
```

second run

```diff
     /**
-     * @var Delete $delete
+     * @var Delete
      */
     private $delete;
```