### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Fork, clone your repository and install dependencies:
 ```bash
 git clone git@github.com:<your-name>/Symplify.git
 cd Symplify
-composer install
+composer update
 ```
 
 ## Contributing


### PR DESCRIPTION
The `composer install` line confused me into thinking that you have a composer.lock in the repo for whatever reason and I should run install instead of update after git pull. That's not the case though so I think this is slightly better.