### PR TITLE
Add failing test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "complete-check": [
             "phpunit",
             "@fix-cs",
-            "@static"
+            "@phpstan"
         ],
         "check-cs": "packages/EasyCodingStandard/bin/ecs check packages",
         "fix-cs": [

--- a/packages/CodingStandard/src/Fixer/LineLength/BreakMethodArgumentsFixer.php
+++ b/packages/CodingStandard/src/Fixer/LineLength/BreakMethodArgumentsFixer.php
@@ -115,6 +115,9 @@ class SomeClass
     private function fixMethod(int $position, Tokens $tokens): void
     {
         $methodWrapper = MethodWrapper::createFromTokensAndPosition($tokens, $position);
+        if (! $methodWrapper->getArguments()) {
+            return;
+        }
 
         if ($methodWrapper->getFirstLineLength() > self::LINE_LENGTH) {
             $this->breakMethodArguments($methodWrapper, $tokens, $position);

--- a/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/BreakMethodArgumentsFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/BreakMethodArgumentsFixerTest.php
@@ -10,6 +10,24 @@ use Symplify\TokenRunner\Testing\AbstractSimpleFixerTestCase;
 final class BreakMethodArgumentsFixerTest extends AbstractSimpleFixerTestCase
 {
     /**
+     * @dataProvider provideCorrectCases()
+     */
+    public function testCorrectCases(string $file): void
+    {
+        $this->doTestCorrectFile($file);
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function provideCorrectCases(): array
+    {
+        return [
+            [__DIR__ . '/correct/correct.php.inc'],
+        ];
+    }
+
+    /**
      * @dataProvider wrongToFixedCases()
      */
     public function test(string $wrongFile, string $fixedFile): void

--- a/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/correct/correct.php.inc
+++ b/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/correct/correct.php.inc
@@ -6,5 +6,7 @@ class SomeClass
         $someLongVariableName = $anotherLongVariableName = $yetAnotherLongVariableName = $andOneMoreLongVariableName = null;
 
         return function () use ($someLongVariableName, $anotherLongVariableName, $yetAnotherLongVariableName, $andOneMoreLongVariableName) {};
+
+        return function ($argument) use ($someLongVariableName, $anotherLongVariableName, $yetAnotherLongVariableName, $andOneMoreLongVariableName) {};
     }
 }

--- a/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/correct/correct.php.inc
+++ b/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/correct/correct.php.inc
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+class SomeClass
+{
+    public function someFunction() {
+        $someLongVariableName = $anotherLongVariableName = $yetAnotherLongVariableName = $andOneMoreLongVariableName = null;
+
+        return function () use ($someLongVariableName, $anotherLongVariableName, $yetAnotherLongVariableName, $andOneMoreLongVariableName) {};
+    }
+}

--- a/packages/TokenRunner/src/Wrapper/FixerWrapper/MethodWrapper.php
+++ b/packages/TokenRunner/src/Wrapper/FixerWrapper/MethodWrapper.php
@@ -3,6 +3,7 @@
 namespace Symplify\TokenRunner\Wrapper\FixerWrapper;
 
 use Nette\Utils\Strings;
+use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symplify\TokenRunner\Analyzer\FixerAnalyzer\DocBlockFinder;
@@ -206,9 +207,9 @@ final class MethodWrapper
         // -1 = do not count PHP_EOL as character
         $lineLength += strlen($currentToken->getContent()) - 2;
 
-        // compute from here to end of line
+        // compute from here to end of line or till the start " use (...) "
         $currentPosition = $this->index + 1;
-        while (! Strings::startsWith($this->tokens[$currentPosition]->getContent(), PHP_EOL)) {
+        while (! $this->isEndOFArgumentsLine($currentPosition)) {
             $lineLength += strlen($this->tokens[$currentPosition]->getContent());
             ++$currentPosition;
         }
@@ -261,5 +262,14 @@ final class MethodWrapper
         }
 
         return $lineLength;
+    }
+
+    private function isEndOFArgumentsLine(int $currentPosition): bool
+    {
+        if (Strings::startsWith($this->tokens[$currentPosition]->getContent(), PHP_EOL)) {
+            return true;
+        }
+
+        return $this->tokens[$currentPosition]->isGivenKind(CT::T_USE_LAMBDA);
     }
 }


### PR DESCRIPTION
Failing test for #668.

In the future you might want to fix it to

```php
return function () use (
    $someLongVariableName,
    $anotherLongVariableName,
    $yetAnotherLongVariableName,
    $andOneMoreLongVariableName
) {};
```

