### PR TITLE
Fix ECS configuration

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -30,6 +30,9 @@ services:
             - 'Symfony\Component\DependencyInjection\ContainerBuilder'
             - 'Symplify\EasyCodingStandard\Yaml\*'
 
+    SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
+        enableObjectTypeHint: false
+
 parameters:
     exclude_checkers:
         # broken in php-cs-fixer 2.10, being fixed in master: https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3438


### PR DESCRIPTION
When I clone this repo and run `composer complete-check` it will remove annotations like `@param object $name` in favor of typehint. This should not happen though since Symplify should be compatible with PHP 7.1 and the typehint was added in PHP 7.2.

The sniff doing this actually has a configuration to fix this which I'm adding in this PR.

However for some reason it's currently broken - the `false` from configuration somehow becomes an empty string which causes a failure. I don't have time to investigate further now so I'll just leave it here.

```
 [ERROR] Return value of                                                        
         SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff::isVal
         idTypeHint() must be of the type boolean, string returned    
```