### PR TITLE
[ECS] Tolerant checker yaml file loader test fix for non-strings

### DIFF
--- a/packages/EasyCodingStandard/src/Yaml/CheckerTolerantYamlFileLoader.php
+++ b/packages/EasyCodingStandard/src/Yaml/CheckerTolerantYamlFileLoader.php
@@ -145,7 +145,15 @@ final class CheckerTolerantYamlFileLoader extends YamlFileLoader
      */
     private function escapeValue($value)
     {
-        if (! is_string($value)) {
+        if (is_bool($value) || is_numeric($value)) {
+            return $value;
+        }
+
+        if (is_array($value)) {
+            foreach ($value as $key => $nestedValue) {
+                $value[$key] = $this->escapeValue($nestedValue);
+            }
+
             return $value;
         }
 

--- a/packages/EasyCodingStandard/src/Yaml/CheckerTolerantYamlFileLoader.php
+++ b/packages/EasyCodingStandard/src/Yaml/CheckerTolerantYamlFileLoader.php
@@ -145,7 +145,7 @@ final class CheckerTolerantYamlFileLoader extends YamlFileLoader
      */
     private function escapeValue($value)
     {
-        if (is_numeric($value)) {
+        if (! is_string($value)) {
             return $value;
         }
 

--- a/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-with-bool.yml
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-with-bool.yml
@@ -1,0 +1,3 @@
+services:
+    SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
+        enableObjectTypeHint: false

--- a/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderTest.php
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderTest.php
@@ -5,6 +5,7 @@ namespace Symplify\EasyCodingStandard\Tests\Yaml;
 use PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PHPUnit\Framework\TestCase;
+use SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -74,6 +75,12 @@ final class CheckerTolerantYamlFileLoaderTest extends TestCase
                 ArraySyntaxFixer::class,
                 ['configure', [['syntax' => 'short']]],
                 [],
+            ],
+            [
+                __DIR__ . '/CheckerTolerantYamlFileLoaderSource/config-with-bool.yml',
+                TypeHintDeclarationSniff::class,
+                [],
+                ['enableObjectTypeHint' => false],
             ],
         ];
     }


### PR DESCRIPTION
Follow up to #685