### PR TITLE
[ECS] Rename deprecated Fixers to their new equivalents

### DIFF
--- a/packages/EasyCodingStandard/config/symfony.yml
+++ b/packages/EasyCodingStandard/config/symfony.yml
@@ -15,17 +15,21 @@ services:
     PhpCsFixer\Fixer\CastNotation\CastSpacesFixer: ~
     PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
-    PhpCsFixer\Fixer\Comment\HashToSlashCommentFixer: ~
+    PhpCsFixer\Fixer\Comment\SingleLineCommentStyleFixer:
+        comment_types:
+            - hash
     PhpCsFixer\Fixer\ControlStructure\IncludeFixer: ~
     PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer: ~
-    PhpCsFixer\Fixer\ClassNotation\MethodSeparationFixer: ~
+    PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer:
+        elements:
+            - method
     PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~
     PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer: ~
     PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer: ~
-    PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer:
+    PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer:
         - curly_brace_block
         - extra
         - parenthesis_brace_block
@@ -59,7 +63,8 @@ services:
     PhpCsFixer\Fixer\Phpdoc\PhpdocTrimFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocTypesFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocVarWithoutNameFixer: ~
-    PhpCsFixer\Fixer\Operator\PreIncrementFixer: ~
+    PhpCsFixer\Fixer\Operator\IncrementStyleFixer:
+        style: pre
     PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer: ~
     PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer: ~
     PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer: ~

--- a/packages/EasyCodingStandard/config/symfony.yml
+++ b/packages/EasyCodingStandard/config/symfony.yml
@@ -30,12 +30,13 @@ services:
     PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
     PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer: ~
     PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer:
-        - curly_brace_block
-        - extra
-        - parenthesis_brace_block
-        - square_brace_block
-        - throw
-        - use
+        tokens:
+            - curly_brace_block
+            - extra
+            - parenthesis_brace_block
+            - square_brace_block
+            - throw
+            - use
     PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer: ~
     PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer: ~
     PhpCsFixer\Fixer\CastNotation\NoShortBoolCastFixer: ~

--- a/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/RemoveMutualCheckersCompilerPass.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/RemoveMutualCheckersCompilerPass.php
@@ -98,6 +98,9 @@ final class RemoveMutualCheckersCompilerPass implements CompilerPassInterface
             'PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer',
             'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff',
         ], [
+            'PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer',
+            'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff',
+        ], [
             'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff',
             'PhpCsFixer\Fixer\ControlStructure\IncludeFixer',
         ], [
@@ -144,6 +147,23 @@ final class RemoveMutualCheckersCompilerPass implements CompilerPassInterface
         ], [
             'PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer',
             'PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff',
+        ],
+        // Aliased deprecated fixers
+        [
+            'PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer',
+            'PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer',
+        ],
+        [
+            'PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer',
+            'PhpCsFixer\Fixer\ClassNotation\MethodSeparationFixer',
+        ],
+        [
+            'PhpCsFixer\Fixer\Operator\IncrementStyleFixer',
+            'PhpCsFixer\Fixer\Operator\PreIncrementFixer',
+        ],
+        [
+            'PhpCsFixer\Fixer\Comment\SingleLineCommentStyleFixer',
+            'PhpCsFixer\Fixer\Comment\HashToSlashCommentFixer',
         ],
     ];
 


### PR DESCRIPTION
Various deprecated fixers from php-cs-fixer used in symfony ruleset renamed to their new equivalents.

Not sure about the `RemoveMutualCheckersCompilerPass` - is this right?