### PR TITLE
[ECS] Add shortcut for config file

### DIFF
--- a/packages/EasyCodingStandard/src/Console/Application.php
+++ b/packages/EasyCodingStandard/src/Console/Application.php
@@ -36,7 +36,7 @@ final class Application extends SymfonyApplication
     {
         $inputDefinition->addOption(new InputOption(
             'config',
-            null,
+            'c',
             InputOption::VALUE_REQUIRED,
             'Path to config file.',
             'easy-coding-standard.(yml|yaml)'


### PR DESCRIPTION
Hi, `-c` is widely used shortcut for config file, so it would by nice to have it in ECS as well.

Used for example by:
- [PHPUnit](https://phpunit.de/manual/current/en/textui.html)
- [PHPStan](https://github.com/phpstan/phpstan#configuration)
- [Steward](https://github.com/lmc-eu/steward/wiki/Configuration-file#usage) :-)
- ...
