### PR TITLE
[ECS] Test parameters.skip are merged

### DIFF
--- a/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-skip-with-import-empty.yml
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-skip-with-import-empty.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: 'config-empty.yml' }
+
+parameters:
+    skip:
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.FirstCode: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.SecondCode: false

--- a/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-skip-with-import.yml
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-skip-with-import.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: 'config-skip.yml' }
+
+parameters:
+    skip:
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.SecondCode: false # overwrite value from config-skip.yml
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.ThirdCode: ~

--- a/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-skip.yml
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderSource/config-skip.yml
@@ -1,0 +1,4 @@
+parameters:
+    skip:
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.FirstCode: ~
+        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.SecondCode: ~

--- a/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderTest.php
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerTolerantYamlFileLoaderTest.php
@@ -85,6 +85,51 @@ final class CheckerTolerantYamlFileLoaderTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideConfigToParametersDefinition()
+     * @param mixed[] $expectedMethodCall
+     * @param mixed[] $expectedProperties
+     */
+    public function testSkipParameters(string $configFile, array $expectedSkip): void
+    {
+        $containerBuilder = $this->createAndLoadContainerBuilderFromConfig($configFile);
+
+        $skip = $containerBuilder->getParameterBag()->get('skip');
+
+        $this->assertSame($expectedSkip, $skip);
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function provideConfigToParametersDefinition(): array
+    {
+        return [
+            'parent configuration' => [
+                __DIR__ . '/CheckerTolerantYamlFileLoaderSource/config-skip.yml',
+                [
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.FirstCode' => null,
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.SecondCode' => null,
+                ],
+            ],
+            'configuration importing the parent with already defined skip parameters' => [
+                __DIR__ . '/CheckerTolerantYamlFileLoaderSource/config-skip-with-import.yml',
+                [
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.FirstCode' => null,
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.SecondCode' => false,
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.ThirdCode' => null,
+                ],
+            ],
+            'configuration importing empty parent' => [
+                __DIR__ . '/CheckerTolerantYamlFileLoaderSource/config-skip-with-import-empty.yml',
+                [
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.FirstCode' => null,
+                    'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\EmptyStatementSniff.SecondCode' => false,
+                ],
+            ],
+        ];
+    }
+
     private function createAndLoadContainerBuilderFromConfig(string $config): ContainerBuilder
     {
         $containerBuilder = new ContainerBuilder();


### PR DESCRIPTION
This is just a failing test for behavior explained [here](https://github.com/Symplify/Symplify/pull/697#issuecomment-373915457).

In the second case the parameters are overwritten instead of being merged.

@TomasVotruba is the test understandable or should I add some more testcases?

Ref.  #697.