### PR TITLE
[EasyCodingStandardTester] init, decouple from ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ This change was finished in [Statie](https://github.com/Symplify/Statie) and [Ea
 - [#713] **PackageBuilder** Renamed method `Symplify\PackageBuilder\Configuration\LevelFileFinder::resolveLevel()` to `Symplify\PackageBuilder\Configuration\LevelFileFinder::detectFromInputAndDirectory()`
 
 - [#722] **TokenRunner** Move form `static` to service and constructor injection
-- [#712] **EasyCodingStandard** Move from `Symplify\EasyCodingStandard\Testing\AbstractContainerAwareCheckerTestCase` to new `Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase`
+- [#712] **EasyCodingStandard** Move from `Symplify\EasyCodingStandard\Testing\AbstractContainerAwareCheckerTestCase` to new `Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase`
 - [#693] **CodingStandard** Move checkers from static to services, follow up to [#680]
 - [#703] Remove dead PHPStan rules, thanks to [@carusogabriel]
 - [#704] Reduce function cyclomatic complexity, thanks to [@carusogabriel]
@@ -107,7 +107,7 @@ This change was finished in [Statie](https://github.com/Symplify/Statie) and [Ea
 ### Removed
 
 - [#720] **PackageBuilder** Removed `Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory`, that was only for exception rendering; use `Symplify\PackageBuilder\Console\ExceptionRenderer` instead
-- [#712] **EasyCodingStandard** Removed `Symplify\EasyCodingStandard\Testing\AbstractContainerAwareCheckerTestCase`, use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase` instead
+- [#712] **EasyCodingStandard** Removed `Symplify\EasyCodingStandard\Testing\AbstractContainerAwareCheckerTestCase`, use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase` instead
 - [#708] Removed `AnnotateMagicContainerGetterFixer`, use awesome [Symfony Plugin](https://plugins.jetbrains.com/plugin/7219-symfony-plugin) instead
 - [#693] Removed `AbstractSimpleFixerTestCase` in favor of more general and advanced `AbstractContainerAwareCheckerTestCase`
 - [#688] **CodingStandard** Removed `DynamicPropertySniff`, use `PHPStan\Rules\Properties\AccessPropertiesRule`  PHPStan with [`--level 0`](https://github.com/phpstan/phpstan/blob/3485d8ce8c64a6becf6cc60f268d051af6ff7ceb/conf/config.level0.neon#L28) instead

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
             "Symplify\\EasyCodingStandard\\Configuration\\": "packages/EasyCodingStandard/packages/Configuration/src",
             "Symplify\\EasyCodingStandard\\FixerRunner\\": "packages/EasyCodingStandard/packages/FixerRunner/src",
             "Symplify\\EasyCodingStandard\\Performance\\": "packages/EasyCodingStandard/packages/Performance/src",
+            "Symplify\\EasyCodingStandardTester\\": "packages/EasyCodingStandardTester/src",
             "Symplify\\PackageBuilder\\": "packages/PackageBuilder/src",
             "Symplify\\Statie\\": "packages/Statie/src",
             "Symplify\\Statie\\FlatWhite\\": "packages/Statie/packages/FlatWhite/src",

--- a/packages/CodingStandard/composer.json
+++ b/packages/CodingStandard/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "nette/application": "^2.4",
-        "symplify/easy-coding-standard": "^4.0",
+        "symplify/easy-coding-standard-tester": "^4.0",
         "symplify/package-builder": "^4.0",
         "phpunit/phpunit": "^7.0"
     },

--- a/packages/CodingStandard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/ArrayNotationTest.php
+++ b/packages/CodingStandard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/ArrayNotationTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer

--- a/packages/CodingStandard/tests/Fixer/Commenting/BlockPropertyCommentFixer/BlockPropertyCommentFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/BlockPropertyCommentFixer/BlockPropertyCommentFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\BlockPropertyCommentFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Commenting\BlockPropertyCommentFixer

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveEmptyDocBlockFixer/RemoveEmptyDocBlockFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveEmptyDocBlockFixer/RemoveEmptyDocBlockFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveEmptyDocBlockFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Commenting\RemoveEmptyDocBlockFixer

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/RemoveSuperfluousDocBlockWhitespaceFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveSuperfluousDocBlockWhitespaceFixer/RemoveSuperfluousDocBlockWhitespaceFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Commenting\RemoveSuperfluousDocBlockWhitespaceFixer

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/ConfiguredTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/ConfiguredTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDocBlockFixer;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/RemoveUselessDocBlockFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/RemoveUselessDocBlockFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDocBlockFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDocBlockFixer

--- a/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/RequireFollowedByAbsolutePathFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/ControlStructure/RequireFollowedByAbsolutePathFixer/RequireFollowedByAbsolutePathFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\ControlStructure\RequireFollowedByAbsolutePathFixer

--- a/packages/CodingStandard/tests/Fixer/Import/ImportNamespacedNameFixer/ConfiguredImportNamespacedNameFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Import/ImportNamespacedNameFixer/ConfiguredImportNamespacedNameFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Import\ImportNamespacedNameFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Import\ImportNamespacedNameFixer

--- a/packages/CodingStandard/tests/Fixer/Import/ImportNamespacedNameFixer/ImportNamespacedNameFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Import/ImportNamespacedNameFixer/ImportNamespacedNameFixerTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Fixer\Import\ImportNamespacedNameFixer;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Import\ImportNamespacedNameFixer

--- a/packages/CodingStandard/tests/Fixer/LineLength/BreakArrayListFixer/BreakArrayListFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/LineLength/BreakArrayListFixer/BreakArrayListFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\BreakArrayListFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\LineLength\BreakArrayListFixer

--- a/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/BreakMethodArgumentsFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodArgumentsFixer/BreakMethodArgumentsFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\BreakMethodArgumentsFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\LineLength\BreakMethodArgumentsFixer

--- a/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodCallsFixer/BreakMethodCallsFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/LineLength/BreakMethodCallsFixer/BreakMethodCallsFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\BreakMethodCallsFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\LineLength\BreakMethodCallsFixer

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/ClassNameSuffixByParentFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/ClassNameSuffixByParentFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Naming\ClassNameSuffixByParentFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer

--- a/packages/CodingStandard/tests/Fixer/Naming/ExceptionNameFixer/ExceptionNameFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Naming/ExceptionNameFixer/ExceptionNameFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Naming\ExceptionNameFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Naming\ExceptionNameFixer

--- a/packages/CodingStandard/tests/Fixer/Naming/MagicMethodsNamingFixer/MagicMethodsNamingFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Naming/MagicMethodsNamingFixer/MagicMethodsNamingFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Naming\MagicMethodsNamingFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Naming\MagicMethodsNamingFixer

--- a/packages/CodingStandard/tests/Fixer/Naming/PropertyNameMatchingTypeFixer/PropertyNameMatchingTypeFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Naming/PropertyNameMatchingTypeFixer/PropertyNameMatchingTypeFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Naming\PropertyNameMatchingTypeFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer

--- a/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixer/ClassStringToClassConstantFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixer/ClassStringToClassConstantFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Php\ClassStringToClassConstantFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer

--- a/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixer/ExistenceNotRequiredTest.php
+++ b/packages/CodingStandard/tests/Fixer/Php/ClassStringToClassConstantFixer/ExistenceNotRequiredTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Php\ClassStringToClassConstantFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer

--- a/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/ArrayPropertyDefaultValueFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Property/ArrayPropertyDefaultValueFixer/ArrayPropertyDefaultValueFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Property\ArrayPropertyDefaultValueFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Property\ArrayPropertyDefaultValueFixer

--- a/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/ConfiguredTest.php
+++ b/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/ConfiguredTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Solid\FinalInterfaceFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Solid\FinalInterfaceFixer

--- a/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/FinalInterfaceFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/FinalInterfaceFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Solid\FinalInterfaceFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Solid\FinalInterfaceFixer

--- a/packages/CodingStandard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer

--- a/packages/CodingStandard/tests/Sniffs/Architecture/ExplicitExceptionSniff/ExplicitExceptionSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Architecture/ExplicitExceptionSniff/ExplicitExceptionSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\Architecture\ExplicitExceptionSniff;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Architecture\ExplicitExceptionSniff

--- a/packages/CodingStandard/tests/Sniffs/CleanCode/ForbiddenReferenceSniff/ForbiddenReferenceSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/CleanCode/ForbiddenReferenceSniff/ForbiddenReferenceSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\CleanCode\ForbiddenReferenceSniff;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\CleanCode\ForbiddenReferenceSniff

--- a/packages/CodingStandard/tests/Sniffs/CleanCode/ForbiddenStaticFunction/ForbiddenStaticFuncitonSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/CleanCode/ForbiddenStaticFunction/ForbiddenStaticFuncitonSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\CleanCode\ForbiddenStaticFunction;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\CleanCode\ForbiddenStaticFunction

--- a/packages/CodingStandard/tests/Sniffs/Commenting/VarConstantComment/VarConstantCommentSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Commenting/VarConstantComment/VarConstantCommentSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\Commenting\VarConstantComment;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Commenting\VarConstantCommentSniff

--- a/packages/CodingStandard/tests/Sniffs/DeadCode/UnusedPublicMethodSniff/UnusedPublicMethodSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/DeadCode/UnusedPublicMethodSniff/UnusedPublicMethodSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\DeadCode\UnusedPublicMethodSniff;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\DeadCode\UnusedPublicMethodSniff

--- a/packages/CodingStandard/tests/Sniffs/Debug/CommentedOutCode/CommentedOutCodeSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Debug/CommentedOutCode/CommentedOutCodeSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\Debug\CommentedOutCode;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff

--- a/packages/CodingStandard/tests/Sniffs/Debug/DebugFunctionCall/DebugFunctionCallSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Debug/DebugFunctionCall/DebugFunctionCallSniffTest.php
@@ -2,7 +2,7 @@
 
 namespace Symplify\CodingStandard\Tests\Sniffs\Debug\DebugFunctionCall;
 
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Debug\DebugFunctionCallSniff

--- a/packages/CodingStandard/tests/Sniffs/DependencyInjection/NoClassInstantiation/NoClassInstantiationSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/DependencyInjection/NoClassInstantiation/NoClassInstantiationSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\DependencyInjection\NoClassInstantiation;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff

--- a/packages/CodingStandard/tests/Sniffs/Naming/AbstractClassName/AbstractClassNameSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Naming/AbstractClassName/AbstractClassNameSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\Naming\AbstractClassName;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff

--- a/packages/CodingStandard/tests/Sniffs/Naming/InterfaceName/InterfaceNameSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Naming/InterfaceName/InterfaceNameSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\Naming\InterfaceName;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff

--- a/packages/CodingStandard/tests/Sniffs/Naming/TraitName/TraitNameSniffTest.php
+++ b/packages/CodingStandard/tests/Sniffs/Naming/TraitName/TraitNameSniffTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\CodingStandard\Tests\Sniffs\Naming\TraitName;
 
 use Iterator;
-use Symplify\EasyCodingStandard\Testing\AbstractCheckerTestCase;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 
 /**
  * @see \Symplify\CodingStandard\Sniffs\Naming\TraitNameSniff

--- a/packages/EasyCodingStandardTester/.gitattributes
+++ b/packages/EasyCodingStandardTester/.gitattributes
@@ -1,0 +1,5 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml export-ignore
+README.md export-ignore

--- a/packages/EasyCodingStandardTester/.gitignore
+++ b/packages/EasyCodingStandardTester/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+composer.lock

--- a/packages/EasyCodingStandardTester/.travis.yml
+++ b/packages/EasyCodingStandardTester/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+
+install:
+  - composer install --prefer-source
+
+script:
+  - bin/ecs
+  - vendor/bin/phpunit
+
+notifications:
+  email: never

--- a/packages/EasyCodingStandardTester/LICENSE
+++ b/packages/EasyCodingStandardTester/LICENSE
@@ -1,0 +1,25 @@
+The MIT License
+---------------
+
+Copyright (c) 2016 Tomáš Votruba (http://tomasvotruba.cz)
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/EasyCodingStandardTester/README.md
+++ b/packages/EasyCodingStandardTester/README.md
@@ -1,0 +1,7 @@
+# The Best Way to Test Sniffs and Fixers
+
+[![Build Status](https://img.shields.io/travis/Symplify/EasyCodingStandardTester/master.svg?style=flat-square)](https://travis-ci.org/Symplify/EasyCodingStandardTester)
+[![Downloads total](https://img.shields.io/packagist/dt/symplify/easy-coding-standard-tester.svg?style=flat-square)](https://packagist.org/packages/symplify/easy-coding-standard-tester)
+[![Subscribe](https://img.shields.io/badge/subscribe-to--releases-green.svg?style=flat-square)](https://libraries.io/packagist/symplify%2Feasy-coding-standard-tester)
+
+@todo HOW TO

--- a/packages/EasyCodingStandardTester/composer.json
+++ b/packages/EasyCodingStandardTester/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "symplify/easy-coding-standard-tester",
+    "description": "# The Best Way to Test Sniffs and Fixers",
+    "license": "MIT",
+    "require": {
+        "php": "^7.1",
+        "phpunit/phpunit": "^7.0",
+        "symplify/easy-coding-standard": "^4.0",
+        "symplify/package-builder": "^4.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symplify\\EasyCodingStandardTester\\": "src"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.0-dev"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/packages/EasyCodingStandardTester/phpunit.xml
+++ b/packages/EasyCodingStandardTester/phpunit.xml
@@ -1,0 +1,10 @@
+<phpunit
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    verbose="true"
+>
+    <!-- tests directories to run -->
+    <testsuite>
+        <directory>tests</directory>
+    </testsuite>
+</phpunit>

--- a/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Symplify\EasyCodingStandard\Testing;
+namespace Symplify\EasyCodingStandardTester\Testing;
 
 use PHPUnit\Framework\TestCase;
 use Symplify\EasyCodingStandard\Configuration\Exception\NoCheckersLoadedException;


### PR DESCRIPTION
The testing part of package needs to be decoupled since it depends on PHPUnit.

To prevent errors like:  https://github.com/Symplify/Symplify/issues/718#issuecomment-375769738