### PR TITLE
[PackageBuilder] ThrowableRenderer consistency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "squizlabs/php_codesniffer": "^3.2",
         "symfony/config": "^4.0",
         "symfony/console": "^4.0",
+        "symfony/debug": "^4.0",
         "symfony/dependency-injection": "^4.0",
         "symfony/event-dispatcher": "^4.0",
         "symfony/finder": "^4.0",

--- a/packages/PackageBuilder/composer.json
+++ b/packages/PackageBuilder/composer.json
@@ -7,6 +7,7 @@
         "nette/utils": "^2.4",
         "symfony/config": "^4.0",
         "symfony/console": "^4.0",
+        "symfony/debug": "^4.0",
         "symfony/dependency-injection": "^4.0",
         "symfony/finder": "^4.0",
         "symfony/http-kernel": "^4.0",

--- a/packages/PackageBuilder/src/Console/ThrowableRenderer.php
+++ b/packages/PackageBuilder/src/Console/ThrowableRenderer.php
@@ -3,12 +3,12 @@
 namespace Symplify\PackageBuilder\Console;
 
 use Error;
-use ErrorException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Throwable;
 
 final class ThrowableRenderer
@@ -52,7 +52,7 @@ final class ThrowableRenderer
     public function render(Throwable $throwable): void
     {
         if ($throwable instanceof Error) {
-            $throwable = $this->wrapErrorToErrorException($throwable);
+            $throwable = new FatalThrowableError($throwable);
         }
 
         $this->application->renderException($throwable, $this->output);
@@ -65,16 +65,5 @@ final class ThrowableRenderer
                 $output->setVerbosity($level);
             }
         }
-    }
-
-    private function wrapErrorToErrorException(Error $error): ErrorException
-    {
-        return new ErrorException(
-            $error->getMessage(),
-            $error->getCode(),
-            E_ERROR,
-            $error->getFile(),
-            $error->getLine()
-        );
     }
 }

--- a/packages/PackageBuilder/tests/Console/ThrowableRendererTest.php
+++ b/packages/PackageBuilder/tests/Console/ThrowableRendererTest.php
@@ -34,21 +34,13 @@ final class ThrowableRendererTest extends TestCase
     public function provideVerbosityLevelsThrowableClassAndExpectedMessage(): Iterator
     {
         yield [null, Error::class, '%wIn ThrowableRendererTest.php line %d:%wRandom message%w'];
-        yield [
-            '-v',
-            Error::class,
-            '%wIn ThrowableRendererTest.php line %d:%w[ErrorException]%wRandom message%wException trace:%a',
-        ];
-        yield [
-            '-vv',
-            Error::class,
-            '%wIn ThrowableRendererTest.php line %d:%w[ErrorException]%wRandom message%wException trace:%a',
-        ];
-        yield [
-            '-vvv',
-            Error::class,
-            '%wIn ThrowableRendererTest.php line %d:%w[ErrorException]%wRandom message%wException trace:%a',
-        ];
+
+        $verboseErrorMessage = '%wIn ThrowableRendererTest.php line %d:%w' .
+            '[Symfony\Component\Debug\Exception\FatalThrowableError]%wRandom message%wException trace:%a';
+        yield ['-v', Error::class, $verboseErrorMessage];
+        yield ['-vv', Error::class, $verboseErrorMessage];
+        yield ['-vvv', Error::class, $verboseErrorMessage];
+
         yield [null, Exception::class, '%wIn ThrowableRendererTest.php line %d:%wRandom message%w'];
         yield [
             '-vvv',


### PR DESCRIPTION
Be consistent with original Exception and use FatalThrowableError: https://github.com/symfony/symfony/pull/25255/files#diff-38eebdda7d6ebfcb7405b91167f05c9cR124

Part of #723 
