### PR TITLE
[ECS] Support loading PHP resources in config

### DIFF
--- a/packages/EasyCodingStandard/src/DependencyInjection/EasyCodingStandardKernel.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/EasyCodingStandardKernel.php
@@ -8,6 +8,7 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\GlobFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symplify\EasyCodingStandard\DependencyInjection\CompilerPass\AutowireCheckersCompilerPass;
@@ -102,6 +103,7 @@ final class EasyCodingStandardKernel extends AbstractCliKernel
         return new DelegatingLoader(new LoaderResolver([
             new GlobFileLoader($container, $fileLocator),
             new CheckerTolerantYamlFileLoader($container, $fileLocator),
+            new PhpFileLoader($container, $fileLocator),
         ]));
     }
 }


### PR DESCRIPTION
This adds support of loading custom PHP resources (besides using default yaml resources).

It should allow some non-typical customization, like conditional loading of resources or something like using run-time detected path to resource, as we needed in https://github.com/lmc-eu/php-coding-standard/pull/6 .