### PR TITLE
[ECS] fix false report of unused erros while using code for all

### DIFF
--- a/packages/EasyCodingStandard/src/Skipper.php
+++ b/packages/EasyCodingStandard/src/Skipper.php
@@ -50,6 +50,7 @@ final class Skipper
 
             // skip all
             if ($value === null) {
+                unset($this->unusedSkipped[$index]);
                 return true;
             }
 


### PR DESCRIPTION
These skips were reported as unused, even if found:

```yml
parameters:
    skip:
        PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff.Found: ~
```
