### PR TITLE
[ECS] Print fixable messages as warnings [WIP]

### DIFF
--- a/packages/EasyCodingStandard/src/Console/Command/CheckCommand.php
+++ b/packages/EasyCodingStandard/src/Console/Command/CheckCommand.php
@@ -176,7 +176,7 @@ final class CheckCommand extends Command
             return;
         }
 
-        $this->easyCodingStandardStyle->success(sprintf(
+        $this->easyCodingStandardStyle->warning(sprintf(
             '%s%d file%s %s fixable! Just add "--fix" to console command and rerun to apply.',
             $errorCount ? 'Good news is that ' : '',
             $fileDiffsCount,

--- a/packages/EasyCodingStandard/src/Console/Command/CheckCommand.php
+++ b/packages/EasyCodingStandard/src/Console/Command/CheckCommand.php
@@ -176,7 +176,7 @@ final class CheckCommand extends Command
             return;
         }
 
-        $this->easyCodingStandardStyle->warning(sprintf(
+        $this->easyCodingStandardStyle->fixableError(sprintf(
             '%s%d file%s %s fixable! Just add "--fix" to console command and rerun to apply.',
             $errorCount ? 'Good news is that ' : '',
             $fileDiffsCount,

--- a/packages/EasyCodingStandard/src/Console/Style/EasyCodingStandardStyle.php
+++ b/packages/EasyCodingStandard/src/Console/Style/EasyCodingStandardStyle.php
@@ -105,6 +105,11 @@ final class EasyCodingStandardStyle extends SymfonyStyle
         $this->newLine();
     }
 
+    public function fixableError(string $message): void
+    {
+        $this->block($message, 'WARNING', 'fg=black;bg=yellow', ' ', true);
+    }
+
     /**
      * @param string[] $headers
      * @param mixed[] $rows


### PR DESCRIPTION
Ref #775 .

It seems SymfonyStyle has Warnings in red... https://github.com/symfony/console/blob/master/Style/SymfonyStyle.php#L155

![](https://user-images.githubusercontent.com/793041/38571214-2f53d3c4-3cf0-11e8-9e7e-e831bd4dfe07.png)

I don't care that much (it is ok for me), so its up to you if you'd like to redefine the style or use the red color :). What do you think?