### PR TITLE
[CS] Add test case for #855

### DIFF
--- a/packages/CodingStandard/tests/Issues/Issue855Test.php
+++ b/packages/CodingStandard/tests/Issues/Issue855Test.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Sniffs\Issues;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class Issue855Test extends AbstractCheckerTestCase
+{
+    public function test(): void
+    {
+        $this->doTestCorrectFile(__DIR__ . '/correct/correct855.php.inc');
+    }
+
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config/config855.yml';
+    }
+}

--- a/packages/CodingStandard/tests/Issues/config/config855.yml
+++ b/packages/CodingStandard/tests/Issues/config/config855.yml
@@ -1,0 +1,3 @@
+services:
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer: ~
+

--- a/packages/CodingStandard/tests/Issues/correct/correct855.php.inc
+++ b/packages/CodingStandard/tests/Issues/correct/correct855.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+class Foo
+{
+    protected function bar()
+    {
+        return new class() implements ResponseInterface {
+            public function baz()
+            {
+                return [];
+            }
+        };
+    }
+}


### PR DESCRIPTION
See #855 . 

Hope I got it right :). Both wrong and fixed are the same files, because the expected behavior is the file will be left untouched by the Sniff.