### PR TITLE
RemoveUselessDocBlockFixer should not reformat custom annotations

### DIFF
--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/RemoveUselessDocBlockFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/RemoveUselessDocBlockFixerTest.php
@@ -37,6 +37,7 @@ final class RemoveUselessDocBlockFixerTest extends AbstractCheckerTestCase
         yield [__DIR__ . '/correct/correct15.php.inc'];
         yield [__DIR__ . '/correct/correct16.php.inc'];
         yield [__DIR__ . '/correct/correct17.php.inc'];
+        yield [__DIR__ . '/correct/correct18.php.inc'];
     }
 
     /**

--- a/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/correct/correct18.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/RemoveUselessDocBlockFixer/correct/correct18.php.inc
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+class CustomAnnotationTest
+{
+    /**
+     * @customAnnotation
+     */
+    public function customAnnotation(): void
+    {
+    }
+
+    /**
+     * @customAnnotation(arg)
+     */
+    public function customAnnotationWithArgument(): void
+    {
+    }
+}


### PR DESCRIPTION
Fixes #869 

This is a work in progress, only failing test describing the issue yet.