### PR TITLE
 [CodingStandard] Allow list option in ClassNameSuffixByParentFixer

### DIFF
--- a/ecs.yml
+++ b/ecs.yml
@@ -15,7 +15,7 @@ services:
 
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         extra_parent_types_to_suffixes:
-            - '*FileDecorator'
+            - 'FileDecorator'
 
     Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff:
         extraAllowedClasses:

--- a/ecs.yml
+++ b/ecs.yml
@@ -13,6 +13,10 @@ services:
     # class should be Abstact or Final
     SlamCsFixer\FinalInternalClassFixer: ~
 
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
+        extra_parent_types_to_suffixes:
+            - '*FileDecorator'
+
     Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff:
         extraAllowedClasses:
             - 'Symplify\EasyCodingStandard\Error\Error'

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -206,7 +206,7 @@ services:
  }
 ```
 
-### Property name should match its type, if possible
+### Property name should match its key, if possible
 
 - :wrench:
 - class: [`Symplify\CodingStandard\Fixer\Naming\PropertyNameMatchingTypeFixer`](src/Fixer/Naming/PropertyNameMatchingTypeFixer.php)

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -546,12 +546,12 @@ services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         parent_types_to_suffixes:
             # defaults
-            '*Command': 'Command'
-            '*Controller': 'Controller'
-            '*Repository': 'Repository'
-            '*Presenter': 'Presenter'
-            '*Request': 'Request'
-            '*EventSubscriber': 'EventSubscriber'
+            - '*Command'
+            - '*Controller'
+            - '*Repository'
+            - '*Presenter'
+            - '*Request'
+            - '*EventSubscriber'
 ```
 
 Or keep all defaults values by using `extra_parent_types_to_suffixes`:
@@ -561,7 +561,7 @@ Or keep all defaults values by using `extra_parent_types_to_suffixes`:
 services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         extra_parent_types_to_suffixes:
-            '*ProviderInterface': 'Provider'
+            - '*ProviderInterface'
 ```
 
 It also covers `Interface` suffix as well, e.g `EventSubscriber` checks for `EventSubscriberInterface` as well.

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -546,12 +546,17 @@ services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         parent_types_to_suffixes:
             # defaults
-            - '*Command'
-            - '*Controller'
-            - '*Repository'
-            - '*Presenter'
-            - '*Request'
-            - '*EventSubscriber'
+            - 'Command'
+            - 'Controller'
+            - 'Repository'
+            - 'Presenter'
+            - 'Request'
+            - 'Response'
+            - 'EventSubscriber'
+            - 'FixerInterface'
+            - 'Sniff'
+            - 'Exception'
+            - 'Handler'
 ```
 
 Or keep all defaults values by using `extra_parent_types_to_suffixes`:
@@ -561,7 +566,7 @@ Or keep all defaults values by using `extra_parent_types_to_suffixes`:
 services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         extra_parent_types_to_suffixes:
-            - '*ProviderInterface'
+            - 'ProviderInterface'
 ```
 
 It also covers `Interface` suffix as well, e.g `EventSubscriber` checks for `EventSubscriberInterface` as well.

--- a/packages/CodingStandard/README.md
+++ b/packages/CodingStandard/README.md
@@ -554,6 +554,16 @@ services:
             '*EventSubscriber': 'EventSubscriber'
 ```
 
+Or keep all defaults values by using `extra_parent_types_to_suffixes`:
+
+```yaml
+# easy-coding-standard.yml
+services:
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
+        extra_parent_types_to_suffixes:
+            '*ProviderInterface': 'Provider'
+```
+
 It also covers `Interface` suffix as well, e.g `EventSubscriber` checks for `EventSubscriberInterface` as well.
 
 ### Interface should have suffix "Interface"

--- a/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
+++ b/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
@@ -25,6 +25,11 @@ final class ClassNameSuffixByParentFixer implements DefinedFixerInterface, Confi
     private const PARENT_TYPES_TO_SUFFIXES_OPTION = 'parent_types_to_suffixes';
 
     /**
+     * @var string
+     */
+    private const EXTRA_PARENT_TYPES_TO_SUFFIXES_OPTION = 'extra_parent_types_to_suffixes';
+
+    /**
      * @var string[]
      */
     private $defaultParentClassToSuffixMap = [
@@ -139,7 +144,16 @@ CODE
             ->setDefault($this->defaultParentClassToSuffixMap)
             ->getOption();
 
-        return new FixerConfigurationResolver([$parentTypesToSuffixesOption]);
+        $fixerOptionBuilder = new FixerOptionBuilder(
+            self::EXTRA_PARENT_TYPES_TO_SUFFIXES_OPTION,
+            'Extra map of parent classes to suffixes, that their children should have'
+        );
+
+        $extraParentTypesToSuffixesOption = $fixerOptionBuilder->setAllowedTypes(['array'])
+            ->setDefault([])
+            ->getOption();
+
+        return new FixerConfigurationResolver([$parentTypesToSuffixesOption, $extraParentTypesToSuffixesOption]);
     }
 
     private function processClassWrapper(Tokens $tokens, ClassWrapper $classWrapper): void

--- a/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
+++ b/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
@@ -33,17 +33,17 @@ final class ClassNameSuffixByParentFixer implements DefinedFixerInterface, Confi
      * @var string[]
      */
     private $defaultParentClassToSuffixMap = [
-        '*Command' => 'Command',
-        '*Controller' => 'Controller',
-        '*Repository' => 'Repository',
-        '*Presenter' => 'Presenter',
-        '*Request' => 'Request',
-        '*Response' => 'Response',
-        '*EventSubscriber' => 'EventSubscriber',
-        '*FixerInterface' => 'Fixer',
-        '*Sniff' => 'Sniff',
-        '*Exception' => 'Exception',
-        '*Handler' => 'Handler',
+        '*Command',
+        '*Controller',
+        '*Repository',
+        '*Presenter',
+        '*Request',
+        '*Response',
+        '*EventSubscriber',
+        '*FixerInterface',
+        '*Sniff',
+        '*Exception',
+        '*Handler',
     ];
 
     /**
@@ -180,7 +180,7 @@ CODE
         string $parentType,
         string $className
     ): void {
-        $classToSuffixMap = $this->configuration[self::PARENT_TYPES_TO_SUFFIXES_OPTION];
+        $classToSuffixMap = $this->getClassToSuffixMap();
 
         foreach ($classToSuffixMap as $classMatch => $suffix) {
             if (! fnmatch($classMatch, $parentType) && ! fnmatch($classMatch . 'Interface', $parentType)) {
@@ -193,5 +193,36 @@ CODE
 
             $tokens[$classWrapper->getNamePosition()] = new Token([T_STRING, $className . $suffix]);
         }
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getClassToSuffixMap(): array
+    {
+        $parentTypesToSuffixes = $this->configuration[self::PARENT_TYPES_TO_SUFFIXES_OPTION];
+        $extraParentTypesToSuffixes = $this->configuration[self::EXTRA_PARENT_TYPES_TO_SUFFIXES_OPTION];
+
+        $typesToSuffixes = array_merge($parentTypesToSuffixes, $extraParentTypesToSuffixes);
+
+        // allow 1 option with numeric keys
+        foreach ($typesToSuffixes as $key => $type) {
+            if (! is_numeric($key)) {
+                continue;
+            }
+
+            $suffix = ltrim($type, '*');
+
+            // remove "Interface" suffix
+            if (Strings::endsWith($suffix, 'Interface')) {
+                $suffix = substr($suffix, 0, -strlen('Interface'));
+            }
+
+            $typesToSuffixes[$type] = $suffix;
+
+            unset($typesToSuffixes[$key]);
+        }
+
+        return $typesToSuffixes;
     }
 }

--- a/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
+++ b/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
@@ -202,37 +202,63 @@ CODE
 
         $typesToSuffixes = array_merge($parentTypesToSuffixes, $extraParentTypesToSuffixes);
 
-        // allow 1 option with numeric keys
-        foreach ($typesToSuffixes as $key => $type) {
+        $typesToSuffixes = $this->convertListValuesToKeysToSuffixes($typesToSuffixes);
+        return $this->prefixKeysWithAsteriks($typesToSuffixes);
+    }
+
+    /**
+     * From:
+     * - [0 => "*Type"]
+     * to:
+     * - ["*Type" => "Type"]
+     *
+     * @param string[] $values
+     * @return string[]
+     */
+    private function convertListValuesToKeysToSuffixes(array $values): array
+    {
+        foreach ($values as $key => $value) {
             if (! is_numeric($key)) {
                 continue;
             }
 
-            $suffix = ltrim($type, '*');
+            $suffix = ltrim($value, '*');
 
             // remove "Interface" suffix
             if (Strings::endsWith($suffix, 'Interface')) {
                 $suffix = substr($suffix, 0, -strlen('Interface'));
             }
 
-            $typesToSuffixes[$type] = $suffix;
+            $values[$value] = $suffix;
 
-            unset($typesToSuffixes[$key]);
+            unset($values[$key]);
         }
+        return $values;
+    }
 
-        // turns "Type => Suffix" to "*Type => Suffix"
-        foreach ($typesToSuffixes as $type => $suffix) {
-            if (Strings::startsWith($type, '*')) {
+    /**
+     * From:
+     * - ["Type" => "Suffix"]
+     * to:
+     * - ["*Type" => "Suffix"]
+     *
+     * @param string[] $values
+     * @return string[]
+     */
+    private function prefixKeysWithAsteriks(array $values): array
+    {
+        foreach ($values as $key => $value) {
+            if (Strings::startsWith($key, '*')) {
                 continue;
             }
 
-            $fnmatchAwareType = '*' . $type;
+            $newKey = '*' . $key;
 
-            $typesToSuffixes[$fnmatchAwareType] = $suffix;
+            $values[$newKey] = $value;
 
-            unset($typesToSuffixes[$type]);
+            unset($values[$key]);
         }
 
-        return $typesToSuffixes;
+        return $values;
     }
 }

--- a/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
+++ b/packages/CodingStandard/src/Fixer/Naming/ClassNameSuffixByParentFixer.php
@@ -33,17 +33,17 @@ final class ClassNameSuffixByParentFixer implements DefinedFixerInterface, Confi
      * @var string[]
      */
     private $defaultParentClassToSuffixMap = [
-        '*Command',
-        '*Controller',
-        '*Repository',
-        '*Presenter',
-        '*Request',
-        '*Response',
-        '*EventSubscriber',
-        '*FixerInterface',
-        '*Sniff',
-        '*Exception',
-        '*Handler',
+        'Command',
+        'Controller',
+        'Repository',
+        'Presenter',
+        'Request',
+        'Response',
+        'EventSubscriber',
+        'FixerInterface',
+        'Sniff',
+        'Exception',
+        'Handler',
     ];
 
     /**
@@ -89,9 +89,7 @@ CODE
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
-            $token = $tokens[$index];
-
-            if (! $token->isClassy()) {
+            if (! $tokens[$index]->isClassy()) {
                 continue;
             }
 
@@ -164,7 +162,6 @@ CODE
         }
 
         $parentClassName = $classWrapper->getParentClassName();
-
         if ($parentClassName) {
             $this->processType($tokens, $classWrapper, $parentClassName, $className);
         }
@@ -221,6 +218,19 @@ CODE
             $typesToSuffixes[$type] = $suffix;
 
             unset($typesToSuffixes[$key]);
+        }
+
+        // turns "Type => Suffix" to "*Type => Suffix"
+        foreach ($typesToSuffixes as $type => $suffix) {
+            if (Strings::startsWith($type, '*')) {
+                continue;
+            }
+
+            $fnmatchAwareType = '*' . $type;
+
+            $typesToSuffixes[$fnmatchAwareType] = $suffix;
+
+            unset($typesToSuffixes[$type]);
         }
 
         return $typesToSuffixes;

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/ConfiguredTest.php
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/ConfiguredTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Naming\ClassNameSuffixByParentFixer;
+
+use Iterator;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+/**
+ * @see \Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer
+ */
+final class ConfiguredTest extends AbstractCheckerTestCase
+{
+    /**
+     * @dataProvider provideWrongToFixedCases()
+     */
+    public function testWrongToFixed(string $wrongFile, string $fixedFile): void
+    {
+        $this->doTestWrongToFixedFile($wrongFile, $fixedFile);
+    }
+
+    public function provideWrongToFixedCases(): Iterator
+    {
+        yield [__DIR__ . '/wrong/wrong.php.inc', __DIR__ . '/fixed/fixed.php.inc'];
+    }
+
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config.yml';
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/ListConfiguredTest.php
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/ListConfiguredTest.php
@@ -8,7 +8,7 @@ use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 /**
  * @see \Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer
  */
-final class ConfiguredTest extends AbstractCheckerTestCase
+final class ListConfiguredTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideWrongToFixedCases()
@@ -25,6 +25,6 @@ final class ConfiguredTest extends AbstractCheckerTestCase
 
     protected function provideConfig(): string
     {
-        return __DIR__ . '/configured-config.yml';
+        return __DIR__ . '/list-configured-config.yml';
     }
 }

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/configured-config.yml
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/configured-config.yml
@@ -1,0 +1,4 @@
+services:
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
+        extra_parent_types_to_suffixes:
+            '*RandomInterface': 'Random'

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/fixed/fixed5.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/fixed/fixed5.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symplify\Statie\Console\Command;
+
+final class SomethingRandom extends RandomInterface
+{
+}

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/list-configured-config.yml
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/list-configured-config.yml
@@ -1,4 +1,4 @@
 services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         extra_parent_types_to_suffixes:
-            - '*Random'
+            - 'Random'

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/list-configured-config.yml
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/list-configured-config.yml
@@ -1,0 +1,4 @@
+services:
+    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
+        extra_parent_types_to_suffixes:
+            - '*Random'

--- a/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/wrong/wrong5.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Naming/ClassNameSuffixByParentFixer/wrong/wrong5.php.inc
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symplify\Statie\Console\Command;
+
+final class Something extends RandomInterface
+{
+}


### PR DESCRIPTION
Closes #899 


### Before

```yaml
services:
    Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
        extra_parent_types_to_suffixes:
            '*FileDecorator': 'FileDecorator'
```


### After (the same effect)

```diff
 services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         extra_parent_types_to_suffixes:
-            '*FileDecorator': 'FileDecorator'
+            'FileDecorator': 'FileDecorator'
```

**or even**

```diff
 services:
     Symplify\CodingStandard\Fixer\Naming\ClassNameSuffixByParentFixer:
         extra_parent_types_to_suffixes:
-            'FileDecorator': 'FileDecorator'
+            - 'FileDecorator'
```