### PR TITLE
[ChangelogLinker] Add --dry-run option to dump-merges command to dump to the output vs write into CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 PRs and issues are linked, so you can find more about it. Thanks to [ChangelogLinker](https://github.com/Symplify/ChangelogLinker).
 
+<!-- changelog-linker -->
+
 ## [Unreleased]
 
 ### Added

--- a/packages/ChangelogLinker/README.md
+++ b/packages/ChangelogLinker/README.md
@@ -32,6 +32,13 @@ The config is autodiscovered in the root directory or by `--config` option.
 vendor/bin/changelog-linker dump-mergers
 ```
 
+### Write or Dry-run?
+
+First thing you need to know, it has a `--dry-run` option that only prints the result to the output.
+
+Without that, I looks for `<!-- changelog-linker -->` in the `CHANGELOG.md` to replace with the content.
+
+
 This command finds the last #ID in the `CHANGELOG.md`, than looks on Github via API and dumps all the merged PRs since the last #ID in nice format.
 
 But that is a mash-up of everything. Not very nice:

--- a/packages/ChangelogLinker/src/ChangeTree/ChangeSorter.php
+++ b/packages/ChangelogLinker/src/ChangeTree/ChangeSorter.php
@@ -22,7 +22,7 @@ final class ChangeSorter
      * @param Change[] $changes
      * @return Change[]
      */
-    public function sortByCategoryAndPackage(array $changes, string $priority): array
+    public function sortByCategoryAndPackage(array $changes, ?string $priority): array
     {
         $categoryList = array_map(function (Change $change) {
             return $change->getPackage();

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -24,6 +24,7 @@ use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 final class DumpMergesCommand extends Command
 {
     /**
+     * @inspiration markdown comment: https://gist.github.com/jonikarppinen/47dc8c1d7ab7e911f4c9#gistcomment-2109856
      * @var string
      */
     private const CHANGELOG_PLACEHOLDER_TO_WRITE = '<!-- changelog-linker -->';

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -46,7 +46,7 @@ final class DumpMergesCommand extends Command
     /**
      * @var string
      */
-    private const OPTION_WRITE = 'write';
+    private const OPTION_DRY_RUN = 'dry-run';
 
     /**
      * @var GithubApi
@@ -128,10 +128,10 @@ final class DumpMergesCommand extends Command
         );
 
         $this->addOption(
-            self::OPTION_WRITE,
+            self::OPTION_DRY_RUN,
             null,
             InputOption::VALUE_NONE,
-            'Instead of just print out to output, write directly into CHANGELOG.md.'
+            'Print out to the output instead of writing directly into CHANGELOG.md.'
         );
 
         $this->addOption('token', 't', InputOption::VALUE_REQUIRED, 'Github Token to overcome request limit.');
@@ -173,11 +173,10 @@ final class DumpMergesCommand extends Command
             $sortPriority
         );
 
-        // @tod change to "--dry-run" vs none approach
-        if ($input->getOption(self::OPTION_WRITE)) {
-            $this->updateChangelogContent($content);
-        } else {
+        if ($input->getOption(self::OPTION_DRY_RUN)) {
             $this->symfonyStyle->writeln($content);
+        } else {
+            $this->updateChangelogContent($content);
         }
 
         // success

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -233,7 +233,8 @@ final class DumpMergesCommand extends Command
             PHP_EOL,
             PHP_EOL,
             PHP_EOL,
-            $newContent
+            $newContent,
+            PHP_EOL
         );
 
         $updatedChangelogContent = str_replace(

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -37,6 +37,11 @@ final class DumpMergesCommand extends Command
     private const OPTION_IN_TAGS = 'in-tags';
 
     /**
+     * @var string
+     */
+    private const OPTION_WRITE = 'write';
+
+    /**
      * @var GithubApi
      */
     private $githubApi;
@@ -112,7 +117,14 @@ final class DumpMergesCommand extends Command
             self::OPTION_IN_TAGS,
             null,
             InputOption::VALUE_NONE,
-            'Print withs tags - detected from date of merge .'
+            'Print withs tags - detected from date of merge.'
+        );
+
+        $this->addOption(
+            self::OPTION_WRITE,
+            null,
+            InputOption::VALUE_NONE,
+            'Instead of just print out to output, write directly into CHANGELOG.md.'
         );
 
         $this->addOption('token', 't', InputOption::VALUE_REQUIRED, 'Github Token to overcome request limit.');
@@ -149,7 +161,7 @@ final class DumpMergesCommand extends Command
         $sortedChanges = $this->changeSorter->sortByCategoryAndPackage($this->changes, $sortPriority);
         $sortedChanges = $this->changeSorter->sortByTags($sortedChanges);
 
-        $this->dumpMergesReporter->reportChangesWithHeadlines(
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines(
             $sortedChanges,
             $input->getOption(self::OPTION_IN_CATEGORIES),
             $input->getOption(self::OPTION_IN_PACKAGES),
@@ -157,7 +169,7 @@ final class DumpMergesCommand extends Command
             $sortPriority
         );
 
-        $this->symfonyStyle->writeln($this->dumpMergesReporter->getContent());
+        $this->symfonyStyle->writeln($content);
 
         // success
         return 0;

--- a/packages/ChangelogLinker/src/Console/Output/DumpMergesReporter.php
+++ b/packages/ChangelogLinker/src/Console/Output/DumpMergesReporter.php
@@ -56,7 +56,7 @@ final class DumpMergesReporter
         bool $withPackages,
         bool $withTags,
         ?string $priority
-    ): void {
+    ): string {
         $this->content .= PHP_EOL;
 
         foreach ($changes as $change) {
@@ -75,10 +75,7 @@ final class DumpMergesReporter
         }
 
         $this->content .= PHP_EOL;
-    }
 
-    public function getContent(): string
-    {
         return $this->dumpMergesFormatter->format($this->content);
     }
 

--- a/packages/ChangelogLinker/src/Console/Output/DumpMergesReporter.php
+++ b/packages/ChangelogLinker/src/Console/Output/DumpMergesReporter.php
@@ -60,15 +60,7 @@ final class DumpMergesReporter
         $this->content .= PHP_EOL;
 
         foreach ($changes as $change) {
-            $this->displayTagIfDesired($change, $withTags);
-
-            if ($priority === ChangeSorter::PRIORITY_PACKAGES) {
-                $this->displayPackageIfDesired($change, $withPackages, $priority);
-                $this->displayCategoryIfDesired($change, $withCategories, $priority);
-            } else {
-                $this->displayCategoryIfDesired($change, $withCategories, $priority);
-                $this->displayPackageIfDesired($change, $withPackages, $priority);
-            }
+            $this->displayHeadlines($withCategories, $withPackages, $withTags, $priority, $change);
 
             $message = $withPackages ? $change->getMessageWithoutPackage() : $change->getMessage();
             $this->content .= $message . PHP_EOL;
@@ -121,5 +113,23 @@ final class DumpMergesReporter
         }
 
         return $tagLine;
+    }
+
+    private function displayHeadlines(
+        bool $withCategories,
+        bool $withPackages,
+        bool $withTags,
+        ?string $priority,
+        Change $change
+    ): void {
+        $this->displayTagIfDesired($change, $withTags);
+
+        if ($priority === ChangeSorter::PRIORITY_PACKAGES) {
+            $this->displayPackageIfDesired($change, $withPackages, $priority);
+            $this->displayCategoryIfDesired($change, $withCategories, $priority);
+        } else {
+            $this->displayCategoryIfDesired($change, $withCategories, $priority);
+            $this->displayPackageIfDesired($change, $withPackages, $priority);
+        }
     }
 }

--- a/packages/ChangelogLinker/src/Exception/MissingPlaceholderInChangelogException.php
+++ b/packages/ChangelogLinker/src/Exception/MissingPlaceholderInChangelogException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\ChangelogLinker\Exception;
+
+use Exception;
+
+final class MissingPlaceholderInChangelogException extends Exception
+{
+}

--- a/packages/ChangelogLinker/tests/Console/Output/DumpMergesReporterTest.php
+++ b/packages/ChangelogLinker/tests/Console/Output/DumpMergesReporterTest.php
@@ -30,11 +30,11 @@ final class DumpMergesReporterTest extends TestCase
 
     public function testReportChanges(): void
     {
-        $this->dumpMergesReporter->reportChangesWithHeadlines($this->changes, false, false, false, 'packages');
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines($this->changes, false, false, false, 'packages');
 
         $this->assertStringEqualsFile(
             __DIR__ . '/DumpMergesReporterSource/expected1.md',
-            $this->dumpMergesReporter->getContent()
+            $content
         );
     }
 
@@ -48,7 +48,7 @@ final class DumpMergesReporterTest extends TestCase
         string $priority,
         string $expectedOutputFile
     ): void {
-        $this->dumpMergesReporter->reportChangesWithHeadlines(
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines(
             $this->changes,
             $withCategories,
             $withPackages,
@@ -56,7 +56,7 @@ final class DumpMergesReporterTest extends TestCase
             $priority
         );
 
-        $this->assertStringEqualsFile($expectedOutputFile, $this->dumpMergesReporter->getContent());
+        $this->assertStringEqualsFile($expectedOutputFile, $content);
     }
 
     public function provideDataForReportChangesWithHeadlines(): Iterator

--- a/packages/ChangelogLinker/tests/Console/Output/DumpMergesReporterTest.php
+++ b/packages/ChangelogLinker/tests/Console/Output/DumpMergesReporterTest.php
@@ -30,12 +30,15 @@ final class DumpMergesReporterTest extends TestCase
 
     public function testReportChanges(): void
     {
-        $content = $this->dumpMergesReporter->reportChangesWithHeadlines($this->changes, false, false, false, 'packages');
-
-        $this->assertStringEqualsFile(
-            __DIR__ . '/DumpMergesReporterSource/expected1.md',
-            $content
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines(
+            $this->changes,
+            false,
+            false,
+            false,
+            'packages'
         );
+
+        $this->assertStringEqualsFile(__DIR__ . '/DumpMergesReporterSource/expected1.md', $content);
     }
 
     /**

--- a/packages/ChangelogLinker/tests/Console/Output/WithTagsTest.php
+++ b/packages/ChangelogLinker/tests/Console/Output/WithTagsTest.php
@@ -35,11 +35,11 @@ final class WithTagsTest extends TestCase
             $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
         }
 
-        $this->dumpMergesReporter->reportChangesWithHeadlines($this->changes, false, false, true, 'categories');
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines($this->changes, false, false, true, 'categories');
 
         $this->assertStringEqualsFile(
             __DIR__ . '/WithTagsSource/expected1.md',
-            $this->dumpMergesReporter->getContent()
+            $content
         );
     }
 
@@ -58,7 +58,7 @@ final class WithTagsTest extends TestCase
             $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
         }
 
-        $this->dumpMergesReporter->reportChangesWithHeadlines(
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines(
             $this->changes,
             $withCategories,
             $withPackages,
@@ -66,7 +66,7 @@ final class WithTagsTest extends TestCase
             $priority
         );
 
-        $this->assertStringEqualsFile($expectedOutputFile, $this->dumpMergesReporter->getContent());
+        $this->assertStringEqualsFile($expectedOutputFile, $content);
     }
 
     public function provideDataForReportChangesWithHeadlines(): Iterator

--- a/packages/ChangelogLinker/tests/Console/Output/WithTagsTest.php
+++ b/packages/ChangelogLinker/tests/Console/Output/WithTagsTest.php
@@ -35,12 +35,15 @@ final class WithTagsTest extends TestCase
             $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
         }
 
-        $content = $this->dumpMergesReporter->reportChangesWithHeadlines($this->changes, false, false, true, 'categories');
-
-        $this->assertStringEqualsFile(
-            __DIR__ . '/WithTagsSource/expected1.md',
-            $content
+        $content = $this->dumpMergesReporter->reportChangesWithHeadlines(
+            $this->changes,
+            false,
+            false,
+            true,
+            'categories'
         );
+
+        $this->assertStringEqualsFile(__DIR__ . '/WithTagsSource/expected1.md', $content);
     }
 
     /**


### PR DESCRIPTION
Clsoes #889