### PR TITLE
[EasyCodingStandard] Fix custom source provider troubles

### DIFF
--- a/packages/EasyCodingStandard/packages/SniffRunner/src/File/File.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/File/File.php
@@ -191,7 +191,7 @@ final class File extends BaseFile
         }
 
         $this->errorAndDiffCollector->addErrorMessage(
-            $this->path,
+            $this->currentFileProvider->getFileInfo(),
             $line,
             $message,
             $this->resolveFullyQualifiedCode($sniffClassOrCode)

--- a/packages/EasyCodingStandard/src/Application/Application.php
+++ b/packages/EasyCodingStandard/src/Application/Application.php
@@ -115,8 +115,8 @@ final class Application implements FileProcessorCollectorInterface
      */
     private function processFoundFiles(array $fileInfos): void
     {
-        foreach ($fileInfos as $relativePath => $fileInfo) {
-            $this->singleFileProcessor->processFileInfo($fileInfo, $relativePath);
+        foreach ($fileInfos as $fileInfo) {
+            $this->singleFileProcessor->processFileInfo($fileInfo);
         }
     }
 

--- a/packages/EasyCodingStandard/src/Application/SingleFileProcessor.php
+++ b/packages/EasyCodingStandard/src/Application/SingleFileProcessor.php
@@ -63,7 +63,7 @@ final class SingleFileProcessor implements FileProcessorCollectorInterface
         $this->fileProcessors[] = $fileProcessor;
     }
 
-    public function processFileInfo(SplFileInfo $fileInfo, string $relativePath): void
+    public function processFileInfo(SplFileInfo $fileInfo): void
     {
         if ($this->configuration->showProgressBar()) {
             $this->easyCodingStandardStyle->progressAdvance();
@@ -85,7 +85,7 @@ final class SingleFileProcessor implements FileProcessorCollectorInterface
         } catch (ParseError $parseError) {
             $this->changedFilesDetector->invalidateFileInfo($fileInfo);
             $this->errorAndDiffCollector->addErrorMessage(
-                $relativePath,
+                $fileInfo->getRelativePath(),
                 $parseError->getLine(),
                 $parseError->getMessage(),
                 ParseError::class

--- a/packages/EasyCodingStandard/src/Application/SingleFileProcessor.php
+++ b/packages/EasyCodingStandard/src/Application/SingleFileProcessor.php
@@ -85,7 +85,7 @@ final class SingleFileProcessor implements FileProcessorCollectorInterface
         } catch (ParseError $parseError) {
             $this->changedFilesDetector->invalidateFileInfo($fileInfo);
             $this->errorAndDiffCollector->addErrorMessage(
-                $fileInfo->getRelativePath(),
+                $fileInfo,
                 $parseError->getLine(),
                 $parseError->getMessage(),
                 ParseError::class

--- a/packages/EasyCodingStandard/src/Error/ErrorAndDiffCollector.php
+++ b/packages/EasyCodingStandard/src/Error/ErrorAndDiffCollector.php
@@ -4,7 +4,6 @@ namespace Symplify\EasyCodingStandard\Error;
 
 use Nette\Utils\Arrays;
 use Symfony\Component\Finder\SplFileInfo;
-use Symplify\EasyCodingStandard\Application\CurrentFileProvider;
 use Symplify\EasyCodingStandard\ChangedFilesDetector\ChangedFilesDetector;
 
 final class ErrorAndDiffCollector
@@ -39,31 +38,23 @@ final class ErrorAndDiffCollector
      */
     private $errorFactory;
 
-    /**
-     * @var CurrentFileProvider
-     */
-    private $currentFileProvider;
-
     public function __construct(
         ChangedFilesDetector $changedFilesDetector,
         ErrorSorter $errorSorter,
         FileDiffFactory $fileDiffFactory,
-        ErrorFactory $errorFactory,
-        CurrentFileProvider $currentFileProvider
+        ErrorFactory $errorFactory
     ) {
         $this->changedFilesDetector = $changedFilesDetector;
         $this->errorSorter = $errorSorter;
         $this->fileDiffFactory = $fileDiffFactory;
         $this->errorFactory = $errorFactory;
-        $this->currentFileProvider = $currentFileProvider;
     }
 
-    public function addErrorMessage(string $filePath, int $line, string $message, string $sourceClass): void
+    public function addErrorMessage(SplFileInfo $fileInfo, int $line, string $message, string $sourceClass): void
     {
-        $fileInfo = $this->currentFileProvider->getFileInfo();
         $this->changedFilesDetector->invalidateFileInfo($fileInfo);
 
-        $this->errors[$filePath][] = $this->errorFactory->createFromLineMessageSourceClass(
+        $this->errors[$fileInfo->getRelativePath()][] = $this->errorFactory->createFromLineMessageSourceClass(
             $line,
             $message,
             $sourceClass

--- a/packages/EasyCodingStandard/src/Error/ErrorAndDiffCollector.php
+++ b/packages/EasyCodingStandard/src/Error/ErrorAndDiffCollector.php
@@ -54,7 +54,7 @@ final class ErrorAndDiffCollector
     {
         $this->changedFilesDetector->invalidateFileInfo($fileInfo);
 
-        $this->errors[$fileInfo->getRelativePath()][] = $this->errorFactory->createFromLineMessageSourceClass(
+        $this->errors[$fileInfo->getRelativePathname()][] = $this->errorFactory->createFromLineMessageSourceClass(
             $line,
             $message,
             $sourceClass

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/AppendFileSourceProvider.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/AppendFileSourceProvider.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Tests\Finder\SourceFinderSource;
+
+use IteratorAggregate;
+use Symfony\Component\Finder\Finder;
+use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;
+
+final class AppendFileSourceProvider implements CustomSourceProviderInterface
+{
+    /**
+     * @param string[] $source
+     */
+    public function find(array $source): IteratorAggregate
+    {
+        return Finder::create()
+            ->name('#\.php\.inc$#')
+            ->in(__DIR__ . '/Source')
+            ->append([__DIR__ . '/Source/SomeClass.php']);
+    }
+}

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/config-with-append-file-provider.yml
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderSource/config-with-append-file-provider.yml
@@ -1,0 +1,2 @@
+services:
+    Symplify\EasyCodingStandard\Tests\Finder\SourceFinderSource\AppendFileSourceProvider: ~

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
@@ -3,11 +3,22 @@
 namespace Symplify\EasyCodingStandard\Tests\Finder;
 
 use Symplify\EasyCodingStandard\DependencyInjection\ContainerFactory;
+use Symplify\EasyCodingStandard\Finder\FinderSanitizer;
 use Symplify\EasyCodingStandard\Finder\SourceFinder;
 use Symplify\EasyCodingStandard\Tests\AbstractContainerAwareTestCase;
 
 final class SourceFinderTest extends AbstractContainerAwareTestCase
 {
+    /**
+     * @var FinderSanitizer
+     */
+    private $finderSanitizer;
+
+    protected function setUp(): void
+    {
+        $this->finderSanitizer = $this->container->get(FinderSanitizer::class);
+    }
+
     public function test(): void
     {
         /** @var SourceFinder $sourceFinder */
@@ -29,5 +40,20 @@ final class SourceFinderTest extends AbstractContainerAwareTestCase
         $foundFiles = $sourceFinder->find([__DIR__ . '/SourceFinderSource/Source/tests']);
 
         $this->assertCount(1, $foundFiles);
+    }
+
+    public function testAppendFileAndSanitize(): void
+    {
+        $container = (new ContainerFactory())->createWithConfig(
+            __DIR__ . '/SourceFinderSource/config-with-append-file-provider.yml'
+        );
+
+        /** @var SourceFinder $sourceFinder */
+        $sourceFinder = $container->get(SourceFinder::class);
+        $foundFiles = $sourceFinder->find([__DIR__ . '/SourceFinderSource/Source/tests']);
+
+        $foundFiles = $this->finderSanitizer->sanitize($foundFiles);
+
+        $this->assertCount(3, $foundFiles);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,8 @@
 parameters:
     ignoreErrors:
+        # part of test / bugged
+        - '#Parameter \#1 \$finder of method Symplify\\EasyCodingStandard\\Finder\\FinderSanitizer::sanitize\(\) expects \(iterable<SplFileInfo>&Nette\\Utils\\Finder\)\|Symfony\\Component\\Finder\\Finder, (array<int, SplFileInfo>|array<Symfony\\Component\\Finder\\SplFileInfo>|(Nette\\Utils\\Finder\|Symfony\\Component\\Finder\\Finder)) given#'
+
         # temporary
         - '#Parameter \#1 \$e of method Symfony\\Component\\Console\\Application::renderException\(\) expects Exception, Throwable given#'
 
@@ -48,9 +51,6 @@ parameters:
         # object
         - '#does not accept object#'
         - '#Call to an undefined method object#'
-
-        # part of test
-        - '#Parameter \#1 \$finder of method Symplify\\EasyCodingStandard\\Finder\\FinderSanitizer::sanitize\(\) expects Nette\\Utils\\Finder|Symfony\\Component\\Finder\\Finder, SplFileInfo\[\] given#'
 
         # intersect/union buggy
         - '#Parameter \#(2|3) \$items of method PhpCsFixer\\Tokenizer\\Tokens::(insertAt|overrideRange)\(\) expects (\()?iterable<PhpCsFixer\\Tokenizer\\Token>&PhpCsFixer\\Tokenizer\\Tokens(\))?(\|PhpCsFixer\\Tokenizer\\Token)?, array<(int, )?PhpCsFixer\\Tokenizer\\Token> given#'


### PR DESCRIPTION
Closes #939

This allows

```php
 <?php declare(strict_types=1);

 namespace Shopsys\CodingStandards\Finder;

 use IteratorAggregate;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
 use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;

 final class FileFinder implements CustomSourceProviderInterface
 {
     /**
      * @param string[] $source
      * @return IteratorAggregate
      */
     public function find(array $source): IteratorAggregate
     {
         $directories = [];
         $files = [];
         foreach ($source as $singleSource) {
             if (is_file($singleSource)) {
                 $fileInfo = new SplFileInfo($singleSource);
                 $files[$fileInfo->getPath()] = new SymfonySplFileInfo($singleSource, $fileInfo->getPath(), $fileInfo->getPathname());
             } else {
                 $directories[] = $singleSource;
             }
         }

         $finder = Finder::create()->files()
             ->name('#\.(twig|html.twig|php|js)$#')
             ->in($directories);

+        $finder->append($files);
-        $finder->append(new \ArrayIterator($files));

         return $finder;
     }
 }
```