### PR TITLE
[EasyCodingStandard] Make fnmatch skipping more user-friendly [closes #942]

### DIFF
--- a/packages/EasyCodingStandard/src/Skipper.php
+++ b/packages/EasyCodingStandard/src/Skipper.php
@@ -146,15 +146,15 @@ final class Skipper
      * Supports both relative and absolute $file path.
      * They differ for PHP-CS-Fixer and PHP_CodeSniffer.
      */
-    private function fileMatchesPattern(string $file, string $ignoredPath): bool
+    private function fileMatchesPattern(string $absoluteFilePath, string $ignoredPath): bool
     {
-        $file = str_replace('\\', '/', $file);
+        $absoluteFilePath = str_replace('\\', '/', $absoluteFilePath);
 
-        if (Strings::endsWith($file, $ignoredPath)) {
+        if (Strings::endsWith($absoluteFilePath, $ignoredPath)) {
             return true;
         }
 
-        return fnmatch($ignoredPath, $file) || fnmatch($ignoredPath, '*/' . $file);
+        return fnmatch($ignoredPath, $absoluteFilePath) || fnmatch('*/' . $ignoredPath, $absoluteFilePath);
     }
 
     private function removeEmptyUnusedSkipped(string $skippedChecker): void

--- a/packages/EasyCodingStandard/tests/Skipper/SkipperTest.php
+++ b/packages/EasyCodingStandard/tests/Skipper/SkipperTest.php
@@ -57,6 +57,11 @@ final class SkipperTest extends TestCase
             'someSniff.someOtherCode',
             __DIR__ . '/someDirectory/someFile'
         ));
+
+        $this->assertTrue($this->skipper->shouldSkipCodeAndFile(
+            'someSniff.someAnotherCode',
+            __DIR__ . '/someDirectory/someFile'
+        ));
     }
 
     /**
@@ -68,6 +73,7 @@ final class SkipperTest extends TestCase
             DeclareStrictTypesFixer::class => ['someFile', '*/someDirectory/*'],
             'someSniff.someCode' => null,
             'someSniff.someOtherCode' => ['*/someDirectory/*'],
+            'someSniff.someAnotherCode' => ['someDirectory/*'],
         ];
     }
 }


### PR DESCRIPTION
### Before

```yaml
parameters:
    skip:
        SomeClass:
            # this doesn't work
            - 'packages/LatteToTwigConverter/src/CaseConverter/*CaseConverter.php'

            # this does    
            - '*packages/LatteToTwigConverter/src/CaseConverter/*CaseConverter.php'
```

### After

```yaml
parameters:
    skip:
        SomeClass:
            # works!
            - 'packages/LatteToTwigConverter/src/CaseConverter/*CaseConverter.php'
            - '*packages/LatteToTwigConverter/src/CaseConverter/*CaseConverter.php'
```
