### PR TITLE
[ChangelogLinker] [MonorepoBuilder] Fix Travis-related Tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: php
 
+# required for "git tag" presence for MonorepoBuilder split and ChangelogLinker git tags resolver
+# see https://github.com/travis-ci/travis-ci/issues/7422
+git:
+  depth: false
+
 matrix:
   include:
     - php: 7.1

--- a/packages/ChangelogLinker/tests/ChangeTree/ChangeFactoryTest.php
+++ b/packages/ChangelogLinker/tests/ChangeTree/ChangeFactoryTest.php
@@ -94,11 +94,6 @@ final class ChangeFactoryTest extends TestCase
 
     public function testTagDetection(): void
     {
-        // @see https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-        if (getenv('TRAVIS')) {
-            $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
-        }
-
         $pullRequest = [
             'number' => 10,
             'title' => '[SomePackage] SomeMessage',

--- a/packages/ChangelogLinker/tests/ChangelogDumper/WithTagsTest.php
+++ b/packages/ChangelogLinker/tests/ChangelogDumper/WithTagsTest.php
@@ -30,11 +30,6 @@ final class WithTagsTest extends TestCase
 
     public function testReportChanges(): void
     {
-        // @see https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-        if (getenv('TRAVIS')) {
-            $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
-        }
-
         $content = $this->changelogDumper->reportChangesWithHeadlines($this->changes, false, false, 'categories');
 
         $this->assertStringEqualsFile(__DIR__ . '/WithTagsSource/expected1.md', $content);
@@ -49,11 +44,6 @@ final class WithTagsTest extends TestCase
         ?string $priority,
         string $expectedOutputFile
     ): void {
-        // @see https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-        if (getenv('TRAVIS')) {
-            $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
-        }
-
         $content = $this->changelogDumper->reportChangesWithHeadlines(
             $this->changes,
             $withCategories,

--- a/packages/ChangelogLinker/tests/Git/GitCommitDateTagResolverTest.php
+++ b/packages/ChangelogLinker/tests/Git/GitCommitDateTagResolverTest.php
@@ -15,11 +15,6 @@ final class GitCommitDateTagResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        // @see https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
-        if (getenv('TRAVIS')) {
-            $this->markTestSkipped('Travis makes shallow clones, so unable to test commits/tags.');
-        }
-
         $this->gitCommitDateTagResolver = new GitCommitDateTagResolver();
     }
 


### PR DESCRIPTION
Closes #866

Closes #937 as not a big performance issue

Related  https://github.com/travis-ci/travis-ci/issues/7422

The full git clone is like 3 seconds, so no problem at all:

![image](https://user-images.githubusercontent.com/924196/42512300-88a89288-8454-11e8-86f4-fa0bf6d8e34e.png)
