### PR TITLE
CHANGELOG: Correct ClassNameSuffixByParentSniff migration instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ PRs and issues are linked, so you can find more about it. Thanks to [ChangelogLi
     ```yaml
     services:
         Symplify\CodingStandard\Sniffs\Naming\ClassNameSuffixByParentSniff:
-            parentTypesToSuffixes:
+            defaultParentClassToSuffixMap:
                 - 'Command'
                 - 'Controller'
             extraParentTypesToSuffixes:


### PR DESCRIPTION
Instead of property `parent_types_to_suffixes` in `ClassNameSuffixByParentFixer` one should use `defaultParentClassToSuffixMap` when migrating to `ClassNameSuffixByParentSniff`.
See https://github.com/Symplify/Symplify/issues/985.