### PR TITLE
[PackageBuilder] Add PublicDefaultCompilerPass

### DIFF
--- a/packages/ChangelogLinker/src/DependencyInjection/ChangelogLinkerKernel.php
+++ b/packages/ChangelogLinker/src/DependencyInjection/ChangelogLinkerKernel.php
@@ -8,6 +8,7 @@ use Symplify\ChangelogLinker\DependencyInjection\CompilerPass\CollectorCompilerP
 use Symplify\ChangelogLinker\DependencyInjection\CompilerPass\DetectParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\AbstractCliKernel;
 
@@ -53,5 +54,6 @@ final class ChangelogLinkerKernel extends AbstractCliKernel
         $containerBuilder->addCompilerPass(new DetectParametersCompilerPass());
         $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
+        $containerBuilder->addCompilerPass(new PublicDefaultCompilerPass());
     }
 }

--- a/packages/ChangelogLinker/src/config/services.yml
+++ b/packages/ChangelogLinker/src/config/services.yml
@@ -3,8 +3,7 @@ services:
         resource: ".."
         exclude: "../{Contract,Exception,ChangeTree/Change.php}"
 
-    Symplify\PackageBuilder\Console\ConfigAwareApplication:
-        public: true # for bin file
+    Symplify\PackageBuilder\Console\ConfigAwareApplication: ~
 
     Symplify\PackageBuilder\Yaml\ParametersMerger: ~
 

--- a/packages/EasyCodingStandard/src/DependencyInjection/EasyCodingStandardKernel.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/EasyCodingStandardKernel.php
@@ -18,6 +18,7 @@ use Symplify\EasyCodingStandard\DependencyInjection\CompilerPass\RemoveMutualChe
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\AbstractCliKernel;
 
@@ -80,8 +81,9 @@ final class EasyCodingStandardKernel extends AbstractCliKernel
         // exceptions
         $containerBuilder->addCompilerPass(new ConflictingCheckersCompilerPass());
 
-        // autowire
+        // autowire + public
         $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
+        $containerBuilder->addCompilerPass(new PublicDefaultCompilerPass());
 
         // tests
         $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());

--- a/packages/EasyCodingStandard/src/config/services.yml
+++ b/packages/EasyCodingStandard/src/config/services.yml
@@ -3,8 +3,7 @@ services:
         resource: '../../src'
         exclude: '../../src/{Contract,DependencyInjection,Exception,Error/Error.php,Error/FileDiff.php,Yaml}'
 
-    Symplify\EasyCodingStandard\Console\Application:
-        public: true
+    Symplify\EasyCodingStandard\Console\Application: ~
 
     _instanceof:
         Symplify\EasyCodingStandard\Contract\Application\FileProcessorCollectorInterface:

--- a/packages/LatteToTwigConverter/src/DependencyInjection/LatteToTwigConverterKernel.php
+++ b/packages/LatteToTwigConverter/src/DependencyInjection/LatteToTwigConverterKernel.php
@@ -6,6 +6,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symplify\LatteToTwigConverter\DependencyInjection\CompilerPass\CollectorCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\AbstractCliKernel;
 
@@ -34,5 +35,6 @@ final class LatteToTwigConverterKernel extends AbstractCliKernel
         $containerBuilder->addCompilerPass(new CollectorCompilerPass());
         $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
+        $containerBuilder->addCompilerPass(new PublicDefaultCompilerPass());
     }
 }

--- a/packages/LatteToTwigConverter/src/DependencyInjection/LatteToTwigConverterKernel.php
+++ b/packages/LatteToTwigConverter/src/DependencyInjection/LatteToTwigConverterKernel.php
@@ -5,6 +5,7 @@ namespace Symplify\LatteToTwigConverter\DependencyInjection;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symplify\LatteToTwigConverter\DependencyInjection\CompilerPass\CollectorCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\AbstractCliKernel;
 
@@ -32,5 +33,6 @@ final class LatteToTwigConverterKernel extends AbstractCliKernel
     {
         $containerBuilder->addCompilerPass(new CollectorCompilerPass());
         $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
+        $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
     }
 }

--- a/packages/LatteToTwigConverter/src/config/config.yml
+++ b/packages/LatteToTwigConverter/src/config/config.yml
@@ -3,8 +3,7 @@ services:
         resource: ".."
         exclude: "../{Contract}"
 
-    Symfony\Component\Console\Application:
-        public: true
+    Symfony\Component\Console\Application: ~
 
     # SymfonyStyle
     Symfony\Component\Console\Input\ArgvInput: ~

--- a/packages/MonorepoBuilder/src/DependencyInjection/MonorepoBuilderKernel.php
+++ b/packages/MonorepoBuilder/src/DependencyInjection/MonorepoBuilderKernel.php
@@ -50,7 +50,5 @@ final class MonorepoBuilderKernel extends AbstractCliKernel
         $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
-
-        // autowire default all from local configs
     }
 }

--- a/packages/MonorepoBuilder/src/DependencyInjection/MonorepoBuilderKernel.php
+++ b/packages/MonorepoBuilder/src/DependencyInjection/MonorepoBuilderKernel.php
@@ -8,6 +8,7 @@ use Symplify\MonorepoBuilder\DependencyInjection\CompilerPass\CollectorCompilerP
 use Symplify\MonorepoBuilder\Split\DependencyInjection\CompilerPass\DetectParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\AbstractCliKernel;
 
@@ -50,5 +51,6 @@ final class MonorepoBuilderKernel extends AbstractCliKernel
         $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
+        $containerBuilder->addCompilerPass(new PublicDefaultCompilerPass());
     }
 }

--- a/packages/MonorepoBuilder/src/config/config.yml
+++ b/packages/MonorepoBuilder/src/config/config.yml
@@ -15,8 +15,7 @@ services:
 
     Symplify\PackageBuilder\Yaml\ParametersMerger: ~
 
-    Symplify\PackageBuilder\Console\ConfigAwareApplication:
-        public: true # for bin file
+    Symplify\PackageBuilder\Console\ConfigAwareApplication: ~
 
     # SymfonyStyle
     Symfony\Component\Console\Input\ArgvInput: ~

--- a/packages/PackageBuilder/README.md
+++ b/packages/PackageBuilder/README.md
@@ -15,7 +15,7 @@ composer require symplify/package-builder
 
 ## Usage
 
-### 1.Usage in Symfony CompilerPass
+### 1. Usage in Symfony CompilerPass
 
 #### Collect Services of Certain Type Together
 
@@ -472,6 +472,41 @@ $parameterBag = $parametersMergingYamlLoader->loadParameterBagFromFile(__DIR__ .
 
 var_dump($parameterBag);
 // instance of "Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface"
+```
+
+### 12. Do You Use Default Autowiring Everywhere?
+
+Great job! Why to repeat it in every single config?
+
+```diff
+ services:
+-    _defaults:
+-        autowire: true
+
+     Symplify\Statie\:
+         resource: '../../src'
+```
+
+Just use `Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass`:
+
+```php
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
+
+final class AppKernel extends Kernel
+{
+    // ...
+
+    protected function build(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
+    }
+}
 ```
 
 That's all :)

--- a/packages/PackageBuilder/README.md
+++ b/packages/PackageBuilder/README.md
@@ -509,4 +509,39 @@ final class AppKernel extends Kernel
 }
 ```
 
+### 13. Do You Use Public Services Only When Really Need?
+
+Great job! Why to repeat `public: true` in config everytime you need it?
+
+```diff
+ services:
+-    _defaults:
+-        public: true
+
+     Symplify\Statie\:
+         resource: '../../src'
+```
+
+Just use `Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass`:
+
+```php
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass;
+
+final class AppKernel extends Kernel
+{
+    // ...
+
+    protected function build(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->addCompilerPass(new PublicDefaultCompilerPass());
+    }
+}
+```
+
 That's all :)

--- a/packages/PackageBuilder/src/DependencyInjection/CompilerPass/PublicDefaultCompilerPass.php
+++ b/packages/PackageBuilder/src/DependencyInjection/CompilerPass/PublicDefaultCompilerPass.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Make services public to get rid of troubles.
+ */
+final class PublicDefaultCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $containerBuilder): void
+    {
+        foreach ($containerBuilder->getDefinitions() as $definition) {
+            $definition->setPublic(true);
+        }
+
+        foreach ($containerBuilder->getAliases() as $definition) {
+            $definition->setPublic(true);
+        }
+    }
+}

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutoBindParametersCompilerPass/Source/config.yml
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutoBindParametersCompilerPass/Source/config.yml
@@ -2,5 +2,4 @@ parameters:
     someParameter: value
 
 services:
-    Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass\Source\ServiceWithAutowiredParameter:
-        public: true
+    Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass\Source\ServiceWithAutowiredParameter: ~

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutoBindParametersCompilerPass/Source/config.yml
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutoBindParametersCompilerPass/Source/config.yml
@@ -2,4 +2,5 @@ parameters:
     someParameter: value
 
 services:
-    Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass\Source\ServiceWithAutowiredParameter: ~
+    Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass\Source\ServiceWithAutowiredParameter:
+        public: true

--- a/packages/Statie/src/DependencyInjection/StatieKernel.php
+++ b/packages/Statie/src/DependencyInjection/StatieKernel.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicDefaultCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\Yaml\AbstractParameterMergingYamlFileLoader;
 use Symplify\Statie\DependencyInjection\CompilerPass\CollectorCompilerPass;
@@ -71,6 +72,7 @@ final class StatieKernel extends Kernel
         $containerBuilder->addCompilerPass(new AutowireSinglyImplementedCompilerPass());
         $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireDefaultCompilerPass());
+        $containerBuilder->addCompilerPass(new PublicDefaultCompilerPass());
     }
 
     /**

--- a/packages/Statie/src/config/services.yml
+++ b/packages/Statie/src/config/services.yml
@@ -4,5 +4,4 @@ services:
         exclude: '../../src/{Exception,Renderable/File/File.php,Renderable/File/PostFile.php,Event}'
 
     # bin file
-    Symplify\Statie\Console\Application:
-        public: true
+    Symplify\Statie\Console\Application: ~


### PR DESCRIPTION
To get rid of cherry-picking public: true/false. It really has no added value in those packages