### PR TITLE
[MonorepoBuilder] Fix autoloading for overlapping namespaces

### DIFF
--- a/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
+++ b/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
@@ -92,7 +92,7 @@ final class AutoloadRelativePathComposerJsonDecorator implements ComposerJsonDec
             foreach ($packageComposerFiles as $packageComposerFile) {
                 $namespaceWithSlashes = addslashes($namespace);
 
-                if (! Strings::contains($packageComposerFile->getContents(), $namespaceWithSlashes)) {
+                if (! Strings::contains($packageComposerFile->getContents(), '"' . $namespaceWithSlashes . '"')) {
                     continue;
                 }
 

--- a/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/AutoloadRelativePathComposerJsonDecoratorTest.php
+++ b/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/AutoloadRelativePathComposerJsonDecoratorTest.php
@@ -23,6 +23,20 @@ final class AutoloadRelativePathComposerJsonDecoratorTest extends TestCase
     ];
 
     /**
+     * @var mixed[]
+     */
+    private $composerJsonWithOverlappingNamespaces = [
+        'autoload' => [
+            'psr-4' => [
+                'App\\' => 'src',
+                'App\\PackageB\\' => 'src',
+                'Shopsys\\' => ['app/', 'src/Shopsys/'],
+                'Shopsys\\PackageB\\' => ['app/', 'src/Shopsys/'],
+            ],
+        ],
+    ];
+
+    /**
      * @var AutoloadRelativePathComposerJsonDecorator
      */
     private $autoloadRelativePathComposerJsonDecorator;
@@ -41,6 +55,22 @@ final class AutoloadRelativePathComposerJsonDecoratorTest extends TestCase
         $decorated = $this->autoloadRelativePathComposerJsonDecorator->decorate($this->composerJson);
 
         $this->assertSame($this->getExpectedComposerJson(), $decorated);
+    }
+
+    public function testOverlappingNamespaces(): void
+    {
+        $packageComposerFinder = new PackageComposerFinder([
+            __DIR__ . '/SourceOverlappingNamespaces/PackageA',
+            __DIR__ . '/SourceOverlappingNamespaces/PackageB',
+        ]);
+
+        $autoloadRelativePathComposerJsonDecorator = new AutoloadRelativePathComposerJsonDecorator(
+            $packageComposerFinder
+        );
+
+        $decorated = $autoloadRelativePathComposerJsonDecorator->decorate($this->composerJsonWithOverlappingNamespaces);
+
+        $this->assertSame($this->getExpectedComposerJsonWithOverlappingNamespaces(), $decorated);
     }
 
     /**
@@ -63,10 +93,40 @@ final class AutoloadRelativePathComposerJsonDecoratorTest extends TestCase
         ];
     }
 
+    /**
+     * @return mixed[]
+     */
+    private function getExpectedComposerJsonWithOverlappingNamespaces(): array
+    {
+        return [
+            'autoload' => [
+                'psr-4' => [
+                    'App\\' => $this->getRelativeOverlappingSourcePath() . '/PackageA/src',
+                    'App\\PackageB\\' => $this->getRelativeOverlappingSourcePath() . '/PackageB/src',
+                    'Shopsys\\' => [
+                        $this->getRelativeOverlappingSourcePath() . '/PackageA/app/',
+                        $this->getRelativeOverlappingSourcePath() . '/PackageA/src/Shopsys/',
+                    ],
+                    'Shopsys\\PackageB\\' => [
+                        $this->getRelativeOverlappingSourcePath() . '/PackageB/app/',
+                        $this->getRelativeOverlappingSourcePath() . '/PackageB/src/Shopsys/',
+                    ],
+                ],
+            ],
+        ];
+    }
+
     private function getRelativeSourcePath(): string
     {
         $prefix = defined('SYMPLIFY_MONOREPO') ? 'packages/MonorepoBuilder/' : '';
 
         return $prefix . 'tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/Source';
+    }
+
+    private function getRelativeOverlappingSourcePath(): string
+    {
+        $prefix = defined('SYMPLIFY_MONOREPO') ? 'packages/MonorepoBuilder/' : '';
+
+        return $prefix . 'tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/SourceOverlappingNamespaces';
     }
 }

--- a/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/SourceOverlappingNamespaces/PackageA/composer.json
+++ b/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/SourceOverlappingNamespaces/PackageA/composer.json
@@ -1,0 +1,11 @@
+{
+    "autoload": {
+        "psr-4": {
+            "App\\": "src",
+            "Shopsys\\": [
+                "app/",
+                "src/Shopsys/"
+            ]
+        }
+    }
+}

--- a/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/SourceOverlappingNamespaces/PackageB/composer.json
+++ b/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/SourceOverlappingNamespaces/PackageB/composer.json
@@ -1,0 +1,11 @@
+{
+    "autoload": {
+        "psr-4": {
+            "App\\PackageB\\": "src",
+            "Shopsys\\PackageB\\": [
+                "app/",
+                "src/Shopsys/"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
There is a problem when two packages are using namespaces like `App` and `App\Foo`.

Currently only the namespace itself is checked to be contained within a `composer.json`, so when you have a namespace `App` it will be found in each `composer.json` using `App\<whatever>` and the path of the last matching `composer.json` will be taken.

I tried to fix this by adding quotation marks for the lookup, so partial matches won't be successful anymore.