### PR TITLE
[ChangelogLinker] improve regexes for guessing the type of change

### DIFF
--- a/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php
+++ b/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php
@@ -10,22 +10,22 @@ final class ChangeFactory
     /**
      * @var string
      */
-    private const ADDED_PATTERN = '#(add|added|adds) #i';
+    private const ADDED_PATTERN = '#\b(add(s|ed|ing)?)\b#i';
 
     /**
      * @var string
      */
-    private const FIXED_PATTERN = '#(fix(es|ed)?)#i';
+    private const FIXED_PATTERN = '#\b(fix(es|ed|ing)?)\b#i';
 
     /**
      * @var string
      */
-    private const CHANGED_PATTERN = '#( change| improve|( now )|bump|improve|allow|return|rename|decouple)#i';
+    private const CHANGED_PATTERN = '#\b(chang(e|es|ed|ing)|improv(e|es|ed|ing)|bump(s|ed|ing)?|(dis)?allow(s|ed|ing)?|return(s|ed|ing)?|renam(e|es|ed|ing)|decoupl(e|es|ed|ing)|now)\b#i';
 
     /**
      * @var string
      */
-    private const REMOVED_PATTERN = '#remove(d)?|delete(d)|drop|dropped?#i';
+    private const REMOVED_PATTERN = '#\b(remov(e|es|ed|ing)|delet(e|es|ed|ing|)|drop(s|ped|ping)?)\b#i';
 
     /**
      * @var GitCommitDateTagResolver

--- a/packages/ChangelogLinker/tests/ChangeTree/ChangeFactoryTest.php
+++ b/packages/ChangelogLinker/tests/ChangeTree/ChangeFactoryTest.php
@@ -49,6 +49,37 @@ final class ChangeFactoryTest extends TestCase
         yield ['Improve behavior', 'Changed', 'Unknown Package'];
         yield ['Remove this', 'Removed', 'Unknown Package'];
         yield ['All was deleted', 'Removed', 'Unknown Package'];
+
+        yield ['New design of a hydroplane', 'Unknown Category', 'Unknown Package'];
+        yield ['Removing all classes ending "Adapter" for no reason', 'Removed', 'Unknown Package'];
+        yield ['[Skeleton] Deletes unnecessary templates', 'Removed', 'Skeleton'];
+        
+        yield from $this->provideDataForCategoryKeywords(['add', 'adds', 'added', 'adding'], 'Added');
+        
+        yield from $this->provideDataForCategoryKeywords(['fix', 'fixes', 'fixed', 'fixing'], 'Fixed');
+        
+        yield from $this->provideDataForCategoryKeywords(['change', 'changes', 'changed', 'changing'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['improve', 'improves', 'improved', 'improving'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['bump', 'bumps', 'bumped', 'bumping'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['allow', 'allows', 'allowed', 'allowing'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['disallow', 'disallows', 'disallowed', 'disallowing'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['return', 'returns', 'returned', 'returning'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['rename', 'renames', 'renamed', 'renaming'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['decouple', 'decouples', 'decoupled', 'decoupling'], 'Changed');
+        yield from $this->provideDataForCategoryKeywords(['now'], 'Changed');
+        
+        yield from $this->provideDataForCategoryKeywords(['remove', 'removes', 'removed', 'removing'], 'Removed');
+        yield from $this->provideDataForCategoryKeywords(['delete', 'deletes', 'deleted', 'deleting'], 'Removed');
+        yield from $this->provideDataForCategoryKeywords(['drop', 'drops', 'dropped', 'dropping'], 'Removed');
+    }
+    
+    private function provideDataForCategoryKeywords(array $keywords, string $expectedCategory): Iterator
+    {
+        foreach ($keywords as $keyword) {
+            yield [$keyword, $expectedCategory, 'Unknown Package'];
+            yield ['prefix' . $keyword, 'Unknown Category', 'Unknown Package'];
+            yield [$keyword . 'postfix', 'Unknown Category', 'Unknown Package'];
+        } 
     }
 
     public function testEgoTag(): void

--- a/packages/ChangelogLinker/tests/ChangeTree/ChangeFactoryTest.php
+++ b/packages/ChangelogLinker/tests/ChangeTree/ChangeFactoryTest.php
@@ -72,7 +72,10 @@ final class ChangeFactoryTest extends TestCase
         yield from $this->provideDataForCategoryKeywords(['delete', 'deletes', 'deleted', 'deleting'], 'Removed');
         yield from $this->provideDataForCategoryKeywords(['drop', 'drops', 'dropped', 'dropping'], 'Removed');
     }
-    
+
+    /**
+     * @param string[] $keywords
+     */
     private function provideDataForCategoryKeywords(array $keywords, string $expectedCategory): Iterator
     {
         foreach ($keywords as $keyword) {


### PR DESCRIPTION
- original regexes contained a few issues (like not matching "delete")
- regexes now have common structure
- matching whole words only
- matching past tenses and present participles

I've noticed an issue in 139f0b8111b81f6e104b71a6c20af7ed10548610, when the new cases were inserted into a wrong place - before the question mark instead of behind it. It started matching "droppe" and stopped matching "delete".

I would suggest using word boundaries (`\b`), otherwise it would match even a part of a word (and that would mean the past tenses were redundant - eg. `drop` always matches "dropped").

Also, I would suggest adding present participles as they often appear in PR titles in my experience.

See the original regex for matching removals in action at https://regex101.com/r/uLeG8b/1/ and the suggested one at https://regex101.com/r/uLeG8b/2.