### PR TITLE
[ECS] Allow combination of --level and --config [closes #1072]

### DIFF
--- a/packages/EasyCodingStandard/bin/container.php
+++ b/packages/EasyCodingStandard/bin/container.php
@@ -5,25 +5,24 @@ use Symplify\EasyCodingStandard\DependencyInjection\ContainerFactory;
 use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
 use Symplify\PackageBuilder\Configuration\LevelFileFinder;
 
-// 1. Detect configuration from level option
-$configFile = (new LevelFileFinder())->detectFromInputAndDirectory(new ArgvInput(), __DIR__ . '/../config/');
+// Detect configuration from level option
+$configFiles = [];
+$configFiles[] = (new LevelFileFinder())->detectFromInputAndDirectory(new ArgvInput(), __DIR__ . '/../config/');
 
-// 2. Fallback to config option
-if ($configFile === null) {
-    ConfigFileFinder::detectFromInput('ecs', new ArgvInput());
-    // 3. Fallback to root file
-    $configFile = ConfigFileFinder::provide(
-        'ecs',
-        ['easy-coding-standard.yml', 'easy-coding-standard.yaml', 'ecs.yml', 'ecs.yaml']
-    );
-} else {
-    ConfigFileFinder::set('ecs', $configFile);
-}
+// Fallback to config option
+ConfigFileFinder::detectFromInput('ecs', new ArgvInput());
+$configFiles[] = ConfigFileFinder::provide(
+    'ecs',
+    ['easy-coding-standard.yml', 'easy-coding-standard.yaml', 'ecs.yml', 'ecs.yaml']
+);
 
-// 4. Build DI container
+// remove empty values
+$configFiles = array_filter($configFiles);
+
+// Build DI container
 $containerFactory = new ContainerFactory();
-if ($configFile) {
-    return $containerFactory->createWithConfig($configFile);
+if ($configFiles) {
+    return $containerFactory->createWithConfigs($configFiles);
 }
 
 return $containerFactory->create();

--- a/packages/EasyCodingStandard/packages/FixerRunner/tests/Application/FileProcessorTest.php
+++ b/packages/EasyCodingStandard/packages/FixerRunner/tests/Application/FileProcessorTest.php
@@ -18,8 +18,8 @@ final class FileProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/FileProcessorSource/easy-coding-standard.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/FileProcessorSource/easy-coding-standard.yml']
         );
 
         $this->fixerFileProcessor = $container->get(FixerFileProcessor::class);

--- a/packages/EasyCodingStandard/packages/FixerRunner/tests/DependencyInjection/FixerServiceRegistrationTest.php
+++ b/packages/EasyCodingStandard/packages/FixerRunner/tests/DependencyInjection/FixerServiceRegistrationTest.php
@@ -15,8 +15,8 @@ final class FixerServiceRegistrationTest extends TestCase
 {
     public function test(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/FixerServiceRegistrationSource/easy-coding-standard.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/FixerServiceRegistrationSource/easy-coding-standard.yml']
         );
 
         /** @var FixerFileProcessor $fixerFileProcessor */
@@ -45,8 +45,8 @@ final class FixerServiceRegistrationTest extends TestCase
             StrictParamFixer::class
         ));
 
-        (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/FixerServiceRegistrationSource/non-configurable-fixer.yml'
+        (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/FixerServiceRegistrationSource/non-configurable-fixer.yml']
         );
     }
 }

--- a/packages/EasyCodingStandard/packages/SniffRunner/tests/Application/FileProcessorTest.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/tests/Application/FileProcessorTest.php
@@ -21,8 +21,8 @@ final class FileProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/FileProcessorSource/easy-coding-standard.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/FileProcessorSource/easy-coding-standard.yml']
         );
 
         $this->sniffFileProcessor = $container->get(SniffFileProcessor::class);
@@ -48,8 +48,8 @@ final class FileProcessorTest extends TestCase
 
     public function testFileProvingNeedOfProperSupportOfChangesets(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/FileProcessorSource/ReferenceUsedNamesOnlySniff/easy-coding-standard.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/FileProcessorSource/ReferenceUsedNamesOnlySniff/easy-coding-standard.yml']
         );
 
         $fileInfo = new SplFileInfo(

--- a/packages/EasyCodingStandard/packages/SniffRunner/tests/DI/SniffServiceRegistrationTest.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/tests/DI/SniffServiceRegistrationTest.php
@@ -11,8 +11,8 @@ final class SniffServiceRegistrationTest extends TestCase
 {
     public function test(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/SniffServiceRegistrationSource/easy-coding-standard.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/SniffServiceRegistrationSource/easy-coding-standard.yml']
         );
 
         /** @var SniffFileProcessor $sniffFileProcessor */

--- a/packages/EasyCodingStandard/src/DependencyInjection/ContainerFactory.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/ContainerFactory.php
@@ -14,10 +14,13 @@ final class ContainerFactory
         return $appKernel->getContainer();
     }
 
-    public function createWithConfig(string $config): ContainerInterface
+    /**
+     * @param string[] $configs
+     */
+    public function createWithConfigs(array $configs): ContainerInterface
     {
-        $kernel = new EasyCodingStandardKernel();
-        $kernel->bootWithConfig($config);
+        $kernel = new EasyCodingStandardKernel($configs);
+        $kernel->boot();
 
         return $kernel->getContainer();
     }

--- a/packages/EasyCodingStandard/tests/DependencyInjection/ConfigurationFileTest.php
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/ConfigurationFileTest.php
@@ -11,7 +11,9 @@ final class ConfigurationFileTest extends TestCase
 {
     public function testEmptyConfig(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(__DIR__ . '/ConfigurationFileSource/empty-config.yml');
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/ConfigurationFileSource/empty-config.yml']
+        );
 
         /** @var FixerFileProcessor $fixerFileProcessor */
         $fixerFileProcessor = $container->get(FixerFileProcessor::class);
@@ -24,8 +26,8 @@ final class ConfigurationFileTest extends TestCase
 
     public function testIncludeConfig(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/ConfigurationFileSource/include-another-config.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/ConfigurationFileSource/include-another-config.yml']
         );
 
         /** @var FixerFileProcessor $fixerFileProcessor */

--- a/packages/EasyCodingStandard/tests/DependencyInjection/ConflictingCheckersTest.php
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/ConflictingCheckersTest.php
@@ -12,6 +12,6 @@ final class ConflictingCheckersTest extends TestCase
     {
         $this->expectException(ConflictingCheckersLoadedException::class);
 
-        (new ContainerFactory())->createWithConfig(__DIR__ . '/ConflictingCheckersSource/config.yml');
+        (new ContainerFactory())->createWithConfigs([__DIR__ . '/ConflictingCheckersSource/config.yml']);
     }
 }

--- a/packages/EasyCodingStandard/tests/DependencyInjection/ContainerFactoryTest.php
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/ContainerFactoryTest.php
@@ -29,8 +29,8 @@ final class ContainerFactoryTest extends TestCase
 
     public function testCreateFromConfig(): void
     {
-        $container = $this->containerFactory->createWithConfig(
-            __DIR__ . '/ContainerFactorySource/normal-config.yml'
+        $container = $this->containerFactory->createWithConfigs(
+            [__DIR__ . '/ContainerFactorySource/normal-config.yml']
         );
         $this->assertInstanceOf(ContainerInterface::class, $container);
 
@@ -47,8 +47,8 @@ final class ContainerFactoryTest extends TestCase
             LineLengthSniff::class
         ));
 
-        $this->containerFactory->createWithConfig(
-            __DIR__ . '/ContainerFactorySource/config-with-typo-in-configuration.yml'
+        $this->containerFactory->createWithConfigs(
+            [__DIR__ . '/ContainerFactorySource/config-with-typo-in-configuration.yml']
         );
     }
 }

--- a/packages/EasyCodingStandard/tests/DependencyInjection/ExcludedCheckersTest.php
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/ExcludedCheckersTest.php
@@ -10,7 +10,7 @@ final class ExcludedCheckersTest extends TestCase
 {
     public function test(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(__DIR__ . '/ExcludedCheckersSource/config.yml');
+        $container = (new ContainerFactory())->createWithConfigs([__DIR__ . '/ExcludedCheckersSource/config.yml']);
 
         /** @var FixerFileProcessor $fixerFileProcessor */
         $fixerFileProcessor = $container->get(FixerFileProcessor::class);

--- a/packages/EasyCodingStandard/tests/DependencyInjection/MutualExcludedCheckersTest.php
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/MutualExcludedCheckersTest.php
@@ -11,7 +11,9 @@ final class MutualExcludedCheckersTest extends TestCase
 {
     public function test(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(__DIR__ . '/MutualExcludedCheckersSource/config.yml');
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/MutualExcludedCheckersSource/config.yml']
+        );
 
         /** @var FixerFileProcessor $fixerFileProcessor */
         $fixerFileProcessor = $container->get(FixerFileProcessor::class);

--- a/packages/EasyCodingStandard/tests/Error/ErrorCollector/FixerFileProcessorTest.php
+++ b/packages/EasyCodingStandard/tests/Error/ErrorCollector/FixerFileProcessorTest.php
@@ -22,8 +22,8 @@ final class FixerFileProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/FixerRunnerSource/phpunit-fixer-config.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/FixerRunnerSource/phpunit-fixer-config.yml']
         );
 
         $this->errorAndDiffCollector = $container->get(ErrorAndDiffCollector::class);

--- a/packages/EasyCodingStandard/tests/Error/ErrorCollector/SniffFileProcessorTest.php
+++ b/packages/EasyCodingStandard/tests/Error/ErrorCollector/SniffFileProcessorTest.php
@@ -23,8 +23,8 @@ final class SniffFileProcessorTest extends TestCase
 
     protected function setUp(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/SniffRunnerSource/easy-coding-standard.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/SniffRunnerSource/easy-coding-standard.yml']
         );
 
         $this->errorAndDiffCollector = $container->get(ErrorAndDiffCollector::class);

--- a/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
+++ b/packages/EasyCodingStandard/tests/Finder/SourceFinderTest.php
@@ -32,8 +32,8 @@ final class SourceFinderTest extends AbstractContainerAwareTestCase
 
     public function testSourceProviders(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/SourceFinderSource/config-with-source-provider.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/SourceFinderSource/config-with-source-provider.yml']
         );
 
         $sourceFinder = $container->get(SourceFinder::class);
@@ -44,8 +44,8 @@ final class SourceFinderTest extends AbstractContainerAwareTestCase
 
     public function testAppendFileAndSanitize(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/SourceFinderSource/config-with-append-file-provider.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/SourceFinderSource/config-with-append-file-provider.yml']
         );
 
         /** @var SourceFinder $sourceFinder */

--- a/packages/EasyCodingStandard/tests/Indentation/IndentationTest.php
+++ b/packages/EasyCodingStandard/tests/Indentation/IndentationTest.php
@@ -15,8 +15,8 @@ final class IndentationTest extends TestCase
 {
     public function testSpaces(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/IndentationSource/config-with-spaces-indentation.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/IndentationSource/config-with-spaces-indentation.yml']
         );
         $indentationTypeFixer = $this->getIndentationTypeFixerFromContainer($container);
 
@@ -27,8 +27,8 @@ final class IndentationTest extends TestCase
 
     public function testTabs(): void
     {
-        $container = (new ContainerFactory())->createWithConfig(
-            __DIR__ . '/IndentationSource/config-with-tabs-indentation.yml'
+        $container = (new ContainerFactory())->createWithConfigs(
+            [__DIR__ . '/IndentationSource/config-with-tabs-indentation.yml']
         );
         $indentationTypeFixer = $this->getIndentationTypeFixerFromContainer($container);
 

--- a/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
@@ -146,6 +146,6 @@ abstract class AbstractCheckerTestCase extends TestCase
             return self::$cachedContainers[$fileHash];
         }
 
-        return self::$cachedContainers[$fileHash] = (new ContainerFactory())->createWithConfig($this->provideConfig());
+        return self::$cachedContainers[$fileHash] = (new ContainerFactory())->createWithConfigs([$this->provideConfig()]);
     }
 }

--- a/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
@@ -146,6 +146,8 @@ abstract class AbstractCheckerTestCase extends TestCase
             return self::$cachedContainers[$fileHash];
         }
 
-        return self::$cachedContainers[$fileHash] = (new ContainerFactory())->createWithConfigs([$this->provideConfig()]);
+        return self::$cachedContainers[$fileHash] = (new ContainerFactory())->createWithConfigs(
+            [$this->provideConfig()]
+        );
     }
 }

--- a/packages/PHPStanExtensions/README.md
+++ b/packages/PHPStanExtensions/README.md
@@ -45,7 +45,7 @@ Do you need to ignore few errors but don't want to play with regex? Run:
 vendor/bin/phpstan analyse src --level max --error-format ignore
 ```
 
-to get it on silver plate, ready for copy-paste: 
+to get it on silver plate, ready for copy-paste:
 
 ```bash
 


### PR DESCRIPTION
This change fixes previously invalid behavior, when `--level ...` isuses could not be ingnored, because `ecs.yml` would never be loaded.

This might cause to pop up new errors when `--level` and `--config` fixers are applied. The propper use is to have just one run and make it pass, so be sure to fix it and make it pass.