### PR TITLE
fix package name resolving

### DIFF
--- a/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php
+++ b/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php
@@ -70,7 +70,7 @@ final class ChangeFactory
 
     private function resolveMessageWithoutPackage(string $message): string
     {
-        $match = Strings::match($message, '#\[(?<package>\w+)\]#');
+        $match = Strings::match($message, '#\[(?<package>[-\w]+)\]#');
 
         if (! isset($match['package'])) {
             return $message;


### PR DESCRIPTION
fixed ChangeFactory::resolveMessageWithoutPackage()

- allow dash ("-") in a package name
- should have been resolved in https://github.com/Symplify/Symplify/pull/1065