### PR TITLE
Simple test case for loop inconsistency with PHP_CodeSniffer

### DIFF
--- a/packages/EasyCodingStandard/tests/Issues/Issue1107Test.php
+++ b/packages/EasyCodingStandard/tests/Issues/Issue1107Test.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Tests\Issues;
+
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+
+final class Issue1107Test extends AbstractCheckerTestCase
+{
+    public function test(): void
+    {
+        $this->doTestWrongToFixedFile(__DIR__ . '/wrong/wrong1107.php.inc', __DIR__ . '/fixed/fixed1107.php.inc');
+    }
+
+    protected function provideConfig(): string
+    {
+        return __DIR__ . '/config/config1107.yml';
+    }
+}

--- a/packages/EasyCodingStandard/tests/Issues/config/config1107.yml
+++ b/packages/EasyCodingStandard/tests/Issues/config/config1107.yml
@@ -1,7 +1,7 @@
 services:
-    - PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff.SpaceBeforeBrace
-    - PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff.Indent
-    - PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff.IncorrectExact
+    PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff:
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff:
+    PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff:
         ignoreIndentationTokens:
             - T_COMMENT
             - T_DOC_COMMENT_OPEN_TAG

--- a/packages/EasyCodingStandard/tests/Issues/config/config1107.yml
+++ b/packages/EasyCodingStandard/tests/Issues/config/config1107.yml
@@ -1,0 +1,7 @@
+services:
+    - PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff.SpaceBeforeBrace
+    - PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff.Indent
+    - PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff.IncorrectExact
+        ignoreIndentationTokens:
+            - T_COMMENT
+            - T_DOC_COMMENT_OPEN_TAG

--- a/packages/EasyCodingStandard/tests/Issues/config/config1107.yml
+++ b/packages/EasyCodingStandard/tests/Issues/config/config1107.yml
@@ -1,7 +1,3 @@
 services:
     PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\ClassDeclarationSniff:
-    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\ScopeClosingBraceSniff:
     PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\ScopeIndentSniff:
-        ignoreIndentationTokens:
-            - T_COMMENT
-            - T_DOC_COMMENT_OPEN_TAG

--- a/packages/EasyCodingStandard/tests/Issues/fixed/fixed1107.php.inc
+++ b/packages/EasyCodingStandard/tests/Issues/fixed/fixed1107.php.inc
@@ -1,0 +1,25 @@
+<?php
+namespace Vendor\Package;
+
+use FooInterface;
+use BarClass as Bar;
+use OtherVendor\OtherPackage\BazClass;
+
+class Foo extends Bar implements FooInterface
+{
+    public function sampleMethod($a, $b = null)
+    {
+        if ($a === $b) {
+            bar();
+        } elseif ($a > $b) {
+            $foo->bar($arg1);
+        } else {
+            BazClass::bar($arg2, $arg3);
+        }
+    }
+
+    final public static function bar()
+    {
+      // method body
+    }
+}

--- a/packages/EasyCodingStandard/tests/Issues/fixed/fixed1107.php.inc
+++ b/packages/EasyCodingStandard/tests/Issues/fixed/fixed1107.php.inc
@@ -1,25 +1,6 @@
 <?php
 namespace Vendor\Package;
 
-use FooInterface;
-use BarClass as Bar;
-use OtherVendor\OtherPackage\BazClass;
-
-class Foo extends Bar implements FooInterface
+class Foo
 {
-    public function sampleMethod($a, $b = null)
-    {
-        if ($a === $b) {
-            bar();
-        } elseif ($a > $b) {
-            $foo->bar($arg1);
-        } else {
-            BazClass::bar($arg2, $arg3);
-        }
-    }
-
-    final public static function bar()
-    {
-      // method body
-    }
 }

--- a/packages/EasyCodingStandard/tests/Issues/fixed/fixed1107.php.inc
+++ b/packages/EasyCodingStandard/tests/Issues/fixed/fixed1107.php.inc
@@ -1,5 +1,4 @@
 <?php
-namespace Vendor\Package;
 
 class Foo
 {

--- a/packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc
+++ b/packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc
@@ -1,0 +1,25 @@
+<?php
+namespace Vendor\Package;
+
+use FooInterface;
+use BarClass as Bar;
+use OtherVendor\OtherPackage\BazClass;
+
+  class Foo extends Bar implements FooInterface
+{
+    public function sampleMethod($a, $b = null)
+    {
+        if ($a === $b) {
+            bar();
+        } elseif ($a > $b) {
+            $foo->bar($arg1);
+        } else {
+            BazClass::bar($arg2, $arg3);
+        }
+    }
+
+    final public static function bar()
+    {
+      // method body
+    }
+}

--- a/packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc
+++ b/packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc
@@ -1,5 +1,4 @@
 <?php
-namespace Vendor\Package;
 
   class Foo
 {

--- a/packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc
+++ b/packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc
@@ -1,25 +1,6 @@
 <?php
 namespace Vendor\Package;
 
-use FooInterface;
-use BarClass as Bar;
-use OtherVendor\OtherPackage\BazClass;
-
-  class Foo extends Bar implements FooInterface
+  class Foo
 {
-    public function sampleMethod($a, $b = null)
-    {
-        if ($a === $b) {
-            bar();
-        } elseif ($a > $b) {
-            $foo->bar($arg1);
-        } else {
-            BazClass::bar($arg2, $arg3);
-        }
-    }
-
-    final public static function bar()
-    {
-      // method body
-    }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset>
+    <rule ref="PSR2.Classes.ClassDeclaration"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
+</ruleset>


### PR DESCRIPTION
Contination of #1108

These should be consistent.

PHP_CodeSniffer:

```
vendor/bin/phpcs packages/EasyCodingStandard/tests/Issues/wrong/wrong1107.php.inc --report=diff -vvv
```

ECS:

```
vendor/bin/phpunit packages/EasyCodingStandard/tests/Issues/Issue1107Test.php
```