### PR TITLE
[PHPStanExtensions] Add SplFileInfoTolerantDynamicMethodReturnTypeExtension

### DIFF
--- a/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
+++ b/packages/EasyCodingStandard/src/Finder/FinderSanitizer.php
@@ -35,6 +35,9 @@ final class FinderSanitizer
     {
         return array_filter($fileInfos, function (SplFileInfo $fileInfo) {
             $this->ensureFileInfoExists($fileInfo);
+            if ($fileInfo->getRealPath() === false) {
+                return false;
+            }
 
             return filesize($fileInfo->getRealPath());
         });

--- a/packages/PHPStanExtensions/src/Type/SplFileInfoTolerantDynamicMethodReturnTypeExtension.php
+++ b/packages/PHPStanExtensions/src/Type/SplFileInfoTolerantDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PHPStanExtensions\Type;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use SplFileInfo;
+
+/**
+ * SplFileInfo->getRealPath() always exists, since it comes from Finder, that finds only existing files
+ * This removes many false positives that have to be excluded manually otherwise.
+ */
+final class SplFileInfoTolerantDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return SplFileInfo::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getRealPath';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): Type {
+        return new StringType();
+    }
+}

--- a/packages/PHPStanExtensions/src/Type/SplFileInfoTolerantDynamicMethodReturnTypeExtension.php
+++ b/packages/PHPStanExtensions/src/Type/SplFileInfoTolerantDynamicMethodReturnTypeExtension.php
@@ -8,11 +8,14 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use SplFileInfo;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
- * SplFileInfo->getRealPath() always exists, since it comes from Finder, that finds only existing files
- * This removes many false positives that have to be excluded manually otherwise.
+ * Symfony provided Symfony\Component\Finder\SplFileInfo always exists,
+ * so checking every single $splFileInfo->getRealPath() has no added value.
+ * Just pollutes code and config and makes it unreadable.
+ *
+ * This narrows validation only to custom created SplFileInfo.
  */
 final class SplFileInfoTolerantDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/packages/PackageBuilder/src/Configuration/LevelFileFinder.php
+++ b/packages/PackageBuilder/src/Configuration/LevelFileFinder.php
@@ -2,9 +2,9 @@
 
 namespace Symplify\PackageBuilder\Configuration;
 
-use SplFileInfo;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\PackageBuilder\Exception\Configuration\LevelNotFoundException;
 use function Safe\sort;
 use function Safe\sprintf;

--- a/packages/Statie/packages/Generator/src/Renderable/File/GeneratorFileGuard.php
+++ b/packages/Statie/packages/Generator/src/Renderable/File/GeneratorFileGuard.php
@@ -53,7 +53,7 @@ final class GeneratorFileGuard
 
         throw new GeneratorException(sprintf(
             'File "%s" must have "id: [0-9]+" in the header in --- blocks.',
-            (string) $fileInfo->getRealPath()
+            $fileInfo->getRealPath()
         ));
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,20 +22,6 @@ parameters:
         - packages/EasyCodingStandard/tests/Finder/SourceFinderSource/Source/SomeClass.php
 
     ignoreErrors:
-        # (new SplFileInfo(...))->getRealPath()
-        - '#Parameter \#1 \$absoluteFilePath of method Symplify\\EasyCodingStandard\\Skipper::fileMatchesPattern\(\) expects string, string\|false given#'
-        - '#Parameter \#1 \$file of method Symplify\\LatteToTwigConverter\\LatteToTwigConverter::convertFile\(\) expects string, string\|false given#'
-        - '#Method Symplify\\PackageBuilder\\Configuration\\LevelFileFinder::detectFromInputAndDirectory\(\) should return string|null but returns string\|false#'
-        - '#Parameter \#1 \$filename of function filesize expects string, string\|false given#'
-        - '#Parameter \#1 \$relativePath of method Symplify\\EasyCodingStandard\\Skipper::removeFileFromUnused\(\) expects string, string\|false given#'
-        - '#Parameter \#1 \$filename of function md5_file expects string, string\|false given#'
-        - '#Parameter \#2 \$absoluteFilePath of method Symplify\\EasyCodingStandard\\Skipper::shouldSkipCodeAndFile\(\) expects string, string\|false given#'
-        - '#Parameter \#2 \$absoluteFilePath of method Symplify\\EasyCodingStandard\\Skipper::shouldSkipCheckerAndFile\(\) expects string, string\|false given#'
-        - '#Parameter \#1 \$filePath of method Symplify\\EasyCodingStandard\\FixerRunner\\Parser\\FileToTokensParser::parseFromFilePath\(\) expects string, string\|false given#'
-        - '#Parameter \#1 \$filePath of method Symplify\\EasyCodingStandard\\ChangedFilesDetector\\FileHashComputer::compute\(\) expects string, string\|false given#'
-        - '#Parameter \#1 \$str of function sha1 expects string, string\|false given#'
-        # end
-
         # part of test / bugged
         - '#Parameter \#1 \$finder of method Symplify\\EasyCodingStandard\\Finder\\FinderSanitizer::sanitize\(\) expects \(iterable<SplFileInfo>&Nette\\Utils\\Finder\)\|Symfony\\Component\\Finder\\Finder, (array<int, SplFileInfo>|array<Symfony\\Component\\Finder\\SplFileInfo>|(Nette\\Utils\\Finder\|Symfony\\Component\\Finder\\Finder)) given#'
 
@@ -114,3 +100,9 @@ parameters:
         # variadic
         - '#In method (.*?), parameter (.*?) can be type-hinted to "array"#'
         - '#PHPDoc tag \@param for parameter (.*?) with type array is not subtype of native type array<int, mixed>#'
+
+services:
+    -
+        class: Symplify\PHPStanExtensions\Type\SplFileInfoTolerantDynamicMethodReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension


### PR DESCRIPTION
**Symfony**\SplFileInfo->getRealPath() always exists, since it comes from Symfony\Finder, that finds only existing files

This removes many false positives that have to be excluded manually otherwise.