### PR TITLE
[ECS] Allow NoExtraBlankLinesFixer in PSR-12

### DIFF
--- a/packages/EasyCodingStandard/config/psr12.yml
+++ b/packages/EasyCodingStandard/config/psr12.yml
@@ -42,4 +42,3 @@ services:
 parameters:
     exclude_checkers:
         - 'PhpCsFixer\Fixer\Import\SingleImportPerStatementFixer'
-        - 'PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer'


### PR DESCRIPTION
Allow NoExtraBlankLinesFixer to be used in PSR-12.

Related to #1138