### PR TITLE
[MonorepoBuilder] Add option for maximum number of parallel processes to split command

### DIFF
--- a/packages/MonorepoBuilder/packages/Split/src/Command/SplitCommand.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Command/SplitCommand.php
@@ -4,6 +4,7 @@ namespace Symplify\MonorepoBuilder\Split\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\MonorepoBuilder\Split\Configuration\RepositoryGuard;
 use Symplify\MonorepoBuilder\Split\PackageToRepositorySplitter;
@@ -59,6 +60,13 @@ final class SplitCommand extends Command
                 'monorepo-builder.yml'
             )
         );
+        $this->addOption(
+            'max-processes',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Maximum number of processes to run in parallel',
+            0
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -67,7 +75,8 @@ final class SplitCommand extends Command
 
         $this->packageToRepositorySplitter->splitDirectoriesToRepositories(
             $this->directoriesToRepositories,
-            $this->rootDirectory
+            $this->rootDirectory,
+            intval($input->getOption('max-processes'))
         );
 
         // success


### PR DESCRIPTION
This pr adds an option to limit the maximum number of parallel processes for the repository split. I came accross the problem that one of my monorepos has 19 packages and the split fails most of the time. I think this is because of resource limits of my server, so one option would be to fix this on the server side but I thought it would be a good option to have anyways. And it works for me, so I don't have to struggle with my server settings. :wink: 

For me, a limit of 10 still works, everything above causes at least one process to fail most of the time. This is very annoying when you perform the split as part of the ci. :wink: 
This patch solves this issue for me.

The current output is not perfect since it waits during process creation whenever the maximum number of processes is reached and after all processes were created it prints `[OK] Running XX jobs in parallel` where `XX` now only reflects the number of the last chunk of processes.

I think this is a minor smell but maybe you have an idea to improve this.