### PR TITLE
[BetterPhpDocParser] Add support for GenericTypeNode

### DIFF
--- a/packages/BetterPhpDocParser/src/PhpDocParser/TypeNodeToStringsConvertor.php
+++ b/packages/BetterPhpDocParser/src/PhpDocParser/TypeNodeToStringsConvertor.php
@@ -3,6 +3,7 @@
 namespace Symplify\BetterPhpDocParser\PhpDocParser;
 
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;

--- a/packages/BetterPhpDocParser/src/PhpDocParser/TypeNodeToStringsConvertor.php
+++ b/packages/BetterPhpDocParser/src/PhpDocParser/TypeNodeToStringsConvertor.php
@@ -49,6 +49,15 @@ final class TypeNodeToStringsConvertor
             return implode('&', $resolvedDocTypes);
         }
 
+        if ($typeNode instanceof GenericTypeNode) {
+            $resolvedDocTypes = [];
+            foreach ($typeNode->genericTypes as $subTypeNode) {
+                $resolvedDocTypes[] = $this->resolveTypeNodeToString($subTypeNode);
+            }
+
+            return $this->resolveTypeNodeToString($typeNode->type) . '<' . implode(', ', $resolvedDocTypes) . '>';
+        }
+
         throw new NotImplementedYetException(sprintf(
             'Add new "%s" type format to "%s" method',
             get_class($typeNode),


### PR DESCRIPTION
@TomasVotruba What is the reason for this `TypeNodeToStringsConvertor`? Can't we just use `TypeNode::__toString()`?