### PR TITLE
[MonorepoBuilder] Fix autoload paths under Windows

### DIFF
--- a/packages/MonorepoBuilder/packages/Split/tests/Process/ProcessFactoryTest.php
+++ b/packages/MonorepoBuilder/packages/Split/tests/Process/ProcessFactoryTest.php
@@ -27,7 +27,15 @@ final class ProcessFactoryTest extends AbstractContainerAwareTestCase
         );
 
         $subsplitRealpath = realpath(__DIR__ . '/../../bash/subsplit.sh');
-        $commandLine = "'" . $subsplitRealpath . "' '--from-directory=localDirectory' '--to-repository=git@github.com:Symplify/Symplify.git' '--branch=master' %s '--repository=%s/.git'";
-        $this->assertStringMatchesFormat($commandLine, $subsplitProcess->getCommandLine());
+        $this->assertRegExp(
+            implode('', [
+                "/^['\"]?" . preg_quote($subsplitRealpath, '/') . "['\"]? ",
+                "['\"]?\-\-from\-directory\=localDirectory['\"]? ",
+                "['\"]?\-\-to\-repository\=git@github\.com\:Symplify\/Symplify\.git['\"]? ",
+                "['\"]?\-\-branch\=master['\"]? [^\r\n]+ ",
+                "['\"]?\-\-repository\=[^\r\n]+\/\.git['\"]?$/s",
+            ]),
+            $subsplitProcess->getCommandLine()
+        );
     }
 }

--- a/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
+++ b/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
@@ -149,8 +149,8 @@ final class AutoloadRelativePathComposerJsonDecorator implements ComposerJsonDec
         }
 
         $composerDirectory = dirname($packageComposerFile->getRealPath());
-        $relativeDirectory = Strings::substring($composerDirectory, strlen(rtrim(getcwd(), '/') . '/'));
+        $relativeDirectory = Strings::substring($composerDirectory, strlen(rtrim(getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR));
 
-        return $relativeDirectory . DIRECTORY_SEPARATOR . $path;
+        return str_replace(DIRECTORY_SEPARATOR, '/', $relativeDirectory . '/' . $path);
     }
 }

--- a/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
+++ b/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
@@ -6,6 +6,7 @@ use Nette\Utils\Strings;
 use Symfony\Component\Finder\SplFileInfo;
 use Symplify\MonorepoBuilder\Composer\Section;
 use Symplify\MonorepoBuilder\Contract\ComposerJsonDecoratorInterface;
+use Symplify\MonorepoBuilder\FileSystem\FileSystem;
 use Symplify\MonorepoBuilder\PackageComposerFinder;
 use function Safe\getcwd;
 
@@ -16,9 +17,15 @@ final class AutoloadRelativePathComposerJsonDecorator implements ComposerJsonDec
      */
     private $packageComposerFinder;
 
-    public function __construct(PackageComposerFinder $packageComposerFinder)
+    /**
+     * @var FileSystem
+     */
+    private $fileSystem;
+
+    public function __construct(PackageComposerFinder $packageComposerFinder, FileSystem $fileSystem)
     {
         $this->packageComposerFinder = $packageComposerFinder;
+        $this->fileSystem = $fileSystem;
     }
 
     /**
@@ -149,8 +156,11 @@ final class AutoloadRelativePathComposerJsonDecorator implements ComposerJsonDec
         }
 
         $composerDirectory = dirname($packageComposerFile->getRealPath());
-        $relativeDirectory = Strings::substring($composerDirectory, strlen(rtrim(getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR));
+        $relativeDirectory = Strings::substring(
+            $composerDirectory,
+            strlen(rtrim(getcwd(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR)
+        );
 
-        return str_replace(DIRECTORY_SEPARATOR, '/', $relativeDirectory . '/' . $path);
+        return $this->fileSystem->normalizeSlashes($relativeDirectory . '/' . $path);
     }
 }

--- a/packages/MonorepoBuilder/src/FileSystem/FileSystem.php
+++ b/packages/MonorepoBuilder/src/FileSystem/FileSystem.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\FileSystem;
+
+final class FileSystem
+{
+    public function normalizeSlashes(string $path): string
+    {
+        return str_replace(['/', '\\'], '/', $path);
+    }
+}

--- a/packages/MonorepoBuilder/src/FileSystem/JsonFileManager.php
+++ b/packages/MonorepoBuilder/src/FileSystem/JsonFileManager.php
@@ -56,6 +56,6 @@ final class JsonFileManager
      */
     private function encodeJsonToFileContent(array $json): string
     {
-        return Json::encode($json, Json::PRETTY) . PHP_EOL;
+        return Json::encode($json, Json::PRETTY) . "\n";
     }
 }

--- a/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/AutoloadRelativePathComposerJsonDecoratorTest.php
+++ b/packages/MonorepoBuilder/tests/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator/AutoloadRelativePathComposerJsonDecoratorTest.php
@@ -4,6 +4,7 @@ namespace Symplify\MonorepoBuilder\Tests\ComposerJsonDecorator\AutoloadRelativeP
 
 use PHPUnit\Framework\TestCase;
 use Symplify\MonorepoBuilder\ComposerJsonDecorator\AutoloadRelativePathComposerJsonDecorator;
+use Symplify\MonorepoBuilder\FileSystem\FileSystem;
 use Symplify\MonorepoBuilder\PackageComposerFinder;
 
 final class AutoloadRelativePathComposerJsonDecoratorTest extends TestCase
@@ -44,9 +45,11 @@ final class AutoloadRelativePathComposerJsonDecoratorTest extends TestCase
     protected function setUp(): void
     {
         $packageComposerFinder = new PackageComposerFinder([__DIR__ . '/Source']);
+        $fileSystem = new FileSystem();
 
         $this->autoloadRelativePathComposerJsonDecorator = new AutoloadRelativePathComposerJsonDecorator(
-            $packageComposerFinder
+            $packageComposerFinder,
+            $fileSystem
         );
     }
 
@@ -63,9 +66,11 @@ final class AutoloadRelativePathComposerJsonDecoratorTest extends TestCase
             __DIR__ . '/SourceOverlappingNamespaces/PackageA',
             __DIR__ . '/SourceOverlappingNamespaces/PackageB',
         ]);
+        $fileSystem = new FileSystem();
 
         $autoloadRelativePathComposerJsonDecorator = new AutoloadRelativePathComposerJsonDecorator(
-            $packageComposerFinder
+            $packageComposerFinder,
+            $fileSystem
         );
 
         $decorated = $autoloadRelativePathComposerJsonDecorator->decorate($this->composerJsonWithOverlappingNamespaces);

--- a/packages/MonorepoBuilder/tests/DevMasterAliasUpdater/DevMasterAliasUpdaterTest.php
+++ b/packages/MonorepoBuilder/tests/DevMasterAliasUpdater/DevMasterAliasUpdaterTest.php
@@ -17,7 +17,6 @@ final class DevMasterAliasUpdaterTest extends AbstractContainerAwareTestCase
     protected function setUp(): void
     {
         $this->devMasterAliasUpdater = $this->container->get(DevMasterAliasUpdater::class);
-        $this->devMasterAliasUpdater = $this->container->get(DevMasterAliasUpdater::class);
     }
 
     protected function tearDown(): void

--- a/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
+++ b/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
@@ -5,7 +5,6 @@ namespace Symplify\MonorepoBuilder\Tests\VersionValidator;
 use Symfony\Component\Finder\Finder;
 use Symplify\MonorepoBuilder\Tests\AbstractContainerAwareTestCase;
 use Symplify\MonorepoBuilder\VersionValidator;
-use function Safe\sprintf;
 
 final class VersionValidatorTest extends AbstractContainerAwareTestCase
 {
@@ -31,9 +30,11 @@ final class VersionValidatorTest extends AbstractContainerAwareTestCase
 
         $this->assertArrayHasKey('some/package', $conflictingPackageVersionsPerFile);
 
+        $sourcePath = __DIR__ . DIRECTORY_SEPARATOR . 'Source';
+
         $expectedConflictingPackageVersionsPerFile = [
-            sprintf('%s%sSource%2$sfirst.json', __DIR__, DIRECTORY_SEPARATOR) => '^1.0',
-            sprintf('%s%sSource%2$ssecond.json', __DIR__, DIRECTORY_SEPARATOR) => '^2.0',
+            $sourcePath . DIRECTORY_SEPARATOR . 'first.json' => '^1.0',
+            $sourcePath . DIRECTORY_SEPARATOR . 'second.json' => '^2.0',
         ];
 
         $this->assertSame(

--- a/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
+++ b/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
@@ -5,6 +5,7 @@ namespace Symplify\MonorepoBuilder\Tests\VersionValidator;
 use Symfony\Component\Finder\Finder;
 use Symplify\MonorepoBuilder\Tests\AbstractContainerAwareTestCase;
 use Symplify\MonorepoBuilder\VersionValidator;
+use function Safe\sprintf;
 
 final class VersionValidatorTest extends AbstractContainerAwareTestCase
 {

--- a/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
+++ b/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
@@ -20,7 +20,9 @@ final class VersionValidatorTest extends AbstractContainerAwareTestCase
 
     public function test(): void
     {
-        $fileInfos = iterator_to_array(Finder::create()->name('*.json')->in(__DIR__ . '/Source') ->getIterator());
+        $fileInfos = iterator_to_array(
+            Finder::create()->name('*.json')->in(__DIR__ . DIRECTORY_SEPARATOR . 'Source') ->getIterator()
+        );
 
         $conflictingPackageVersionsPerFile = $this->versionValidator->findConflictingPackageVersionsInFileInfos(
             $fileInfos
@@ -29,8 +31,8 @@ final class VersionValidatorTest extends AbstractContainerAwareTestCase
         $this->assertArrayHasKey('some/package', $conflictingPackageVersionsPerFile);
 
         $expectedConflictingPackageVersionsPerFile = [
-            __DIR__ . '/Source/first.json' => '^1.0',
-            __DIR__ . '/Source/second.json' => '^2.0',
+            sprintf('%s%sSource%2$sfirst.json', __DIR__, DIRECTORY_SEPARATOR) => '^1.0',
+            sprintf('%s%sSource%2$ssecond.json', __DIR__, DIRECTORY_SEPARATOR) => '^2.0',
         ];
 
         $this->assertSame(


### PR DESCRIPTION
`autoload`/`autoload-dev` paths generated under windows contain incorrect slashes, as the composer paths should always be unix-style.
This PR fixes the directory separator handling to use the system-style consistently and replacing the separator in the last step.

Fixes #1198