### PR TITLE
[CodingStandard] Improve ParamReturnAndVarTagMalformsFixer for this and missing dollar signs

### DIFF
--- a/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
@@ -28,6 +28,7 @@ final class ParamReturnAndVarTagMalformsFixerTest extends AbstractCheckerTestCas
         yield [__DIR__ . '/wrong/wrong6.php.inc', __DIR__ . '/fixed/fixed6.php.inc'];
         yield [__DIR__ . '/wrong/wrong7.php.inc', __DIR__ . '/fixed/fixed7.php.inc'];
         yield [__DIR__ . '/wrong/wrong8.php.inc', __DIR__ . '/fixed/fixed8.php.inc'];
+        yield [__DIR__ . '/wrong/wrong9.php.inc', __DIR__ . '/fixed/fixed9.php.inc'];
     }
 
     protected function provideConfig(): string

--- a/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/fixed/fixed8.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/fixed/fixed8.php.inc
@@ -6,6 +6,11 @@ class SomeClass
      * @var string
      */
     private $property;
+
+    /**
+     * @var self
+     */
+    private $self;
 }
 
 /** @var int $previousTokenPointer */

--- a/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/fixed/fixed9.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/fixed/fixed9.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param $argument
+ * @param string $argument2
+ * @param ExceptionMessageFactoryInterface|null $exceptionMessageFactory
+ * @param string[] $items
+ */
+function someFunction($argument, $argument2, $exceptionMessageFactory, $items)
+{
+}

--- a/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/wrong/wrong8.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/wrong/wrong8.php.inc
@@ -6,6 +6,11 @@ class SomeClass
      * @var string $property
      */
     private $property;
+
+    /**
+     * @var $this
+     */
+    private $self;
 }
 
 /** @var int $previousTokenPointer */

--- a/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/wrong/wrong9.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/wrong/wrong9.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @param argument
+ * @param string argument2
+ * @param ExceptionMessageFactoryInterface|null exceptionMessageFactory
+ * @param string[] items
+ */
+function someFunction($argument, $argument2, $exceptionMessageFactory, $items)
+{
+}

--- a/packages/EasyCodingStandard/config/clean-code.yml
+++ b/packages/EasyCodingStandard/config/clean-code.yml
@@ -1,4 +1,7 @@
 services:
+    # fix all @param, @var, @return tag mallforms
+    Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer: ~
+
     SlevomatCodingStandard\Sniffs\Variables\UnusedVariableSniff: ~
     SlevomatCodingStandard\Sniffs\Variables\UselessVariableSniff: ~
 

--- a/packages/TokenRunner/src/DocBlock/MalformWorker/SuperfluousVarNameMalformWorker.php
+++ b/packages/TokenRunner/src/DocBlock/MalformWorker/SuperfluousVarNameMalformWorker.php
@@ -36,6 +36,10 @@ final class SuperfluousVarNameMalformWorker extends AbstractMalformWorker
                         $replacement .= $match['type'];
                     }
 
+                    if (Strings::match($match[0], '#\$this$#')) {
+                        return Strings::replace($match[0], '#\$this$#', 'self');
+                    }
+
                     return $replacement;
                 }
             );


### PR DESCRIPTION
```diff
 /**
- * @var $this
+ * @var self
  */
```

```diff
 /**
- * @param int value
+ * @param int $value
  */
 function ($value) {
 }
```