### PR TITLE
[ECS] Decouple reporting from CheckCommand to CheckCommandReporter

### DIFF
--- a/packages/EasyCodingStandard/src/Console/Command/CheckCommand.php
+++ b/packages/EasyCodingStandard/src/Console/Command/CheckCommand.php
@@ -12,19 +12,10 @@ use Symplify\EasyCodingStandard\Configuration\Configuration;
 use Symplify\EasyCodingStandard\Configuration\Exception\NoCheckersLoadedException;
 use Symplify\EasyCodingStandard\Configuration\Option;
 use Symplify\EasyCodingStandard\Console\Output\CheckCommandReporter;
-use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
-use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
-use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 final class CheckCommand extends Command
 {
-    /**
-     * @var EasyCodingStandardStyle
-     */
-    private $easyCodingStandardStyle;
-
     /**
      * @var Application
      */
@@ -36,28 +27,19 @@ final class CheckCommand extends Command
     private $configuration;
 
     /**
-     * @var ErrorAndDiffCollector
-     */
-    private $errorAndDiffCollector;
-
-    /**
      * @var CheckCommandReporter
      */
     private $checkCommandReporter;
 
     public function __construct(
         Application $application,
-        EasyCodingStandardStyle $easyCodingStandardStyle,
         Configuration $configuration,
-        ErrorAndDiffCollector $errorAndDiffCollector,
         CheckCommandReporter $checkCommandReporter
     ) {
         parent::__construct();
 
         $this->ecsApplication = $application;
-        $this->easyCodingStandardStyle = $easyCodingStandardStyle;
         $this->configuration = $configuration;
-        $this->errorAndDiffCollector = $errorAndDiffCollector;
         $this->checkCommandReporter = $checkCommandReporter;
     }
 
@@ -93,22 +75,7 @@ final class CheckCommand extends Command
         $this->configuration->resolveFromInput($input);
         $processedFilesCount = $this->ecsApplication->run();
 
-        $this->checkCommandReporter->reportFileDiffs($this->errorAndDiffCollector->getFileDiffs());
-
-        if ($this->errorAndDiffCollector->getErrorCount() === 0
-            && $this->errorAndDiffCollector->getFileDiffsCount() === 0
-        ) {
-            if ($processedFilesCount) {
-                $this->easyCodingStandardStyle->newLine();
-            }
-            $this->easyCodingStandardStyle->success('No errors found. Great job - your code is shiny in style!');
-
-            return ShellCode::SUCCESS;
-        }
-
-        $this->easyCodingStandardStyle->newLine();
-
-        return $this->configuration->isFixer() ? $this->printAfterFixerStatus() : $this->printNoFixerStatus();
+        return $this->checkCommandReporter->report($processedFilesCount);
     }
 
     private function ensureSomeCheckersAreRegistered(): void
@@ -120,76 +87,5 @@ final class CheckCommand extends Command
                 . 'section, load them via "--config <file>.yml" or "--level <level> option.'
             );
         }
-    }
-
-    private function printAfterFixerStatus(): int
-    {
-        if ($this->configuration->showErrorTable()) {
-            $this->easyCodingStandardStyle->printErrors($this->errorAndDiffCollector->getErrors());
-        }
-
-        if ($this->errorAndDiffCollector->getErrorCount() === 0) {
-            $this->easyCodingStandardStyle->success(
-                sprintf(
-                    '%d error%s successfully fixed and no other found!',
-                    $this->errorAndDiffCollector->getFileDiffsCount(),
-                    $this->errorAndDiffCollector->getFileDiffsCount() === 1 ? '' : 's'
-                )
-            );
-
-            return ShellCode::SUCCESS;
-        }
-
-        $this->printErrorMessageFromErrorCounts(
-            $this->errorAndDiffCollector->getErrorCount(),
-            $this->errorAndDiffCollector->getFileDiffsCount()
-        );
-
-        return ShellCode::ERROR;
-    }
-
-    private function printNoFixerStatus(): int
-    {
-        if ($this->configuration->showErrorTable()) {
-            $errors = $this->errorAndDiffCollector->getErrors();
-            if (count($errors)) {
-                $this->easyCodingStandardStyle->newLine();
-                $this->easyCodingStandardStyle->printErrors($errors);
-            }
-        }
-
-        $this->printErrorMessageFromErrorCounts(
-            $this->errorAndDiffCollector->getErrorCount(),
-            $this->errorAndDiffCollector->getFileDiffsCount()
-        );
-
-        return ShellCode::ERROR;
-    }
-
-    private function printErrorMessageFromErrorCounts(int $errorCount, int $fileDiffsCount): void
-    {
-        if ($errorCount) {
-            $this->easyCodingStandardStyle->error(
-                sprintf(
-                    'Found %d error%s that need%s to be fixed manually.',
-                    $errorCount,
-                    $errorCount === 1 ? '' : 's',
-                    $errorCount === 1 ? '' : 's'
-                )
-            );
-        }
-
-        if (! $fileDiffsCount || $this->configuration->isFixer()) {
-            return;
-        }
-
-        $this->easyCodingStandardStyle->fixableError(
-            sprintf(
-                '%s%d %s fixable! Just add "--fix" to console command and rerun to apply.',
-                $errorCount ? 'Good news is that ' : '',
-                $fileDiffsCount,
-                $fileDiffsCount === 1 ? 'file is' : 'files are'
-            )
-        );
     }
 }

--- a/packages/EasyCodingStandard/src/Console/Output/CheckCommandReporter.php
+++ b/packages/EasyCodingStandard/src/Console/Output/CheckCommandReporter.php
@@ -2,8 +2,11 @@
 
 namespace Symplify\EasyCodingStandard\Console\Output;
 
+use Symplify\EasyCodingStandard\Configuration\Configuration;
 use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
+use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\EasyCodingStandard\Error\FileDiff;
+use Symplify\PackageBuilder\Console\ShellCode;
 use function Safe\sprintf;
 
 final class CheckCommandReporter
@@ -13,15 +16,50 @@ final class CheckCommandReporter
      */
     private $easyCodingStandardStyle;
 
-    public function __construct(EasyCodingStandardStyle $easyCodingStandardStyle)
-    {
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var ErrorAndDiffCollector
+     */
+    private $errorAndDiffCollector;
+
+    public function __construct(
+        EasyCodingStandardStyle $easyCodingStandardStyle,
+        Configuration $configuration,
+        ErrorAndDiffCollector $errorAndDiffCollector
+    ) {
         $this->easyCodingStandardStyle = $easyCodingStandardStyle;
+        $this->configuration = $configuration;
+        $this->errorAndDiffCollector = $errorAndDiffCollector;
+    }
+
+    public function report(int $processedFilesCount): int
+    {
+        $this->reportFileDiffs($this->errorAndDiffCollector->getFileDiffs());
+
+        if ($this->errorAndDiffCollector->getErrorCount() === 0
+            && $this->errorAndDiffCollector->getFileDiffsCount() === 0
+        ) {
+            if ($processedFilesCount) {
+                $this->easyCodingStandardStyle->newLine();
+            }
+            $this->easyCodingStandardStyle->success('No errors found. Great job - your code is shiny in style!');
+
+            return ShellCode::SUCCESS;
+        }
+
+        $this->easyCodingStandardStyle->newLine();
+
+        return $this->configuration->isFixer() ? $this->printAfterFixerStatus() : $this->printNoFixerStatus();
     }
 
     /**
      * @param FileDiff[][] $fileDiffPerFile
      */
-    public function reportFileDiffs(array $fileDiffPerFile): void
+    private function reportFileDiffs(array $fileDiffPerFile): void
     {
         if (! count($fileDiffPerFile)) {
             return;
@@ -44,5 +82,76 @@ final class CheckCommandReporter
                 $this->easyCodingStandardStyle->listing($fileDiff->getAppliedCheckers());
             }
         }
+    }
+
+    private function printAfterFixerStatus(): int
+    {
+        if ($this->configuration->showErrorTable()) {
+            $this->easyCodingStandardStyle->printErrors($this->errorAndDiffCollector->getErrors());
+        }
+
+        if ($this->errorAndDiffCollector->getErrorCount() === 0) {
+            $this->easyCodingStandardStyle->success(
+                sprintf(
+                    '%d error%s successfully fixed and no other found!',
+                    $this->errorAndDiffCollector->getFileDiffsCount(),
+                    $this->errorAndDiffCollector->getFileDiffsCount() === 1 ? '' : 's'
+                )
+            );
+
+            return ShellCode::SUCCESS;
+        }
+
+        $this->printErrorMessageFromErrorCounts(
+            $this->errorAndDiffCollector->getErrorCount(),
+            $this->errorAndDiffCollector->getFileDiffsCount()
+        );
+
+        return ShellCode::ERROR;
+    }
+
+    private function printNoFixerStatus(): int
+    {
+        if ($this->configuration->showErrorTable()) {
+            $errors = $this->errorAndDiffCollector->getErrors();
+            if (count($errors)) {
+                $this->easyCodingStandardStyle->newLine();
+                $this->easyCodingStandardStyle->printErrors($errors);
+            }
+        }
+
+        $this->printErrorMessageFromErrorCounts(
+            $this->errorAndDiffCollector->getErrorCount(),
+            $this->errorAndDiffCollector->getFileDiffsCount()
+        );
+
+        return ShellCode::ERROR;
+    }
+
+    private function printErrorMessageFromErrorCounts(int $errorCount, int $fileDiffsCount): void
+    {
+        if ($errorCount) {
+            $this->easyCodingStandardStyle->error(
+                sprintf(
+                    'Found %d error%s that need%s to be fixed manually.',
+                    $errorCount,
+                    $errorCount === 1 ? '' : 's',
+                    $errorCount === 1 ? '' : 's'
+                )
+            );
+        }
+
+        if (! $fileDiffsCount || $this->configuration->isFixer()) {
+            return;
+        }
+
+        $this->easyCodingStandardStyle->fixableError(
+            sprintf(
+                '%s%d %s fixable! Just add "--fix" to console command and rerun to apply.',
+                $errorCount ? 'Good news is that ' : '',
+                $fileDiffsCount,
+                $fileDiffsCount === 1 ? 'file is' : 'files are'
+            )
+        );
     }
 }


### PR DESCRIPTION
Move all print functionality inside CheckCommandReporter.

This will allow to extract a common interface, and implement `CheckCommandJsonReporter` and `CheckCommandTableReporter` as mentioned here:
* https://github.com/Symplify/Symplify/issues/1095#issuecomment-420994905
* https://github.com/Symplify/Symplify/issues/1118
