### PR TITLE
(WIP) [MonorepoBuilder] Fix tests for MacOS

### DIFF
--- a/packages/MonorepoBuilder/tests/Package/CombineStringsToArrayJsonMergerTest.php
+++ b/packages/MonorepoBuilder/tests/Package/CombineStringsToArrayJsonMergerTest.php
@@ -5,11 +5,14 @@ namespace Symplify\MonorepoBuilder\Tests\Package;
 use Symfony\Component\Finder\Finder;
 use Symplify\MonorepoBuilder\Package\PackageComposerJsonMerger;
 use Symplify\MonorepoBuilder\Tests\AbstractContainerAwareTestCase;
+use Symplify\MonorepoBuilder\Tests\RecursiveKeySortTrait;
 use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 
 final class CombineStringsToArrayJsonMergerTest extends AbstractContainerAwareTestCase
 {
+    use RecursiveKeySortTrait;
+
     /**
      * @var PackageComposerJsonMerger
      */
@@ -31,8 +34,7 @@ final class CombineStringsToArrayJsonMergerTest extends AbstractContainerAwareTe
         $merged = $this->packageComposerJsonMerger->mergeFileInfos(
             $this->getFileInfosFromDirectory(__DIR__ . '/SourceAutoloadSharedNamespaces')
         );
-
-        $this->assertSame([
+        $original = [
             'autoload' => [
                 'psr-4' => [
                     'ACME\Model\Core\\' => ['packages/A', 'packages/B'],
@@ -41,7 +43,12 @@ final class CombineStringsToArrayJsonMergerTest extends AbstractContainerAwareTe
                     'ACME\\YetYetAnother\\' => 'packages/A',
                 ],
             ],
-        ], $merged);
+        ];
+
+        $this->recursiveSort($original);
+        $this->recursiveSort($merged);
+
+        $this->assertSame($original, $merged);
     }
 
     /**

--- a/packages/MonorepoBuilder/tests/Package/PackageComposerJsonMergerTest.php
+++ b/packages/MonorepoBuilder/tests/Package/PackageComposerJsonMergerTest.php
@@ -5,11 +5,14 @@ namespace Symplify\MonorepoBuilder\Tests\Package;
 use Symfony\Component\Finder\Finder;
 use Symplify\MonorepoBuilder\Package\PackageComposerJsonMerger;
 use Symplify\MonorepoBuilder\Tests\AbstractContainerAwareTestCase;
+use Symplify\MonorepoBuilder\Tests\RecursiveKeySortTrait;
 use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 
 final class PackageComposerJsonMergerTest extends AbstractContainerAwareTestCase
 {
+    use RecursiveKeySortTrait;
+
     /**
      * @var PackageComposerJsonMerger
      */
@@ -32,7 +35,7 @@ final class PackageComposerJsonMergerTest extends AbstractContainerAwareTestCase
             $this->getFileInfosFromDirectory(__DIR__ . '/Source')
         );
 
-        $this->assertSame([
+        $original = [
             'require' => [
                 'rector/rector' => '^2.0',
                 'phpunit/phpunit' => '^2.0',
@@ -44,7 +47,12 @@ final class PackageComposerJsonMergerTest extends AbstractContainerAwareTestCase
                     'Symplify\MonorepoBuilder\\' => 'src',
                 ],
             ],
-        ], $merged);
+        ];
+
+        $this->recursiveSort($original);
+        $this->recursiveSort($merged);
+
+        $this->assertSame($original, $merged);
     }
 
     public function testUniqueRepositories(): void

--- a/packages/MonorepoBuilder/tests/RecursiveKeySortTrait.php
+++ b/packages/MonorepoBuilder/tests/RecursiveKeySortTrait.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests;
+
+use function Safe\ksort;
+
+trait RecursiveKeySortTrait
+{
+    /**
+     * @param mixed[] $array
+     */
+    private static function recursiveSort(array &$array): void
+    {
+        if (! is_array($array)) {
+            return;
+        }
+
+        ksort($array);
+
+        foreach ($array as $key => &$value) {
+            if (is_array($value)) {
+                self::recursiveSort($value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Using ksort fixed `PackageComposerJsonMergerTest`.

But `CombineStringsToArrayJsonMergerTest` is still failing.

```diff
1) Symplify\MonorepoBuilder\Tests\Package\CombineStringsToArrayJsonMergerTest::testSharedNamespaces
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
         'psr-4' => Array &2 (
             'ACME\Another\' => 'packages/A'
             'ACME\Model\Core\' => Array &3 (
-                0 => 'packages/A'
-                1 => 'packages/B'
+                0 => 'packages/B'
+                1 => 'packages/A'
             )
-            'ACME\YetAnother\' => Array &4 (
+            'ACME\YetAnother\' => 'packages/A'
+            'ACME\YetYetAnother\' => Array &4 (
                 0 => 'packages/A'
             )
-            'ACME\YetYetAnother\' => 'packages/A'
         )
     )
 )

Symplify/packages/MonorepoBuilder/tests/Package/CombineStringsToArrayJsonMergerTest.php:51
```