### PR TITLE
make public expicit instead of compiler pass

### DIFF
--- a/packages/BetterPhpDocParser/src/DependencyInjection/BetterPhpDocParserKernel.php
+++ b/packages/BetterPhpDocParser/src/DependencyInjection/BetterPhpDocParserKernel.php
@@ -6,7 +6,6 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 
 final class BetterPhpDocParserKernel extends Kernel
@@ -20,7 +19,6 @@ final class BetterPhpDocParserKernel extends Kernel
 
     protected function build(ContainerBuilder $containerBuilder): void
     {
-        $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireArrayParameterCompilerPass());
     }
 }

--- a/packages/ChangelogLinker/src/DependencyInjection/ChangelogLinkerKernel.php
+++ b/packages/ChangelogLinker/src/DependencyInjection/ChangelogLinkerKernel.php
@@ -10,7 +10,6 @@ use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersC
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoReturnFactoryCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\ConfigurableCollectorCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 
 final class ChangelogLinkerKernel extends Kernel
@@ -53,7 +52,6 @@ final class ChangelogLinkerKernel extends Kernel
         // needs to be first, since it's adding new service definitions
         $containerBuilder->addCompilerPass(new AutoReturnFactoryCompilerPass());
 
-        $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireArrayParameterCompilerPass());
         $containerBuilder->addCompilerPass(new ConfigurableCollectorCompilerPass());
         $containerBuilder->addCompilerPass(new DetectParametersCompilerPass());

--- a/packages/EasyCodingStandard/src/DependencyInjection/EasyCodingStandardKernel.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/EasyCodingStandardKernel.php
@@ -21,7 +21,6 @@ use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParame
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireInterfacesCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\ConfigurableCollectorCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 
 final class EasyCodingStandardKernel extends Kernel
@@ -76,9 +75,6 @@ final class EasyCodingStandardKernel extends Kernel
 
         // exceptions
         $containerBuilder->addCompilerPass(new ConflictingCheckersCompilerPass());
-
-        // tests
-        $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
 
         // parameters
         $containerBuilder->addCompilerPass(new DetectParametersCompilerPass());

--- a/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
@@ -21,6 +21,12 @@ use function Safe\sprintf;
 abstract class AbstractCheckerTestCase extends TestCase
 {
     /**
+     * To invalidate new versions
+     * @var string
+     */
+    private const CACHE_VERSION_ID = 'v1';
+
+    /**
      * @var string
      */
     private const SPLIT_LINE = '#-----\n#';
@@ -126,6 +132,9 @@ abstract class AbstractCheckerTestCase extends TestCase
 
             $servicesConfiguration = [
                 'services' => [
+                    '_defaults' => [
+                        'public' => true, // for tests
+                    ],
                     $this->getCheckerClass() => $this->getCheckerConfiguration() ?: null,
                 ],
             ];
@@ -265,7 +274,7 @@ abstract class AbstractCheckerTestCase extends TestCase
     private function createConfigHash(): string
     {
         return Strings::substring(
-            md5($this->getCheckerClass() . Json::encode($this->getCheckerConfiguration())),
+            md5($this->getCheckerClass() . Json::encode($this->getCheckerConfiguration()) . self::CACHE_VERSION_ID),
             0,
             10
         );

--- a/packages/LatteToTwigConverter/src/DependencyInjection/LatteToTwigConverterKernel.php
+++ b/packages/LatteToTwigConverter/src/DependencyInjection/LatteToTwigConverterKernel.php
@@ -7,7 +7,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoReturnFactoryCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 
 final class LatteToTwigConverterKernel extends Kernel
@@ -28,6 +27,5 @@ final class LatteToTwigConverterKernel extends Kernel
         $containerBuilder->addCompilerPass(new AutoReturnFactoryCompilerPass());
 
         $containerBuilder->addCompilerPass(new AutowireArrayParameterCompilerPass());
-        $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
     }
 }

--- a/packages/MonorepoBuilder/src/DependencyInjection/MonorepoBuilderKernel.php
+++ b/packages/MonorepoBuilder/src/DependencyInjection/MonorepoBuilderKernel.php
@@ -12,7 +12,6 @@ use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoReturnFactoryCo
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireInterfacesCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\ConfigurableCollectorCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 
 final class MonorepoBuilderKernel extends Kernel
@@ -48,7 +47,6 @@ final class MonorepoBuilderKernel extends Kernel
 
         $containerBuilder->addCompilerPass(new ConfigurableCollectorCompilerPass());
         $containerBuilder->addCompilerPass(new DetectParametersCompilerPass());
-        $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireArrayParameterCompilerPass());
         $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
     }

--- a/packages/Statie/src/DependencyInjection/StatieKernel.php
+++ b/packages/Statie/src/DependencyInjection/StatieKernel.php
@@ -15,7 +15,6 @@ use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoReturnFactoryCo
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\ConfigurableCollectorCompilerPass;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\PublicForTestsCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 use Symplify\PackageBuilder\Yaml\FileLoader\ParameterMergingYamlFileLoader;
 
@@ -50,7 +49,6 @@ final class StatieKernel extends Kernel
 
         $containerBuilder->addCompilerPass(new AutowireArrayParameterCompilerPass());
         $containerBuilder->addCompilerPass(new ConfigurableCollectorCompilerPass());
-        $containerBuilder->addCompilerPass(new PublicForTestsCompilerPass());
         $containerBuilder->addCompilerPass(new AutowireSinglyImplementedCompilerPass());
         $containerBuilder->addCompilerPass(new AutoBindParametersCompilerPass());
     }


### PR DESCRIPTION
Focus on public/private brings no value here, no need to play with compiler passes, if you why this was introduced - to move from named service locator to DI. DI is first class citizen here since the very beggining.