### PR TITLE
[CodingStandard] fix FinalInterfaceFixer false positive for anonymous class

### DIFF
--- a/packages/CodingStandard/src/Fixer/Solid/FinalInterfaceFixer.php
+++ b/packages/CodingStandard/src/Fixer/Solid/FinalInterfaceFixer.php
@@ -80,6 +80,10 @@ class SomeClass implements SomeInterface {};')]
             return true;
         }
 
+        if ($classWrapper->isAnonymous()) {
+            return true;
+        }
+
         if ($this->onlyInterfaces) {
             return ! array_intersect($this->onlyInterfaces, $classWrapper->getInterfaceNames());
         }

--- a/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/FinalInterfaceFixerTest.php
+++ b/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/FinalInterfaceFixerTest.php
@@ -15,8 +15,10 @@ final class FinalInterfaceFixerTest extends AbstractCheckerTestCase
             __DIR__ . '/Fixture/correct3.php.inc',
             __DIR__ . '/Fixture/correct4.php.inc',
             __DIR__ . '/Fixture/correct5.php.inc',
+            __DIR__ . '/Fixture/correct6.php.inc',
             __DIR__ . '/Fixture/wrong.php.inc',
             __DIR__ . '/Fixture/wrong2.php.inc',
+            __DIR__ . '/Fixture/wrong4.php.inc',
         ]);
     }
 

--- a/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/Fixture/correct6.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/Fixture/correct6.php.inc
@@ -1,0 +1,81 @@
+<?php
+
+namespace SomeNamespace\AnonymousClass;
+
+// from correct.php.inc
+final class SomeClass implements SomeSpecialInterface
+{
+    public function createAnonymousClass()
+    {
+        return new class
+        {
+        };
+    }
+
+    public function createAnonymousClassImplementsInterface(): SomeInterface
+    {
+        return new class implements SomeInterface
+        {
+        };
+    }
+}
+
+// from correct2.php.inc
+abstract class SomeAbstractClass implements SomeSpecialInterface
+{
+    public function createAnonymousClass()
+    {
+        return new class
+        {
+        };
+    }
+
+    public function createAnonymousClassImplementsInterface(): SomeInterface
+    {
+        return new class implements SomeInterface
+        {
+        };
+    }
+}
+
+// from correct4.php.inc
+
+/**
+ * @ORM\SomeAnnotation
+ * @ORM\Entity
+ * @ORM\SomeAnotherAnnotation
+ */
+class SomeEntity implements SomeInterface
+{
+    public function createAnonymousClass()
+    {
+        return new class
+        {
+        };
+    }
+
+    public function createAnonymousClassImplementsInterface(): SomeInterface
+    {
+        return new class implements SomeInterface
+        {
+        };
+    }
+}
+
+// from correct4.php.inc
+class AnotherEntity
+{
+    public function createAnonymousClass()
+    {
+        return new class
+        {
+        };
+    }
+
+    public function createAnonymousClassImplementsInterface(): SomeInterface
+    {
+        return new class implements SomeInterface
+        {
+        };
+    }
+}

--- a/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/Fixture/wrong4.php.inc
+++ b/packages/CodingStandard/tests/Fixer/Solid/FinalInterfaceFixer/Fixture/wrong4.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+namespace SomeNamespace\AnonymousClass;
+
+
+class SomeClass implements SomeSpecialInterface
+{
+    public function createAnonymousClass()
+    {
+        return new class
+        {
+        };
+    }
+
+    public function createAnonymousClassImplementsInterface(): SomeInterface
+    {
+        return new class implements SomeInterface
+        {
+        };
+    }
+}
+
+?>
+-----
+<?php
+
+namespace SomeNamespace\AnonymousClass;
+
+
+final class SomeClass implements SomeSpecialInterface
+{
+    public function createAnonymousClass()
+    {
+        return new class
+        {
+        };
+    }
+
+    public function createAnonymousClassImplementsInterface(): SomeInterface
+    {
+        return new class implements SomeInterface
+        {
+        };
+    }
+}
+
+?>

--- a/packages/TokenRunner/src/Wrapper/FixerWrapper/ClassWrapper.php
+++ b/packages/TokenRunner/src/Wrapper/FixerWrapper/ClassWrapper.php
@@ -279,6 +279,11 @@ final class ClassWrapper
         return Strings::contains($this->tokens[$docCommentPosition]->getContent(), 'Entity');
     }
 
+    public function isAnonymous(): bool
+    {
+        return (new TokensAnalyzer($this->tokens))->isAnonymousClass($this->startIndex);
+    }
+
     /**
      * @return mixed[]
      */


### PR DESCRIPTION
FinalInterfaceFixer adds `final` keyword onto anonymous classes which implement a interface. This is considered false positive code fixing.

```diff
// true positive code fixing
-class SomeClass implements SomeSpecialInterface
+final class SomeClass implements SomeSpecialInterface
{
    public function createAnonymousClassImplementsInterface(): SomeInterface
    {
         // false positive code fixing
-        return new class implements SomeInterface
+        return new final class implements SomeInterface
        {
        };
    }
}
```

This merge request solve the problem by adding modification that skips the target classes if they are anonymous classes.

```diff
// true positive code fixing
-class SomeClass implements SomeSpecialInterface
+final class SomeClass implements SomeSpecialInterface
{
    public function createAnonymousClassImplementsInterface(): SomeInterface
    {
         // false positive code fixing
        return new class implements SomeInterface
        {
        };
    }
}
```