### PR TITLE
[Autodiscovery] Add yaml explicit to autodiscovery converter

### DIFF
--- a/ecs.yml
+++ b/ecs.yml
@@ -125,6 +125,7 @@ parameters:
             - 'packages/PackageBuilder/src/Console/Command/CommandNaming.php'
             - 'packages/PackageBuilder/src/Configuration/ConfigFileFinder.php'
             - 'packages/PackageBuilder/src/Composer/VendorDirProvider.php'
+            - 'packages/Autodiscovery/src/Arrays.php'
 
         Symplify\CodingStandard\Sniffs\CleanCode\CognitiveComplexitySniff:
             # 3rd party code copy-pasted; kept as is for easier comparison to original

--- a/packages/Autodiscovery/.travis.yml
+++ b/packages/Autodiscovery/.travis.yml
@@ -14,6 +14,7 @@ install:
 
 script:
     - vendor/bin/phpunit
+    - bin/autodiscovery
 
 notifications:
     email: false

--- a/packages/Autodiscovery/bin/autodiscovery
+++ b/packages/Autodiscovery/bin/autodiscovery
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/autoload.php';
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Application;
+use Symplify\PackageBuilder\Console\ThrowableRenderer;
+
+try {
+    /** @var ContainerInterface $container */
+    $container = require_once __DIR__ . '/container.php';
+
+    $application = $container->get(Application::class);
+    exit($application->run());
+} catch (Throwable $throwable) {
+    (new ThrowableRenderer())->render($throwable);
+}

--- a/packages/Autodiscovery/bin/autoload.php
+++ b/packages/Autodiscovery/bin/autoload.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+$possibleAutoloadPaths = [
+    // after split package
+    __DIR__ . '/../vendor/autoload.php',
+    // dependency
+    __DIR__ . '/../../../autoload.php',
+    // monorepo
+    __DIR__ . '/../../../vendor/autoload.php',
+];
+
+foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
+    if (file_exists($possibleAutoloadPath)) {
+        require_once $possibleAutoloadPath;
+
+        break;
+    }
+}

--- a/packages/Autodiscovery/bin/container.php
+++ b/packages/Autodiscovery/bin/container.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+use Symplify\Autodiscovery\DependencyInjection\ContainerFactory;
+
+return (new ContainerFactory())->create();

--- a/packages/Autodiscovery/composer.json
+++ b/packages/Autodiscovery/composer.json
@@ -2,9 +2,13 @@
     "name": "symplify/autodiscovery",
     "description": "Forget manual registration of Doctrine entities, Twig templates and routes. Let autodiscovery handle that for you.",
     "license": "MIT",
+    "bin": [
+        "bin/autodiscovery"
+    ],
     "require": {
         "php": "^7.1",
         "nette/utils": "^2.5",
+        "symfony/console": "^3.4|^4.1",
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
         "symfony/routing": "^3.4|^4.1",

--- a/packages/Autodiscovery/config/config.yml
+++ b/packages/Autodiscovery/config/config.yml
@@ -1,0 +1,11 @@
+services:
+    _defaults:
+        autowire: true
+        public: true
+
+    Symplify\Autodiscovery\:
+        resource: '../src'
+        exclude: '../src/{Contract,DependencyInjection,AutodiscovererCollector.php,Doctrine/DoctrineEntityMappingAutodiscoverer.php,FileSystem.php,Routing/AnnotationRoutesAutodiscover.php,Twig/TwigPathAutodiscoverer.php}'
+
+    Symfony\Component\Console\Application: ~
+    Symfony\Component\Filesystem\Filesystem: ~

--- a/packages/Autodiscovery/src/Arrays.php
+++ b/packages/Autodiscovery/src/Arrays.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery;
+
+final class Arrays
+{
+    /**
+     * @param mixed[] $items
+     */
+    public static function hasOnlyKey(array $items, string $key): bool
+    {
+        if (count($items) !== 1) {
+            return false;
+        }
+
+        return isset($items[$key]);
+    }
+}

--- a/packages/Autodiscovery/src/Command/ConvertYamlCommand.php
+++ b/packages/Autodiscovery/src/Command/ConvertYamlCommand.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Command;
+
+use Nette\Utils\FileSystem;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+use Symplify\Autodiscovery\Yaml\ExplicitToAutodiscoveryConverter;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+use Symplify\PackageBuilder\Console\ShellCode;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
+use function Safe\sprintf;
+
+final class ConvertYamlCommand extends Command
+{
+    /**
+     * @var string
+     */
+    private const OPTION_REMOVE_SINGLY_IMPLEMENTED = 'remove-singly-implemented';
+
+    /**
+     * @var string
+     */
+    private const OPTION_NESTING_LEVEL = 'nesting-level';
+
+    /**
+     * @var ExplicitToAutodiscoveryConverter
+     */
+    private $explicitToAutodiscoveryConverter;
+
+    public function __construct(ExplicitToAutodiscoveryConverter $explicitToAutodiscoveryConverter)
+    {
+        parent::__construct();
+        $this->explicitToAutodiscoveryConverter = $explicitToAutodiscoveryConverter;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(CommandNaming::classToName(self::class));
+        $this->setDescription(
+            'Convert "services.yml" from pre-Symfony 3.3 format to modern format using autodiscovery, autowire and autoconfigure'
+        );
+
+        $this->addArgument('file', InputArgument::REQUIRED, 'Path to "services.yml" to convert');
+
+        $this->addOption(
+            self::OPTION_REMOVE_SINGLY_IMPLEMENTED,
+            'r',
+            InputOption::VALUE_REQUIRED,
+            sprintf(
+                'Remove aliases added only for only-implementations, useful in combination with "%s".',
+                AutowireSinglyImplementedCompilerPass::class
+            ),
+            false
+        );
+
+        $this->addOption(
+            self::OPTION_NESTING_LEVEL,
+            'l',
+            InputOption::VALUE_REQUIRED,
+            'How many namespace levels should be separated in autodiscovery, e.g 1 → "App\", 2 → "App\SomeProject\"',
+            2
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $servicesFile = $input->getArgument('file');
+        $removeSinglyImplemented = (bool) $input->getOption(self::OPTION_REMOVE_SINGLY_IMPLEMENTED);
+        $nestingLevel = (int) $input->getOption(self::OPTION_NESTING_LEVEL);
+
+        $servicesContent = FileSystem::read($servicesFile);
+        $servicesYaml = Yaml::parse($servicesContent);
+
+        $convertedContent = $this->explicitToAutodiscoveryConverter->convert(
+            $servicesYaml,
+            $servicesFile,
+            $nestingLevel,
+            $removeSinglyImplemented
+        );
+
+        $output->writeln($convertedContent);
+
+        return ShellCode::SUCCESS;
+    }
+}

--- a/packages/Autodiscovery/src/DependencyInjection/AutodiscoveryKernel.php
+++ b/packages/Autodiscovery/src/DependencyInjection/AutodiscoveryKernel.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\DependencyInjection;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\ConfigurableCollectorCompilerPass;
+use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
+
+final class AutodiscoveryKernel extends Kernel
+{
+    use SimpleKernelTrait;
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(__DIR__ . '/../../config/config.yml');
+    }
+
+    protected function build(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->addCompilerPass(new ConfigurableCollectorCompilerPass());
+    }
+}

--- a/packages/Autodiscovery/src/DependencyInjection/ContainerFactory.php
+++ b/packages/Autodiscovery/src/DependencyInjection/ContainerFactory.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\DependencyInjection;
+
+use Psr\Container\ContainerInterface;
+use function Safe\putenv;
+
+final class ContainerFactory
+{
+    public function create(): ContainerInterface
+    {
+        $appKernel = new AutodiscoveryKernel();
+        $appKernel->boot();
+
+        // this is require to keep CLI verbosity independent on AppKernel dev/prod mode
+        putenv('SHELL_VERBOSITY=0');
+
+        return $appKernel->getContainer();
+    }
+}

--- a/packages/Autodiscovery/src/Php/InterfaceAnalyzer.php
+++ b/packages/Autodiscovery/src/Php/InterfaceAnalyzer.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Php;
+
+use function Safe\class_implements;
+
+final class InterfaceAnalyzer
+{
+    public function isInterfaceOnlyImplementation(string $interface, string $class): bool
+    {
+        if (! interface_exists($interface)) {
+            return false;
+        }
+
+        if (! class_exists($class)) {
+            return false;
+        }
+
+        $interfaceImplementers = $this->getInterfaceImplementers($interface);
+        if (! in_array($class, $interfaceImplementers, true)) {
+            return false;
+        }
+
+        if (count($interfaceImplementers) !== 1) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getInterfaceImplementers(string $interface): array
+    {
+        $interfaceImplementers = [];
+        foreach (get_declared_classes() as $className) {
+            if (in_array($interface, class_implements($className), true)) {
+                $interfaceImplementers[] = $className;
+            }
+        }
+
+        return $interfaceImplementers;
+    }
+}

--- a/packages/Autodiscovery/src/Yaml/CommonNamespaceResolver.php
+++ b/packages/Autodiscovery/src/Yaml/CommonNamespaceResolver.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Yaml;
+
+use Nette\Utils\Strings;
+
+final class CommonNamespaceResolver
+{
+    /**
+     * @param string[] $classes
+     * @return string[]
+     */
+    public function resolve(array $classes, int $nestingLevel): array
+    {
+        $namespaces = [];
+        foreach ($classes as $class) {
+            $namespace = Strings::before($class, '\\', $nestingLevel);
+            if ($namespace) {
+                $namespaces[] = $namespace;
+            }
+        }
+
+        return array_unique($namespaces);
+    }
+}

--- a/packages/Autodiscovery/src/Yaml/ExplicitToAutodiscoveryConverter.php
+++ b/packages/Autodiscovery/src/Yaml/ExplicitToAutodiscoveryConverter.php
@@ -1,0 +1,303 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Yaml;
+
+use Nette\Utils\Strings;
+use ReflectionClass;
+use Symfony\Component\Filesystem\Filesystem;
+use Symplify\Autodiscovery\Arrays;
+use Symplify\Autodiscovery\Php\InterfaceAnalyzer;
+use function Safe\realpath;
+
+final class ExplicitToAutodiscoveryConverter
+{
+    /**
+     * @var bool
+     */
+    private $enableAutowire = false;
+
+    /**
+     * @var bool
+     */
+    private $removeService = false;
+
+    /**
+     * @var bool
+     */
+    private $enableAutoconfigure = false;
+
+    /**
+     * @var bool
+     */
+    private $removeSinglyImplementedAlaises = false;
+
+    /**
+     * @var string[]
+     */
+    private $classes = [];
+
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var CommonNamespaceResolver
+     */
+    private $commonNamespaceResolver;
+
+    /**
+     * @var InterfaceAnalyzer
+     */
+    private $interfaceAnalyzer;
+
+    /**
+     * @var TagAnalyzer
+     */
+    private $tagAnalyzer;
+
+    public function __construct(
+        Filesystem $filesystem,
+        CommonNamespaceResolver $commonNamespaceResolver,
+        InterfaceAnalyzer $interfaceAnalyzer,
+        TagAnalyzer $tagAnalyzer
+    ) {
+        $this->filesystem = $filesystem;
+        $this->commonNamespaceResolver = $commonNamespaceResolver;
+        $this->interfaceAnalyzer = $interfaceAnalyzer;
+        $this->tagAnalyzer = $tagAnalyzer;
+    }
+
+    /**
+     * @param mixed[] $yaml
+     * @return mixed[]
+     */
+    public function convert(
+        array $yaml,
+        string $filePath,
+        int $nestingLevel,
+        bool $removeSinglyImplementedAliases
+    ): array {
+        $this->reset($removeSinglyImplementedAliases);
+
+        // nothing to change
+        if (! isset($yaml[YamlKey::SERVICES])) {
+            return $yaml;
+        }
+
+        foreach ($yaml[YamlKey::SERVICES] as $name => $service) {
+            $yaml = $this->processService($yaml, $service, $name);
+        }
+
+        $yaml = $this->completeAutodiscovery($yaml, $filePath, $nestingLevel);
+
+        if ($this->enableAutoconfigure) {
+            $yaml = $this->completeDefaultsKeyTrue($yaml, YamlKey::AUTODISCOVERY);
+        }
+
+        if ($this->enableAutowire) {
+            $yaml = $this->completeDefaultsKeyTrue($yaml, YamlKey::AUTOWIRE);
+        }
+
+        return $yaml;
+    }
+
+    private function reset(bool $removeSinglyImplementedAliases): void
+    {
+        $this->classes = [];
+        $this->enableAutowire = false;
+        $this->enableAutoconfigure = false;
+        $this->removeSinglyImplementedAlaises = $removeSinglyImplementedAliases;
+    }
+
+    /**
+     * @param mixed[] $yaml
+     * @param string|mixed[]|null $service
+     * @return mixed[]
+     */
+    private function processService(array $yaml, $service, string $name): array
+    {
+        $this->removeService = false;
+
+        if (is_array($service)) {
+            [$yaml, $service, $name] = $this->processArrayService($yaml, $service, $name);
+        }
+
+        // anonymous service
+        if ($service === null) {
+            $this->classes[] = $name;
+            $this->removeService = true;
+        }
+
+        // update
+        if ($this->removeService) {
+            unset($yaml[YamlKey::SERVICES][$name]);
+        } else {
+            $yaml[YamlKey::SERVICES][$name] = $service;
+        }
+
+        return $yaml;
+    }
+
+    /**
+     * @param mixed[] $yaml
+     * @return mixed[]
+     */
+    private function completeAutodiscovery(array $yaml, string $filePath, int $nestingLevel): array
+    {
+        $commonNamespaces = $this->commonNamespaceResolver->resolve($this->classes, $nestingLevel);
+        $groupedServices = $this->groupServicesByNamespaces($this->classes, $commonNamespaces);
+
+        foreach ($groupedServices as $namespace => $services) {
+            $yaml[YamlKey::SERVICES][$namespace . '\\'] = [
+                YamlKey::RESOURCE => $this->getRelativeClassLocation($services[0], $filePath),
+            ];
+
+            $this->enableAutowire = true;
+        }
+
+        return $yaml;
+    }
+
+    /**
+     * @param mixed[] $yaml
+     * @return mixed[]
+     */
+    private function completeDefaultsKeyTrue(array $yaml, string $key): array
+    {
+        if (isset($yaml[YamlKey::SERVICES][YamlKey::DEFAULTS][$key])) {
+            $yaml[YamlKey::SERVICES][YamlKey::DEFAULTS][$key] = true;
+            return $yaml;
+        }
+
+        // yes "_defaults", but no "autowire" section
+        if (isset($yaml[YamlKey::SERVICES][YamlKey::DEFAULTS])) {
+            $yaml[YamlKey::SERVICES][YamlKey::DEFAULTS] = array_merge(
+                [$key => true],
+                $yaml[YamlKey::SERVICES][YamlKey::DEFAULTS]
+            );
+
+            return $yaml;
+        }
+
+        // no "_defaults" section
+        $yaml[YamlKey::SERVICES] = array_merge([YamlKey::DEFAULTS => [$key => true]], $yaml[YamlKey::SERVICES]);
+
+        return $yaml;
+    }
+
+    /**
+     * @param mixed[] $yaml
+     * @param mixed[] $service
+     * @return mixed[]
+     */
+    private function processArrayService(array $yaml, array $service, string $name): array
+    {
+        $service = $this->processAutowire($service);
+        $service = $this->processTags($service);
+
+        $this->processAlias($service, $name);
+
+        // is only named services
+        if (Arrays::hasOnlyKey($service, 'class')) {
+            unset($yaml[YamlKey::SERVICES][$name]);
+
+            $name = $service['class'];
+            $service = null;
+            $yaml[YamlKey::SERVICES][$name] = $service;
+        }
+
+        // is named service
+        if (isset($service['class']) && is_string($name) && ! ctype_upper($name[0]) && ! class_exists($name)) {
+            // @todo check is no where used in the script, regular would do
+
+            unset($yaml[YamlKey::SERVICES][$name]);
+            $name = $service['class'];
+            unset($service['class']);
+
+            $yaml[YamlKey::SERVICES][$name] = $service;
+        }
+
+        return [$yaml, $service, $name];
+    }
+
+    /**
+     * @param string[] $services
+     * @param string[] $commonNamespaces
+     * @return string[]
+     */
+    private function groupServicesByNamespaces(array $services, array $commonNamespaces): array
+    {
+        $groupedServicesByNamespace = [];
+        foreach ($commonNamespaces as $commonNamespace) {
+            foreach ($services as $service) {
+                if (Strings::startsWith($service, $commonNamespace . '\\')) {
+                    $groupedServicesByNamespace[$commonNamespace][] = $service;
+                    continue;
+                }
+            }
+        }
+
+        return $groupedServicesByNamespace;
+    }
+
+    private function getRelativeClassLocation(string $class, string $configFilePath): string
+    {
+        if (! class_exists($class)) {
+            // assumption of traditional location
+            $classDirectory = realpath(__DIR__ . '/../../src');
+        } else {
+            $reflectionClass = new ReflectionClass($class);
+
+            $classDirectory = dirname($reflectionClass->getFileName());
+        }
+
+        $configDirectory = dirname($configFilePath);
+        $relativePath = $this->filesystem->makePathRelative($classDirectory, $configDirectory);
+
+        return rtrim($relativePath, '/');
+    }
+
+    /**
+     * @param mixed[] $service
+     * @return mixed[]
+     */
+    private function processAutowire(array $service): array
+    {
+        // remove autowire
+        if (isset($service[YamlKey::AUTOWIRE])) {
+            unset($service[YamlKey::AUTOWIRE]);
+            $this->enableAutowire = true;
+        }
+
+        return $service;
+    }
+
+    /**
+     * @param mixed[] $service
+     * @return mixed[]
+     */
+    private function processTags(array $service): array
+    {
+        if (isset($service[YamlKey::TAGS])) {
+            if ($this->tagAnalyzer->isAutoconfiguredTags($service[YamlKey::TAGS])) {
+                unset($service[YamlKey::TAGS]);
+                $this->enableAutoconfigure = true;
+            }
+        }
+
+        return $service;
+    }
+
+    /**
+     * @param mixed[] $service
+     */
+    private function processAlias(array $service, string $name): void
+    {
+        if (Arrays::hasOnlyKey($service, 'alias') && $this->removeSinglyImplementedAlaises) {
+            if ($this->interfaceAnalyzer->isInterfaceOnlyImplementation($name, $service['alias'])) {
+                $this->removeService = true;
+            }
+        }
+    }
+}

--- a/packages/Autodiscovery/src/Yaml/TagAnalyzer.php
+++ b/packages/Autodiscovery/src/Yaml/TagAnalyzer.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Yaml;
+
+use Symplify\Autodiscovery\Arrays;
+
+final class TagAnalyzer
+{
+    /**
+     * @var string[]
+     */
+    private $autoconfiguredTagNames = [
+        'console.command',
+        'config_cache.resource_checker',
+        'container.service_subscriber',
+        'controller.service_arguments',
+        'controller.service_arguments',
+        'data_collector',
+        'form.type',
+        'form.type_guesser',
+        'kernel.cache_clearer',
+        'kernel.cache_warmer',
+        'kernel.event_subscriber',
+        'property_info.list_extractor',
+        'property_info.type_extractor',
+        'property_info.description_extractor',
+        'property_info.access_extractor',
+        'serializer.encoder',
+        'serializer.normalizer',
+        'validator.constraint_validator',
+        'validator.initializer',
+    ];
+
+    /**
+     * @param mixed[] $tags
+     */
+    public function isAutoconfiguredTags(array $tags): bool
+    {
+        if (! Arrays::hasOnlyKey($tags[0], 'name')) {
+            return false;
+        }
+
+        return in_array($tags[0]['name'], $this->autoconfiguredTagNames, true);
+    }
+}

--- a/packages/Autodiscovery/src/Yaml/YamlKey.php
+++ b/packages/Autodiscovery/src/Yaml/YamlKey.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Yaml;
+
+final class YamlKey
+{
+    /**
+     * @var string
+     */
+    public const DEFAULTS = '_defaults';
+
+    /**
+     * @var string
+     */
+    public const SERVICES = 'services';
+
+    /**
+     * @var string
+     */
+    public const AUTOWIRE = 'autowire';
+
+    /**
+     * @var string
+     */
+    public const TAGS = 'tags';
+
+    /**
+     * @var string
+     */
+    public const AUTODISCOVERY = 'autodiscovery';
+
+    /**
+     * @var string
+     */
+    public const RESOURCE = 'resource';
+}

--- a/packages/Autodiscovery/tests/AbstractAppKernelAwareTestCase.php
+++ b/packages/Autodiscovery/tests/AbstractAppKernelAwareTestCase.php
@@ -3,14 +3,14 @@
 namespace Symplify\Autodiscovery\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symplify\Autodiscovery\DependencyInjection\AutodiscoveryKernel;
+use Symplify\Autodiscovery\Tests\DependencyInjection\AudiscoveryTestingKernel;
 
-abstract class AbstractContainerAwareTestCase extends TestCase
+abstract class AbstractAppKernelAwareTestCase extends TestCase
 {
     use ContainerAwareTestCaseTrait;
 
     protected function getKernelClass(): string
     {
-        return AutodiscoveryKernel::class;
+        return AudiscoveryTestingKernel::class;
     }
 }

--- a/packages/Autodiscovery/tests/Doctrine/DoctrineEntityAutodiscoverTest.php
+++ b/packages/Autodiscovery/tests/Doctrine/DoctrineEntityAutodiscoverTest.php
@@ -6,13 +6,13 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\ORM\EntityManager;
-use Symplify\Autodiscovery\Tests\AbstractContainerAwareTestCase;
+use Symplify\Autodiscovery\Tests\AbstractAppKernelAwareTestCase;
 use Symplify\Autodiscovery\Tests\KernelProjectDir\Entity\Product;
 
 /**
  * @covers \Symplify\Autodiscovery\Doctrine\DoctrineEntityMappingAutodiscoverer
  */
-final class DoctrineEntityAutodiscoverTest extends AbstractContainerAwareTestCase
+final class DoctrineEntityAutodiscoverTest extends AbstractAppKernelAwareTestCase
 {
     /**
      * @var MappingDriver

--- a/packages/Autodiscovery/tests/Routing/AnnotationRoutesAutodiscoverTest.php
+++ b/packages/Autodiscovery/tests/Routing/AnnotationRoutesAutodiscoverTest.php
@@ -2,9 +2,9 @@
 
 namespace Symplify\Autodiscovery\Tests\Routing;
 
-use Symplify\Autodiscovery\Tests\AbstractContainerAwareTestCase;
+use Symplify\Autodiscovery\Tests\AbstractAppKernelAwareTestCase;
 
-final class AnnotationRoutesAutodiscoverTest extends AbstractContainerAwareTestCase
+final class AnnotationRoutesAutodiscoverTest extends AbstractAppKernelAwareTestCase
 {
     public function test(): void
     {

--- a/packages/Autodiscovery/tests/Twig/TwigPathAutodiscoveryTest.php
+++ b/packages/Autodiscovery/tests/Twig/TwigPathAutodiscoveryTest.php
@@ -3,7 +3,7 @@
 namespace Symplify\Autodiscovery\Tests\Twig;
 
 use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
-use Symplify\Autodiscovery\Tests\AbstractContainerAwareTestCase;
+use Symplify\Autodiscovery\Tests\AbstractAppKernelAwareTestCase;
 use Twig\Loader\FilesystemLoader as TwigFilesystemLoader;
 use Twig_Environment;
 use function Safe\realpath;
@@ -11,7 +11,7 @@ use function Safe\realpath;
 /**
  * @covers \Symplify\Autodiscovery\Twig\TwigPathAutodiscoverer
  */
-final class TwigPathAutodiscoveryTest extends AbstractContainerAwareTestCase
+final class TwigPathAutodiscoveryTest extends AbstractAppKernelAwareTestCase
 {
     /**
      * @var TwigFilesystemLoader

--- a/packages/Autodiscovery/tests/Yaml/CommonNamespaceResolverTest.php
+++ b/packages/Autodiscovery/tests/Yaml/CommonNamespaceResolverTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Tests\Yaml;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+use Symplify\Autodiscovery\Yaml\CommonNamespaceResolver;
+
+final class CommonNamespaceResolverTest extends TestCase
+{
+    /**
+     * @var CommonNamespaceResolver
+     */
+    private $commonNamespaceResolver;
+
+    protected function setUp(): void
+    {
+        $this->commonNamespaceResolver = new CommonNamespaceResolver();
+    }
+
+    /**
+     * @param string[] $classes
+     * @param string[] $expectedNamespaces
+     * @dataProvider provideData()
+     */
+    public function test(array $classes, int $level, array $expectedNamespaces): void
+    {
+        $this->assertSame($expectedNamespaces, $this->commonNamespaceResolver->resolve($classes, $level));
+    }
+
+    public function provideData(): Iterator
+    {
+        yield [['App\FirstClass', 'App\AnotherClass'], 1, ['App']];
+        yield [['App\Wohoo\FirstClass', 'App\Wohoo\AnotherClass'], 2, ['App\Wohoo']];
+        yield [['App\Wohoo\FirstClass', 'App\Wohoo\AnotherClass'], 1, ['App']];
+        yield [
+            [
+                'Shopsys\FrameworkBundle\Model\Payment\PaymentRepository',
+                'Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade',
+                'Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig',
+            ],
+            2, ['Shopsys\FrameworkBundle'],
+        ];
+        yield [
+            [
+                'Shopsys\FrameworkBundle\Model\Payment\PaymentRepository',
+                'Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade',
+                'Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig',
+            ],
+            3, ['Shopsys\FrameworkBundle\Model', 'Shopsys\FrameworkBundle\Component'],
+        ];
+    }
+}

--- a/packages/Autodiscovery/tests/Yaml/ExplicitToAutodiscoveryConverterTest.php
+++ b/packages/Autodiscovery/tests/Yaml/ExplicitToAutodiscoveryConverterTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Tests\Yaml;
+
+use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+use Symfony\Component\Yaml\Yaml;
+use Symplify\Autodiscovery\Php\InterfaceAnalyzer;
+use Symplify\Autodiscovery\Yaml\CommonNamespaceResolver;
+use Symplify\Autodiscovery\Yaml\ExplicitToAutodiscoveryConverter;
+use Symplify\Autodiscovery\Yaml\TagAnalyzer;
+
+final class ExplicitToAutodiscoveryConverterTest extends TestCase
+{
+    /**
+     * @var string
+     */
+    private const SPLIT_PATTERN = "#---\n#";
+
+    /**
+     * @var ExplicitToAutodiscoveryConverter
+     */
+    private $explicitToAutodiscoveryConverter;
+
+    protected function setUp(): void
+    {
+        $this->explicitToAutodiscoveryConverter = new ExplicitToAutodiscoveryConverter(
+            new SymfonyFilesystem(),
+            new CommonNamespaceResolver(),
+            new InterfaceAnalyzer(),
+            new TagAnalyzer()
+        );
+    }
+
+    public function test(): void
+    {
+        $this->doTestFile(__DIR__ . '/Fixture/singly_implemented_interfaces.yaml', 2);
+        $this->doTestFile(__DIR__ . '/Fixture/singly_implemented_interfaces_excluded.yaml', 2, true);
+        $this->doTestFile(__DIR__ . '/Fixture/first.yaml', 2);
+        $this->doTestFile(__DIR__ . '/Fixture/tags_with_values.yaml', 2);
+        $this->doTestFile(__DIR__ . '/Fixture/shopsys.yaml', 3);
+        $this->doTestFile(__DIR__ . '/Fixture/elasticr.yaml', 3);
+        $this->doTestFile(__DIR__ . '/Fixture/blog_post_votruba.yaml', 1);
+    }
+
+    private function doTestFile(string $file, int $nestingLevel, bool $removeSinglyImplemented = false): void
+    {
+        $yamlContent = FileSystem::read($file);
+
+        [$originalYamlContent, $expectedYamlContent] = $this->splitFile($yamlContent);
+
+        $originalYaml = Yaml::parse($originalYamlContent);
+        $expectedYaml = Yaml::parse($expectedYamlContent);
+
+        $this->assertSame(
+            $expectedYaml,
+            $this->explicitToAutodiscoveryConverter->convert(
+                $originalYaml,
+                $file,
+                $nestingLevel,
+                $removeSinglyImplemented
+            )
+        );
+    }
+
+    /**
+     * @return string[]
+     */
+    private function splitFile(string $yamlContent): array
+    {
+        if (Strings::match($yamlContent, self::SPLIT_PATTERN)) {
+            return Strings::split($yamlContent, self::SPLIT_PATTERN);
+        }
+
+        return [$yamlContent, $yamlContent];
+    }
+}

--- a/packages/Autodiscovery/tests/Yaml/ExplicitToAutodiscoveryConverterTest.php
+++ b/packages/Autodiscovery/tests/Yaml/ExplicitToAutodiscoveryConverterTest.php
@@ -4,15 +4,11 @@ namespace Symplify\Autodiscovery\Tests\Yaml;
 
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
 use Symfony\Component\Yaml\Yaml;
-use Symplify\Autodiscovery\Php\InterfaceAnalyzer;
-use Symplify\Autodiscovery\Yaml\CommonNamespaceResolver;
+use Symplify\Autodiscovery\Tests\AbstractContainerAwareTestCase;
 use Symplify\Autodiscovery\Yaml\ExplicitToAutodiscoveryConverter;
-use Symplify\Autodiscovery\Yaml\TagAnalyzer;
 
-final class ExplicitToAutodiscoveryConverterTest extends TestCase
+final class ExplicitToAutodiscoveryConverterTest extends AbstractContainerAwareTestCase
 {
     /**
      * @var string
@@ -26,12 +22,7 @@ final class ExplicitToAutodiscoveryConverterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->explicitToAutodiscoveryConverter = new ExplicitToAutodiscoveryConverter(
-            new SymfonyFilesystem(),
-            new CommonNamespaceResolver(),
-            new InterfaceAnalyzer(),
-            new TagAnalyzer()
-        );
+        $this->explicitToAutodiscoveryConverter = $this->container->get(ExplicitToAutodiscoveryConverter::class);
     }
 
     public function test(): void
@@ -42,6 +33,8 @@ final class ExplicitToAutodiscoveryConverterTest extends TestCase
         $this->doTestFile(__DIR__ . '/Fixture/tags_with_values.yaml', 2);
         $this->doTestFile(__DIR__ . '/Fixture/shopsys.yaml', 3);
         $this->doTestFile(__DIR__ . '/Fixture/elasticr.yaml', 3);
+        $this->doTestFile(__DIR__ . '/Fixture/untouch.yaml', 3);
+        $this->doTestFile(__DIR__ . '/Fixture/existing_autodiscovery.yaml', 3);
         $this->doTestFile(__DIR__ . '/Fixture/blog_post_votruba.yaml', 1);
     }
 

--- a/packages/Autodiscovery/tests/Yaml/Fixture/blog_post_votruba.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/blog_post_votruba.yaml
@@ -1,0 +1,59 @@
+# app/config/services.yml
+# https://www.tomasvotruba.cz/blog/2017/05/07/how-to-refactor-to-new-dependency-injection-features-in-symfony-3-3/
+services:
+    some_service:
+        class: App\SomeService
+        autowire: true
+
+    some_controller:
+        class: App\Controller\SomeController
+        autowire: true
+
+    first_repository:
+        class: App\Repository\FirstRepository
+        autowire: true
+        calls:
+            - ["setEntityManager", ["@entity_manager"]]
+    second_repository:
+        class: App\Repository\SecondRepository
+        autowire: true
+        calls:
+            - ["setEntityManager", ["@entity_manager"]]
+
+    first_command:
+        class: App\Command\FirstCommand
+        autowire: true
+        tags:
+            - { name: console.command }
+    second_command:
+        class: App\Command\SecondCommand
+        autowire: true
+        tags:
+            - { name: console.command }
+
+    first_subscriber:
+        class: App\EventSubscriber\FirstSubscriber
+        autowire: true
+        tags:
+            - { name: kernel.event_subscriber }
+    second_subscriber:
+        class: App\EventSubscriber\SecondSubscriber
+        autowire: true
+        tags:
+            - { name: kernel.event_subscriber }
+---
+# app/config/services.yml
+services:
+    _defaults:
+        autowire: true
+        autodiscovery: true
+
+    App\Repository\FirstRepository:
+        calls:
+            - ["setEntityManager", ["@entity_manager"]]
+    App\Repository\SecondRepository:
+        calls:
+            - ["setEntityManager", ["@entity_manager"]]
+
+    App\:
+        resource: '../../../src'

--- a/packages/Autodiscovery/tests/Yaml/Fixture/elasticr.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/elasticr.yaml
@@ -1,0 +1,55 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: true
+
+    Elasticr\Bundle\CatalogBundle\DataFixtures\CategoryFixtures: ~
+    Elasticr\Bundle\CatalogBundle\DataFixtures\ProductFixtures: ~
+
+    Elasticr\Bundle\CatalogBundle\Manufacturer\ManufacturerRepository: ~
+
+    Elasticr\Component\Catalog\Manufacturer\ManufacturerRepository:
+        alias: Elasticr\Bundle\CatalogBundle\Manufacturer\ManufacturerRepository
+
+    Elasticr\Bundle\CatalogBundle\Product\ProductRepository: ~
+
+    Elasticr\Component\Catalog\Product\ProductRepository:
+        alias: Elasticr\Bundle\CatalogBundle\Product\ProductRepository
+
+    Elasticr\Bundle\CatalogBundle\Category\CategoryRepository: ~
+
+    Elasticr\Component\Catalog\Category\CategoryRepository:
+        alias: Elasticr\Bundle\CatalogBundle\Category\CategoryRepository
+
+    Elasticr\Bundle\CatalogBundle\Product\EntityLocator: ~
+
+    Elasticr\Component\Catalog\Product\EntityLocator:
+        alias: Elasticr\Bundle\CatalogBundle\Product\EntityLocator
+
+    Elasticr\Component\Catalog\Product\ProductService: ~
+    Elasticr\Component\Catalog\Manufacturer\ManufacturerService: ~
+    Elasticr\Component\Catalog\Category\CategoryService: ~
+---
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: true
+
+    Elasticr\Component\Catalog\Manufacturer\ManufacturerRepository:
+        alias: Elasticr\Bundle\CatalogBundle\Manufacturer\ManufacturerRepository
+
+    Elasticr\Component\Catalog\Product\ProductRepository:
+        alias: Elasticr\Bundle\CatalogBundle\Product\ProductRepository
+
+    Elasticr\Component\Catalog\Category\CategoryRepository:
+        alias: Elasticr\Bundle\CatalogBundle\Category\CategoryRepository
+
+    Elasticr\Component\Catalog\Product\EntityLocator:
+        alias: Elasticr\Bundle\CatalogBundle\Product\EntityLocator
+
+    Elasticr\Bundle\CatalogBundle\:
+        resource: '../../../src'
+    Elasticr\Component\Catalog\:
+        resource: '../../../src'

--- a/packages/Autodiscovery/tests/Yaml/Fixture/existing_autodiscovery.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/existing_autodiscovery.yaml
@@ -1,0 +1,14 @@
+services:
+    _defaults:
+        autowire: true
+    Symfony\Component\Filesystem\Filesystem: ~
+    Symplify\Autodiscovery\Tests\Yaml\Source\AnotherClass: ~
+    Symplify\Autodiscovery\Tests\:
+        resource: ../../Existing
+---
+services:
+    _defaults:
+        autowire: true
+    Symfony\Component\Filesystem\Filesystem: ~
+    Symplify\Autodiscovery\Tests\:
+        resource: ../../Existing

--- a/packages/Autodiscovery/tests/Yaml/Fixture/first.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/first.yaml
@@ -2,9 +2,13 @@ services:
     Symplify\Autodiscovery\Tests\Yaml\Source\AnotherClass: ~
     Symplify\Autodiscovery\Tests\Yaml\Source\SomeClass: ~
 
+    Markdown:
+        class: Markdown
 ---
 services:
     _defaults:
         autowire: true
+    Markdown:
+        class: Markdown
     Symplify\Autodiscovery\:
         resource: "../Source"

--- a/packages/Autodiscovery/tests/Yaml/Fixture/first.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/first.yaml
@@ -1,0 +1,10 @@
+services:
+    Symplify\Autodiscovery\Tests\Yaml\Source\AnotherClass: ~
+    Symplify\Autodiscovery\Tests\Yaml\Source\SomeClass: ~
+
+---
+services:
+    _defaults:
+        autowire: true
+    Symplify\Autodiscovery\:
+        resource: "../Source"

--- a/packages/Autodiscovery/tests/Yaml/Fixture/shopsys.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/shopsys.yaml
@@ -1,0 +1,206 @@
+services:
+    _defaults:
+        autowire: false
+        autoconfigure: true
+        public: true
+
+    Shopsys\FrameworkBundle\Component\Domain\DomainFactory:
+        class: Shopsys\FrameworkBundle\Component\Domain\DomainFactoryOverwritingDomainUrl
+        arguments:
+            - '%overwrite_domain_url%'
+
+    Shopsys\FrameworkBundle\Model\Administrator\Activity\AdministratorActivityFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Administrator\AdministratorRepository: ~
+
+    Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchOrderFilterTranslation: ~
+
+    Shopsys\FrameworkBundle\Form\Admin\AdvancedSearch\AdvancedSearchProductFilterTranslation: ~
+
+    Shopsys\FrameworkBundle\Model\Administrator\Security\AdministratorFrontSecurityFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Availability\AvailabilityFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Security\AdminLogoutHandler: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Brand\BrandFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Brand\BrandFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Security\CustomerLoginHandler: ~
+
+    Shopsys\FrameworkBundle\Model\Customer\CustomerFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Pricing\Currency\CurrencyFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Pricing\Currency\Grid\CurrencyInlineEdit: ~
+
+    Shopsys\FrameworkBundle\Model\Cart\CartFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Category\CategoryFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Category\CategoryFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Cart\Item\CartItemRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Category\CategoryRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Cart\Watcher\CartWatcher: ~
+
+    Shopsys\FrameworkBundle\Model\Cart\CartFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Country\CountryFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Customer\CurrentCustomer: ~
+
+    Shopsys\FrameworkBundle\Model\Order\PromoCode\CurrentPromoCodeFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Feed\Delivery\DeliveryFeedItemRepository: ~
+
+    Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade:
+        arguments:
+            - '%shopsys.default_db_schema_filepath%'
+
+    Shopsys\FrameworkBundle\Component\Domain\Domain:
+        factory: ['@Shopsys\FrameworkBundle\Component\Domain\DomainFactory', create]
+        arguments:
+            - '%shopsys.domain_config_filepath%'
+            - '%shopsys.domain_urls_config_filepath%'
+
+    Shopsys\FrameworkBundle\Component\Domain\Config\DomainsConfigLoader: ~
+
+    Shopsys\FrameworkBundle\Component\Domain\DomainDataCreator: ~
+
+    Shopsys\FrameworkBundle\Component\Domain\DomainDbFunctionsFacade:
+
+    Shopsys\FrameworkBundle\Model\Product\Flag\FlagFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Flag\FlagInlineEdit: ~
+
+    Shopsys\FrameworkBundle\Component\String\HashGenerator: ~
+
+    Shopsys\FrameworkBundle\Model\Transport\IndependentTransportVisibilityCalculation: ~
+
+    Shopsys\FrameworkBundle\Model\Payment\IndependentPaymentVisibilityCalculation: ~
+
+    Shopsys\FrameworkBundle\Component\Javascript\Compiler\Constant\JsConstantCompilerPass: ~
+
+    Shopsys\FrameworkBundle\Component\Javascript\Compiler\Translator\JsTranslatorCompilerPass: ~
+
+    Shopsys\FrameworkBundle\Model\Product\BestsellingProduct\ManualBestsellingProductFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Newsletter\NewsletterRepository: ~
+
+    Shopsys\FrameworkBundle\Model\AdvancedSearch\OrderAdvancedSearchConfig: ~
+
+    Shopsys\FrameworkBundle\Model\Order\OrderNumberSequenceRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Order\OrderRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Order\OrderFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Order\Status\OrderStatusFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Order\Preview\OrderPreviewFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterInlineEdit: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Parameter\ParameterRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Payment\PaymentDataFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Payment\PaymentFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Payment\PaymentFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Payment\PaymentRepository: ~
+
+    Shopsys\FrameworkBundle\Component\DataFixture\PersistentReferenceFacade: ~
+
+    Shopsys\FrameworkBundle\Model\AdvancedSearch\ProductAdvancedSearchConfig: ~
+
+    Shopsys\FrameworkBundle\Model\Pricing\Group\Grid\PricingGroupInlineEdit: ~
+
+    Shopsys\FrameworkBundle\Component\Plugin\PluginDataFixtureRegistry: ~
+
+    Shopsys\FrameworkBundle\Model\Pricing\Group\PricingGroupFacade: ~
+
+    Shopsys\FrameworkBundle\Component\System\PostgresqlLocaleMapper: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductDataFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductHiddenRecalculator: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductSellingDeniedRecalculator: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductVisibilityRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductVariantFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductOnCurrentDomainFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Pricing\ProductPriceCalculationForUser: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductRepository: ~
+
+    Shopsys\FrameworkBundle\DataFixtures\ProductDataFixtureReferenceInjector: ~
+
+    Shopsys\FrameworkBundle\Model\Script\ScriptFacade: ~
+
+    Shopsys\FrameworkBundle\Component\System\System: ~
+
+    Shopsys\FrameworkBundle\Model\Localization\TranslatableListener: ~
+
+    Shopsys\FrameworkBundle\Model\Transport\TransportDataFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Transport\TransportFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Transport\TransportFactory: ~
+
+    Shopsys\FrameworkBundle\Model\Transport\TransportRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Unit\UnitFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Pricing\Vat\VatFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Localization\Localization: ~
+
+    Shopsys\FrameworkBundle\Model\Product\ProductSearchExport\ProductSearchExportRepository: ~
+
+    Shopsys\FrameworkBundle\Model\Product\Pricing\ProductManualInputPriceFacade: ~
+
+    Shopsys\FrameworkBundle\Model\Cart\Item\CartItemFactory: ~
+---
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: true
+
+    Shopsys\FrameworkBundle\Component\Domain\DomainFactory:
+        class: Shopsys\FrameworkBundle\Component\Domain\DomainFactoryOverwritingDomainUrl
+        arguments:
+            - '%overwrite_domain_url%'
+
+    Shopsys\FrameworkBundle\Component\Doctrine\DatabaseSchemaFacade:
+        arguments:
+            - '%shopsys.default_db_schema_filepath%'
+
+    Shopsys\FrameworkBundle\Component\Domain\Domain:
+        factory: ['@Shopsys\FrameworkBundle\Component\Domain\DomainFactory', create]
+        arguments:
+            - '%shopsys.domain_config_filepath%'
+            - '%shopsys.domain_urls_config_filepath%'
+
+    Shopsys\FrameworkBundle\Model\:
+        resource: '../../../src'
+    Shopsys\FrameworkBundle\Form\:
+        resource: '../../../src'
+    Shopsys\FrameworkBundle\Component\:
+        resource: '../../../src'
+    Shopsys\FrameworkBundle\DataFixtures\:
+        resource: '../../../src'

--- a/packages/Autodiscovery/tests/Yaml/Fixture/singly_implemented_interfaces.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/singly_implemented_interfaces.yaml
@@ -1,0 +1,13 @@
+services:
+    Symplify\Autodiscovery\Tests\Yaml\Source\SomeClass: ~
+
+    Symplify\Autodiscovery\Tests\Yaml\Source\SomeInterface:
+        alias: 'Symplify\Autodiscovery\Tests\Yaml\Source\SomeClass'
+---
+services:
+    _defaults:
+        autowire: true
+    Symplify\Autodiscovery\Tests\Yaml\Source\SomeInterface:
+        alias: 'Symplify\Autodiscovery\Tests\Yaml\Source\SomeClass'
+    Symplify\Autodiscovery\:
+        resource: '../Source'

--- a/packages/Autodiscovery/tests/Yaml/Fixture/singly_implemented_interfaces_excluded.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/singly_implemented_interfaces_excluded.yaml
@@ -1,0 +1,11 @@
+services:
+    Symplify\Autodiscovery\Tests\Yaml\Source\SomeClass: ~
+
+    Symplify\Autodiscovery\Tests\Yaml\Source\SomeInterface:
+        alias: 'Symplify\Autodiscovery\Tests\Yaml\Source\AnotherClass'
+---
+services:
+    _defaults:
+        autowire: true
+    Symplify\Autodiscovery\:
+        resource: '../Source'

--- a/packages/Autodiscovery/tests/Yaml/Fixture/tags_with_values.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/tags_with_values.yaml
@@ -1,0 +1,8 @@
+services:
+    Shopsys\FrameworkBundle\Form\EmptyMessageChoiceTypeExtension:
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\ChoiceType }
+
+    Shopsys\FrameworkBundle\Form\CollectionTypeExtension:
+        tags:
+            - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\CollectionType }

--- a/packages/Autodiscovery/tests/Yaml/Fixture/untouch.yaml
+++ b/packages/Autodiscovery/tests/Yaml/Fixture/untouch.yaml
@@ -1,0 +1,10 @@
+services:
+    Symplify\Autodiscovery\Tests\Yaml\Source\AnotherClass: ~
+    Symfony\Component\Filesystem\Filesystem: ~
+---
+services:
+    _defaults:
+        autowire: true
+    Symfony\Component\Filesystem\Filesystem: ~
+    Symplify\Autodiscovery\Tests\:
+        resource: ../Source

--- a/packages/Autodiscovery/tests/Yaml/Source/AnotherClass.php
+++ b/packages/Autodiscovery/tests/Yaml/Source/AnotherClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Tests\Yaml\Source;
+
+final class AnotherClass implements SomeInterface
+{
+}

--- a/packages/Autodiscovery/tests/Yaml/Source/SomeClass.php
+++ b/packages/Autodiscovery/tests/Yaml/Source/SomeClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Tests\Yaml\Source;
+
+final class SomeClass
+{
+}

--- a/packages/Autodiscovery/tests/Yaml/Source/SomeInterface.php
+++ b/packages/Autodiscovery/tests/Yaml/Source/SomeInterface.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Tests\Yaml\Source;
+
+interface SomeInterface
+{
+}

--- a/packages/ChangelogLinker/src/config/services.yml
+++ b/packages/ChangelogLinker/src/config/services.yml
@@ -9,7 +9,6 @@ services:
 
     Symplify\PackageBuilder\Yaml\ParametersMerger: ~
     Symplify\PackageBuilder\Parameter\ParameterProvider: ~
+    Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory: ~
 
     GuzzleHttp\Client: ~
-
-    Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory: ~

--- a/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/config/services.yml
+++ b/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/config/services.yml
@@ -6,7 +6,7 @@ services:
     Symplify\EasyCodingStandard\ChangedFilesDetector\:
         resource: '..'
 
-    Symfony\Component\Cache\Adapter\SimpleCacheAdapter:
+    Symfony\Component\Cache\Adapter\SimpleCacheAdapter: ~
     Symfony\Component\Cache\Adapter\TagAwareAdapter:
         $itemsPool: '@Symfony\Component\Cache\Adapter\SimpleCacheAdapter'
         $tagsPool: '@Symfony\Component\Cache\Adapter\SimpleCacheAdapter'

--- a/packages/PackageBuilder/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
+++ b/packages/PackageBuilder/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
@@ -39,7 +39,7 @@ final class AutowireArrayParameterCompilerPass implements CompilerPassInterface
      * These namespaces are already configured by their bundles/extensions.
      * @var string[]
      */
-    private $excludedNamespaces = ['Doctrine', 'Symfony', 'Sensio', 'Knp', 'EasyCorp', 'Sonata', 'Twig'];
+    private $excludedNamespaces = ['Doctrine', 'JMS', 'Symfony', 'Sensio', 'Knp', 'EasyCorp', 'Sonata', 'Twig'];
 
     /**
      * @var DefinitionFinder

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -60,7 +60,7 @@ parameters:
 
         # Token Runner
         - '#Call to an undefined method Symfony\\Component\\DependencyInjection\\ContainerInterface::getParameterBag()#'
-        - '#Cannot call method (.*?) on Symfony\\Component\\DependencyInjection\\ContainerInterface\|null#'
+        - '#(.*?) Symfony\\Component\\DependencyInjection\\ContainerInterface\|null#'
 
         # buggy
         - '#Symplify\\EasyCodingStandard\\Contract\\Application\\DualRunInterface#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -126,6 +126,7 @@ parameters:
         - '#Cannot cast array<string>\|bool\|string\|null to string#'
         - '#Property Symplify\\Autodiscovery\\Tests\\Doctrine\\DoctrineEntityAutodiscoverTest::\$mappingDriver \(Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver\) does not accept Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver\|null#'
         - '#If condition is always false#'
+        - '#Cannot cast array<string>\|bool\|string\|null to int#'
 
         # false positive
         - '#Call to an undefined method Psr\\Container\\ContainerInterface::set\(\)#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -99,6 +99,7 @@ parameters:
         # false positives
         - '#Call to function method_exists\(\) with (.*?) and (.*?)fromShellCommandline(.*?) will always evaluate to false#'
         - '#Method Symplify\\PackageBuilder\\DependencyInjection\\CompilerPass\\AutoReturnFactoryCompilerPass::findFactoriesWithoutUsage\(\) should return array<string> but returns array<int, string\|null>#'
+        - '#Method Symplify\\Autodiscovery\\Yaml\\ExplicitToAutodiscoveryConverter::groupServicesByNamespaces\(\) should return array<string> but returns array<string, array<int, string>>#'
 
         # variadic
         - '#In method (.*?), parameter (.*?) can be type-hinted to "array"#'
@@ -124,6 +125,7 @@ parameters:
         # false positive, known
         - '#Cannot cast array<string>\|bool\|string\|null to string#'
         - '#Property Symplify\\Autodiscovery\\Tests\\Doctrine\\DoctrineEntityAutodiscoverTest::\$mappingDriver \(Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver\) does not accept Doctrine\\Common\\Persistence\\Mapping\\Driver\\MappingDriver\|null#'
+        - '#If condition is always false#'
 
         # false positive
         - '#Call to an undefined method Psr\\Container\\ContainerInterface::set\(\)#'


### PR DESCRIPTION
### Todo

- [ ] try converting Symplify configs
- [ ] update `README.md`
- [ ] write a post
- [ ] update old post - https://www.tomasvotruba.cz/blog/2017/05/07/how-to-refactor-to-new-dependency-injection-features-in-symfony-3-3/

---

Closes #1258 

```
vendor/bin/autodiscovery convert-yaml /services.yml -nesting-level 2 \
     --remove-singly-implemented
```

### Before

```yaml
services:
    some_service:
        class: App\SomeService
        autowire: true

    some_controller:
        class: App\Controller\SomeController
        autowire: true

    first_repository:
        class: App\Repository\FirstRepository
        autowire: true
        calls:
            - ["setEntityManager", ["@entity_manager"]]
    second_repository:
        class: App\Repository\SecondRepository
        autowire: true
        calls:
            - ["setEntityManager", ["@entity_manager"]]

    first_command:
        class: App\Command\FirstCommand
        autowire: true
        tags:
            - { name: console.command }
    second_command:
        class: App\Command\SecondCommand
        autowire: true
        tags:
            - { name: console.command }

    first_subscriber:
        class: App\EventSubscriber\FirstSubscriber
        autowire: true
        tags:
            - { name: kernel.event_subscriber }
    second_subscriber:
        class: App\EventSubscriber\SecondSubscriber
        autowire: true
        tags:
            - { name: kernel.event_subscriber }
```

### After

```yaml
services:
    _defaults:
        autowire: true
        autodiscovery: true

    App\Repository\FirstRepository:
        calls:
            - ["setEntityManager", ["@entity_manager"]]
    App\Repository\SecondRepository:
        calls:
            - ["setEntityManager", ["@entity_manager"]]

    App\:
        resource: '../../../src'
```
