### PR TITLE
Add posibility to setup config extensions

### DIFF
--- a/packages/FlexLoader/src/Flex/FlexLoader.php
+++ b/packages/FlexLoader/src/Flex/FlexLoader.php
@@ -15,7 +15,7 @@ final class FlexLoader
     /**
      * @var string
      */
-    private const CONFIG_EXTENSIONS = '.{php,xml,yaml,yml}';
+    private $configExtensions;
 
     /**
      * @var string
@@ -32,12 +32,13 @@ final class FlexLoader
      */
     private $flexPathsFactory;
 
-    public function __construct(string $environment, string $projectDir)
+    public function __construct(string $environment, string $projectDir, string $configExtensions = '.{php,xml,yaml,yml}')
     {
         $this->ensureArgumentsAreNotSwapped($environment, $projectDir);
 
         $this->environment = $environment;
         $this->projectDir = $projectDir;
+        $this->configExtensions = $configExtensions;
 
         $this->flexPathsFactory = new FlexPathsFactory();
     }
@@ -59,7 +60,7 @@ final class FlexLoader
         $servicePaths = array_merge($servicePaths, $extraServicePaths);
 
         foreach ($servicePaths as $servicePath) {
-            $loader->load($servicePath . self::CONFIG_EXTENSIONS, 'glob');
+            $loader->load($servicePath . $this->configExtensions, 'glob');
         }
     }
 
@@ -72,7 +73,7 @@ final class FlexLoader
         $routingPaths = array_merge($routingPaths, $extraRoutingPaths);
 
         foreach ($routingPaths as $routingPath) {
-            $routeCollectionBuilder->import($routingPath . self::CONFIG_EXTENSIONS, '/', 'glob');
+            $routeCollectionBuilder->import($routingPath . $this->configExtensions, '/', 'glob');
         }
     }
 


### PR DESCRIPTION
Instead of using private constant to define config extensions, we can allow configuration via Loader's constructor. I think it's good to also have a default, considering that MicroKernelTraitKernel from /tests doesn't declare CONFIG_EXTS constant and can use the default. What do you think?