### PR TITLE
[Statie] Add api generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/output
 
 # composer
 /vendor
@@ -8,5 +7,7 @@ composer.lock
 /node_modules
 package-lock.json
 
-# local dev
+# statie
+/source
+/output
 /statie.yaml

--- a/ecs.yml
+++ b/ecs.yml
@@ -15,6 +15,10 @@ services:
             Symfony\Component\DependencyInjection\ContainerInterface: 'Use constructor injection, collectors or factory instead'
             PhpCsFixer\Finder: 'Symfony\Component\Finder\Finder'
 
+    Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff:
+        extraAllowedClasses:
+            - '*File'
+
     Symplify\CodingStandard\Fixer\Order\MethodOrderByTypeFixer:
         method_order_by_type:
             PhpCsFixer\Fixer\FixerInterface:

--- a/packages/Statie/README.md
+++ b/packages/Statie/README.md
@@ -51,7 +51,7 @@ gulp
 
 4. And see web in browser [localhost:8000](http://localhost:8000).
 
-## Do you use Jekyll or Sculpin? 
+## Do you use Jekyll or Sculpin?
 
 We'll help you migrate:
 
@@ -60,7 +60,7 @@ vendor/bin/statie migrate-jekyll
 vendor/bin/statie migrate-sculpin
 ```
 
-They will do 95 % of migration for you. If you still struggle with migration, look at: 
+They will do 95 % of migration for you. If you still struggle with migration, look at:
 
 - [9 Steps to Migrate From Jekyll to Statie](https://www.tomasvotruba.cz/blog/2019/01/10/9-steps-to-migrate-from-jekyll-to-statie/)
 - [11 Steps to Migrate From Sculpin to Statie](https://www.tomasvotruba.cz/blog/2019/01/14/11-steps-to-migrate-from-sculpin-to-statie/)
@@ -139,6 +139,26 @@ parameters:
 ```
 
 Now people can share specific headlines in your posts.
+
+### How to Generate API?
+
+Statie web [Friendsofphp.org](https://friendsofphp.org/) provide info about PHP meetups and groups. They're already stored in parameters. Do you want to publish them as JSON API?
+
+```yaml
+parameters:
+    api_parameters:
+        - 'groups'
+        - 'meetups'
+```
+
+This will generate 2 pages:
+
+```bash
+/api/groups.json
+/api/meetups.json
+```
+
+With parameters as JSON, that anyone can use now.
 
 ### How to Redirect old page?
 

--- a/packages/Statie/config/config.yml
+++ b/packages/Statie/config/config.yml
@@ -4,6 +4,9 @@ parameters:
     # old url: new url
     redirects: []
 
+    # parameters that will be printed as /api/<parameter-name>.json
+    api_parameters: []
+
     # see https://www.statie.org/docs/generators/
     generators:
         posts:

--- a/packages/Statie/src/Renderable/ApiGenerator.php
+++ b/packages/Statie/src/Renderable/ApiGenerator.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Statie\Renderable;
+
+use Nette\Utils\Json;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\Statie\Renderable\File\VirtualFile;
+
+final class ApiGenerator
+{
+    /**
+     * @var string[]
+     */
+    private $apiParameters = [];
+
+    /**
+     * @var ParameterProvider
+     */
+    private $parameterProvider;
+
+    /**
+     * @param string[] $apiParameters
+     */
+    public function __construct(array $apiParameters, ParameterProvider $parameterProvider)
+    {
+        $this->apiParameters = $apiParameters;
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    /**
+     * @return VirtualFile[]
+     */
+    public function generate(): array
+    {
+        $virtualFiles = [];
+        foreach ($this->apiParameters as $apiParameter) {
+            $outputPath = $this->createOutputPath($apiParameter);
+            $content = $this->createContent($apiParameter);
+
+            $virtualFiles[] = new VirtualFile($outputPath, $content);
+        }
+
+        return $virtualFiles;
+    }
+
+    private function createOutputPath(string $parameter): string
+    {
+        return 'api/' . $parameter . '.json';
+    }
+
+    private function createContent(string $parameterName): string
+    {
+        $parameter = $this->parameterProvider->provideParameter($parameterName);
+
+        $content = [
+            $parameterName => is_array($parameter) ? $parameter : '{}',
+        ];
+
+        return Json::encode($content, Json::PRETTY);
+    }
+}


### PR DESCRIPTION
Statie web [Friendsofphp.org](https://friendsofphp.org/) provide info about PHP meetups and groups. They're already stored in parameters. Do you want to publish them as JSON API?

```yaml
parameters:
    api_parameters:
        - 'groups'
        - 'meetups'
```

This will generate 2 pages:

```bash
/api/groups.json
/api/meetups.json
```

With parameters as JSON, that anyone can use now.