### PR TITLE
[FlexLoader] loading fails when extra path does not exists

### DIFF
--- a/packages/FlexLoader/src/Flex/FlexLoader.php
+++ b/packages/FlexLoader/src/Flex/FlexLoader.php
@@ -59,8 +59,7 @@ final class FlexLoader
             $containerBuilder->setParameter('container.dumper.inline_class_loader', true);
         }
 
-        $servicePaths = $this->flexPathsFactory->createServicePaths($this->projectDir, $this->environment);
-        $servicePaths = array_merge($servicePaths, $extraServicePaths);
+        $servicePaths = $this->flexPathsFactory->createServicePaths($this->projectDir, $this->environment, $extraServicePaths);
 
         foreach ($servicePaths as $servicePath) {
             $loader->load($servicePath . $this->configExtensions, 'glob');

--- a/packages/FlexLoader/src/Flex/FlexPathsFactory.php
+++ b/packages/FlexLoader/src/Flex/FlexPathsFactory.php
@@ -10,7 +10,7 @@ final class FlexPathsFactory
     /**
      * @return string[]
      */
-    public function createServicePaths(string $projectDir, string $environment): array
+    public function createServicePaths(string $projectDir, string $environment, array $extraServicePaths = []): array
     {
         $servicePaths = [
             $projectDir . '/config/packages/*',
@@ -21,7 +21,7 @@ final class FlexPathsFactory
             $projectDir . '/config/parameters_' . $environment,
         ];
 
-        return $this->filterExistingPaths($servicePaths);
+        return $this->filterExistingPaths(array_merge($servicePaths, $extraServicePaths));
     }
 
     /**

--- a/packages/FlexLoader/src/Flex/FlexPathsFactory.php
+++ b/packages/FlexLoader/src/Flex/FlexPathsFactory.php
@@ -10,7 +10,7 @@ final class FlexPathsFactory
     /**
      * @return string[]
      */
-    public function createServicePaths(string $projectDir, string $environment, array $extraServicePaths = []): array
+    public function createServicePaths(string $projectDir, string $environment, array $extraServicePaths): array
     {
         $servicePaths = [
             $projectDir . '/config/packages/*',

--- a/packages/FlexLoader/tests/Flex/FlexLoader/Source/MicroKernelTraitKernel.php
+++ b/packages/FlexLoader/tests/Flex/FlexLoader/Source/MicroKernelTraitKernel.php
@@ -52,6 +52,6 @@ final class MicroKernelTraitKernel extends Kernel
 
     protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
     {
-        $this->flexLoader->loadConfigs($containerBuilder, $loader, [__DIR__ . '/extra-dir/*']);
+        $this->flexLoader->loadConfigs($containerBuilder, $loader, [__DIR__ . '/extra-dir/*', __DIR__ . '/extra-non-existing-dir/*']);
     }
 }


### PR DESCRIPTION
Hi Tomáš,

sending PR - extra service paths are now checked for existence same way as the default ones in FlexPathsFactory

Fixes #1371 