### PR TITLE
[EasyCodingStandard] Detect EOL instead of using PHP_EOL in SniffRunner

### DIFF
--- a/packages/EasyCodingStandard/packages/SniffRunner/src/File/FileFactory.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/File/FileFactory.php
@@ -81,6 +81,8 @@ final class FileFactory
             $this->currentFileProvider
         );
 
+        $file->eolChar = $this->fileToTokensParser->detectLineEndingsFromFileInfo($smartFileInfo);
+
         // BC layer
         $file->tokenizer = $this->fileToTokensParser->createTokenizerFromFileInfo($smartFileInfo);
 

--- a/packages/EasyCodingStandard/packages/SniffRunner/src/Parser/FileToTokensParser.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/Parser/FileToTokensParser.php
@@ -4,6 +4,7 @@ namespace Symplify\EasyCodingStandard\SniffRunner\Parser;
 
 use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Tokenizers\PHP;
+use PHP_CodeSniffer\Util\Common;
 use stdClass;
 use Symplify\EasyCodingStandard\FileSystem\CachedFileLoader;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
@@ -39,7 +40,14 @@ final class FileToTokensParser
     {
         $fileContent = $this->cachedFileLoader->getFileContent($smartFileInfo);
 
-        return new PHP($fileContent, $this->getLegacyConfig(), PHP_EOL);
+        return new PHP($fileContent, $this->getLegacyConfig(), Common::detectLineEndings($fileContent));
+    }
+
+    public function detectLineEndingsFromFileInfo(SmartFileInfo $smartFileInfo): string
+    {
+        $fileContent = $this->cachedFileLoader->getFileContent($smartFileInfo);
+
+        return Common::detectLineEndings($fileContent);
     }
 
     /**


### PR DESCRIPTION
I am using Windows and LF EOL for scripts, which causes some troubles with EasyCodingStandard.

This PR fixes https://github.com/nette/coding-standard/issues/13, which is present in current version of nette/coding-standard (dev-master) + symplify/easy-coding-standard (5.4.0).

Config:
```
services:
    Nette\CodingStandard\Sniffs\WhiteSpace\FunctionSpacingSniff: ~
```

Minimal test file:
```
<?php

declare(strict_types=1);

class BrokenTest
{
	public function test()
	{
	}
}

```

Before PR:
 - Linux (PHP 7.1.16), test file with LF ✔
 - Linux (PHP 7.1.16), test file with CRLF ✔
 - Windows (PHP 7.3.1), test file with CRLF ✔
 - Windows (PHP 7.3.1), test file with LF ❌

Content of test file after fixing with ecs (Win+LF):
![image](https://user-images.githubusercontent.com/6796369/52025904-6a011c80-2506-11e9-8359-a3505962fc59.png)

Tested also `PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\FunctionSpacingSniff` which too behaves better with these changes (and it correctly inserts LF into "LF files" and CRLF into "CRLF files"). 

---

I am seeing this code for the first time in my life and I hardly understand which part of this tool I am modifying. All the tests are passing, but I would appreciate some more tests with real applications before merging it. 