### PR TITLE
[MonorepoBuilder] Add suggest to section_order

### DIFF
--- a/packages/MonorepoBuilder/config/config.yml
+++ b/packages/MonorepoBuilder/config/config.yml
@@ -30,6 +30,7 @@ parameters:
         - 'replace'
         - 'provide'
         - 'scripts'
+        - 'suggest'
         - 'config'
         - 'minimum-stability'
         - 'prefer-stable'


### PR DESCRIPTION
Add `suggest` to `section_order` to avoid it to be moved at the top of the composer.json file.

Related to #1406