### PR TITLE
Remove Safe package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "symfony/process": "^3.4|^4.1",
         "symfony/routing": "^3.4|^4.1",
         "symfony/yaml": "^3.4|^4.1",
-        "thecodingmachine/safe": "0.1.13",
         "twig/twig": "^2.5"
     },
     "require-dev": {
@@ -46,7 +45,6 @@
         "symfony/templating": "^3.4|^4.1",
         "symfony/translation": "^3.4|^4.1",
         "symfony/twig-bundle": "^3.4|^4.1",
-        "thecodingmachine/phpstan-safe-rule": "^0.1.1",
         "thecodingmachine/phpstan-strict-rules": "^0.11.0",
         "tracy/tracy": "^2.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/process": "^3.4|^4.1",
         "symfony/routing": "^3.4|^4.1",
         "symfony/yaml": "^3.4|^4.1",
-        "thecodingmachine/safe": "^0.1.13",
+        "thecodingmachine/safe": "0.1.13",
         "twig/twig": "^2.5"
     },
     "require-dev": {

--- a/monorepo-builder.yml
+++ b/monorepo-builder.yml
@@ -5,7 +5,6 @@ parameters:
             phpstan/phpstan: '^0.11'
             phpunit/phpunit: '^7.5'
             tracy/tracy: '^2.5'
-            thecodingmachine/phpstan-safe-rule: '^0.1.1'
             thecodingmachine/phpstan-strict-rules: '^0.11.0'
 
     # remove these to merge of packages' composer.json

--- a/packages/Autodiscovery/composer.json
+++ b/packages/Autodiscovery/composer.json
@@ -12,8 +12,7 @@
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
         "symfony/routing": "^3.4|^4.1",
-        "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "0.1.13"
+        "symplify/package-builder": "^5.5"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.9",

--- a/packages/Autodiscovery/composer.json
+++ b/packages/Autodiscovery/composer.json
@@ -13,7 +13,7 @@
         "symfony/finder": "^3.4|^4.1",
         "symfony/routing": "^3.4|^4.1",
         "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.9",

--- a/packages/Autodiscovery/src/Command/ConvertYamlCommand.php
+++ b/packages/Autodiscovery/src/Command/ConvertYamlCommand.php
@@ -18,7 +18,6 @@ use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
 use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
 
 final class ConvertYamlCommand extends Command
 {

--- a/packages/Autodiscovery/src/DependencyInjection/ContainerFactory.php
+++ b/packages/Autodiscovery/src/DependencyInjection/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\Autodiscovery\DependencyInjection;
 
 use Psr\Container\ContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/Autodiscovery/src/Exception/ClassLocationNotFoundException.php
+++ b/packages/Autodiscovery/src/Exception/ClassLocationNotFoundException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Autodiscovery\Exception;
+
+use Exception;
+
+final class ClassLocationNotFoundException extends Exception
+{
+}

--- a/packages/Autodiscovery/src/NamespaceDetector.php
+++ b/packages/Autodiscovery/src/NamespaceDetector.php
@@ -5,7 +5,6 @@ namespace Symplify\Autodiscovery;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\glob;
 
 final class NamespaceDetector
 {

--- a/packages/Autodiscovery/src/Php/InterfaceAnalyzer.php
+++ b/packages/Autodiscovery/src/Php/InterfaceAnalyzer.php
@@ -2,8 +2,6 @@
 
 namespace Symplify\Autodiscovery\Php;
 
-use function Safe\class_implements;
-
 final class InterfaceAnalyzer
 {
     public function isInterfaceOnlyImplementation(string $interface, string $class): bool

--- a/packages/Autodiscovery/src/Yaml/ExplicitToAutodiscoveryConverter.php
+++ b/packages/Autodiscovery/src/Yaml/ExplicitToAutodiscoveryConverter.php
@@ -6,11 +6,10 @@ use Nette\Utils\Strings;
 use ReflectionClass;
 use Symfony\Component\Filesystem\Filesystem;
 use Symplify\Autodiscovery\Arrays;
+use Symplify\Autodiscovery\Exception\ClassLocationNotFoundException;
 use Symplify\Autodiscovery\Exception\ClassNotFoundException;
 use Symplify\Autodiscovery\Php\InterfaceAnalyzer;
-use function Safe\realpath;
-use function Safe\sort;
-use function Safe\sprintf;
+use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 
 final class ExplicitToAutodiscoveryConverter
 {
@@ -399,7 +398,12 @@ final class ExplicitToAutodiscoveryConverter
             $classDirectory = dirname($fileName);
         }
 
-        $configDirectory = realpath(dirname($configFilePath));
+        if ($classDirectory === false) {
+            throw new ClassLocationNotFoundException(sprintf('Location for "%s" class was not found.', $class));
+        }
+
+        $fileInfo = new SmartFileInfo($configFilePath);
+        $configDirectory = dirname($fileInfo->getRealPath());
 
         $relativePath = $this->filesystem->makePathRelative($classDirectory, $configDirectory);
 

--- a/packages/Autodiscovery/tests/Twig/TwigPathAutodiscoveryTest.php
+++ b/packages/Autodiscovery/tests/Twig/TwigPathAutodiscoveryTest.php
@@ -6,7 +6,6 @@ use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
 use Symplify\Autodiscovery\Tests\AbstractAppKernelAwareTestCase;
 use Twig\Loader\FilesystemLoader as TwigFilesystemLoader;
 use Twig_Environment;
-use function Safe\realpath;
 
 /**
  * @covers \Symplify\Autodiscovery\Twig\TwigPathAutodiscoverer

--- a/packages/BetterPhpDocParser/composer.json
+++ b/packages/BetterPhpDocParser/composer.json
@@ -6,8 +6,7 @@
         "php": "^7.1",
         "nette/utils": "^2.5",
         "phpstan/phpdoc-parser": "^0.3",
-        "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "0.1.13"
+        "symplify/package-builder": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/BetterPhpDocParser/composer.json
+++ b/packages/BetterPhpDocParser/composer.json
@@ -7,7 +7,7 @@
         "nette/utils": "^2.5",
         "phpstan/phpdoc-parser": "^0.3",
         "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/BetterPhpDocParser/src/DependencyInjection/ContainerFactory.php
+++ b/packages/BetterPhpDocParser/src/DependencyInjection/ContainerFactory.php
@@ -5,7 +5,6 @@ namespace Symplify\BetterPhpDocParser\DependencyInjection;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/BetterPhpDocParser/src/PhpDocParser/TypeNodeToStringsConverter.php
+++ b/packages/BetterPhpDocParser/src/PhpDocParser/TypeNodeToStringsConverter.php
@@ -11,7 +11,6 @@ use PHPStan\PhpDocParser\Ast\Type\ThisTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Symplify\BetterPhpDocParser\Exception\NotImplementedYetException;
-use function Safe\sprintf;
 
 /**
  * @inspiration https://github.com/rectorphp/rector/blob/6006a75c8f3bec3aa976f48c7394d4a4b3a0e2ac/src/PhpParser/Node/Resolver/NameResolver.php#L21

--- a/packages/BetterPhpDocParser/src/Printer/OriginalSpacingRestorer.php
+++ b/packages/BetterPhpDocParser/src/Printer/OriginalSpacingRestorer.php
@@ -6,7 +6,6 @@ use Nette\Utils\Arrays;
 use Nette\Utils\Strings;
 use PHPStan\PhpDocParser\Lexer\Lexer;
 use Symplify\BetterPhpDocParser\PhpDocNodeInfo;
-use function Safe\substr;
 
 final class OriginalSpacingRestorer
 {

--- a/packages/ChangelogLinker/composer.json
+++ b/packages/ChangelogLinker/composer.json
@@ -13,7 +13,7 @@
         "symfony/http-kernel": "^3.4|^4.1",
         "symfony/process": "^3.4|^4.1",
         "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/ChangelogLinker/composer.json
+++ b/packages/ChangelogLinker/composer.json
@@ -12,8 +12,7 @@
         "symfony/console": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
         "symfony/process": "^3.4|^4.1",
-        "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "0.1.13"
+        "symplify/package-builder": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php
+++ b/packages/ChangelogLinker/src/ChangeTree/ChangeFactory.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\ChangeTree\Resolver\CategoryResolver;
 use Symplify\ChangelogLinker\ChangeTree\Resolver\PackageResolver;
 use Symplify\ChangelogLinker\Git\GitCommitDateTagResolver;
-use function Safe\sprintf;
 
 final class ChangeFactory
 {

--- a/packages/ChangelogLinker/src/ChangeTree/ChangeSorter.php
+++ b/packages/ChangelogLinker/src/ChangeTree/ChangeSorter.php
@@ -2,8 +2,6 @@
 
 namespace Symplify\ChangelogLinker\ChangeTree;
 
-use function Safe\usort;
-
 final class ChangeSorter
 {
     /**

--- a/packages/ChangelogLinker/src/ChangelogCleaner.php
+++ b/packages/ChangelogLinker/src/ChangelogCleaner.php
@@ -4,7 +4,6 @@ namespace Symplify\ChangelogLinker;
 
 use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Analyzer\LinksAnalyzer;
-use function Safe\sprintf;
 
 final class ChangelogCleaner
 {

--- a/packages/ChangelogLinker/src/ChangelogLinker.php
+++ b/packages/ChangelogLinker/src/ChangelogLinker.php
@@ -5,7 +5,6 @@ namespace Symplify\ChangelogLinker;
 use Symplify\ChangelogLinker\Analyzer\LinksAnalyzer;
 use Symplify\ChangelogLinker\Analyzer\VersionsAnalyzer;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
-use function Safe\usort;
 
 final class ChangelogLinker
 {

--- a/packages/ChangelogLinker/src/Console/ChangelogConsoleApplication.php
+++ b/packages/ChangelogLinker/src/Console/ChangelogConsoleApplication.php
@@ -12,7 +12,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\ChangelogLinker\Configuration\Option;
 use Symplify\PackageBuilder\Console\HelpfulApplicationTrait;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use function Safe\getcwd;
 
 final class ChangelogConsoleApplication extends Application
 {

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -18,7 +18,6 @@ use Symplify\ChangelogLinker\FileSystem\ChangelogFileSystemGuard;
 use Symplify\ChangelogLinker\Github\GithubApi;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 /**
  * @inspired by https://github.com/weierophinney/changelog_generator

--- a/packages/ChangelogLinker/src/DependencyInjection/CompilerPass/DetectParametersCompilerPass.php
+++ b/packages/ChangelogLinker/src/DependencyInjection/CompilerPass/DetectParametersCompilerPass.php
@@ -6,7 +6,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Process\Process;
 use Symplify\ChangelogLinker\Github\GithubRepositoryFromRemoteResolver;
-use function Safe\substr;
 
 final class DetectParametersCompilerPass implements CompilerPassInterface
 {

--- a/packages/ChangelogLinker/src/DependencyInjection/ContainerFactory.php
+++ b/packages/ChangelogLinker/src/DependencyInjection/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\ChangelogLinker\DependencyInjection;
 
 use Psr\Container\ContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/ChangelogLinker/src/FileSystem/ChangelogFileSystem.php
+++ b/packages/ChangelogLinker/src/FileSystem/ChangelogFileSystem.php
@@ -7,8 +7,6 @@ use Symplify\ChangelogLinker\Analyzer\LinksAnalyzer;
 use Symplify\ChangelogLinker\Configuration\Option;
 use Symplify\ChangelogLinker\LinkAppender;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class ChangelogFileSystem
 {

--- a/packages/ChangelogLinker/src/FileSystem/ChangelogFileSystemGuard.php
+++ b/packages/ChangelogLinker/src/FileSystem/ChangelogFileSystemGuard.php
@@ -5,7 +5,6 @@ namespace Symplify\ChangelogLinker\FileSystem;
 use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Exception\FileNotFoundException;
 use Symplify\ChangelogLinker\Exception\MissingPlaceholderInChangelogException;
-use function Safe\sprintf;
 
 final class ChangelogFileSystemGuard
 {

--- a/packages/ChangelogLinker/src/Github/GithubApi.php
+++ b/packages/ChangelogLinker/src/Github/GithubApi.php
@@ -11,7 +11,6 @@ use Psr\Http\Message\ResponseInterface;
 use Symplify\ChangelogLinker\Exception\Github\GithubApiException;
 use Symplify\ChangelogLinker\Guzzle\ResponseFormatter;
 use Throwable;
-use function Safe\sprintf;
 
 final class GithubApi
 {

--- a/packages/ChangelogLinker/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/ChangelogLinker/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -4,8 +4,6 @@ namespace Symplify\ChangelogLinker\Github;
 
 use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Exception\Git\InvalidGitRemoteException;
-use function Safe\sprintf;
-use function Safe\substr;
 
 final class GithubRepositoryFromRemoteResolver
 {

--- a/packages/ChangelogLinker/src/LinkAppender.php
+++ b/packages/ChangelogLinker/src/LinkAppender.php
@@ -3,7 +3,6 @@
 namespace Symplify\ChangelogLinker;
 
 use Symplify\ChangelogLinker\Analyzer\LinksAnalyzer;
-use function Safe\krsort;
 
 final class LinkAppender
 {

--- a/packages/ChangelogLinker/src/Worker/BracketsAroundReferencesWorker.php
+++ b/packages/ChangelogLinker/src/Worker/BracketsAroundReferencesWorker.php
@@ -5,7 +5,6 @@ namespace Symplify\ChangelogLinker\Worker;
 use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
 use Symplify\ChangelogLinker\Regex\RegexPattern;
-use function Safe\sprintf;
 
 /**
  * Comletes [] around commit, pull-request, issues and version references

--- a/packages/ChangelogLinker/src/Worker/DiffLinksToVersionsWorker.php
+++ b/packages/ChangelogLinker/src/Worker/DiffLinksToVersionsWorker.php
@@ -6,7 +6,6 @@ use Symplify\ChangelogLinker\Analyzer\LinksAnalyzer;
 use Symplify\ChangelogLinker\Analyzer\VersionsAnalyzer;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
 use Symplify\ChangelogLinker\LinkAppender;
-use function Safe\sprintf;
 
 final class DiffLinksToVersionsWorker implements WorkerInterface
 {

--- a/packages/ChangelogLinker/src/Worker/LinkifyWorker.php
+++ b/packages/ChangelogLinker/src/Worker/LinkifyWorker.php
@@ -5,7 +5,6 @@ namespace Symplify\ChangelogLinker\Worker;
 use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
 use Symplify\ChangelogLinker\LinkAppender;
-use function Safe\sprintf;
 
 final class LinkifyWorker implements WorkerInterface
 {

--- a/packages/ChangelogLinker/src/Worker/LinksToReferencesWorker.php
+++ b/packages/ChangelogLinker/src/Worker/LinksToReferencesWorker.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
 use Symplify\ChangelogLinker\LinkAppender;
 use Symplify\ChangelogLinker\Regex\RegexPattern;
-use function Safe\sprintf;
 
 final class LinksToReferencesWorker implements WorkerInterface
 {

--- a/packages/ChangelogLinker/src/Worker/UserReferencesWorker.php
+++ b/packages/ChangelogLinker/src/Worker/UserReferencesWorker.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
 use Symplify\ChangelogLinker\LinkAppender;
 use Symplify\ChangelogLinker\Regex\RegexPattern;
-use function Safe\sprintf;
 
 /**
  * Completes link to @user mentions

--- a/packages/CodingStandard/composer.json
+++ b/packages/CodingStandard/composer.json
@@ -9,8 +9,7 @@
         "squizlabs/php_codesniffer": "^3.4",
         "friendsofphp/php-cs-fixer": "^2.14",
         "symplify/token-runner": "^5.5",
-        "slam/php-cs-fixer-extensions": "^1.17",
-        "thecodingmachine/safe": "0.1.13"
+        "slam/php-cs-fixer-extensions": "^1.17"
     },
     "require-dev": {
         "nette/application": "^2.4",

--- a/packages/CodingStandard/composer.json
+++ b/packages/CodingStandard/composer.json
@@ -10,7 +10,7 @@
         "friendsofphp/php-cs-fixer": "^2.14",
         "symplify/token-runner": "^5.5",
         "slam/php-cs-fixer-extensions": "^1.17",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "nette/application": "^2.4",

--- a/packages/CodingStandard/src/Fixer/Commenting/BlockPropertyCommentFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/BlockPropertyCommentFixer.php
@@ -13,7 +13,6 @@ use PhpCsFixer\WhitespacesFixerConfig;
 use SplFileInfo;
 use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
 use Symplify\TokenRunner\Wrapper\FixerWrapper\ClassWrapperFactory;
-use function Safe\sprintf;
 
 /**
  * possible future-successor https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3810

--- a/packages/CodingStandard/src/Fixer/Order/PrivateMethodOrderByUseFixer.php
+++ b/packages/CodingStandard/src/Fixer/Order/PrivateMethodOrderByUseFixer.php
@@ -9,7 +9,6 @@ use SplFileInfo;
 use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
 use Symplify\TokenRunner\Transformer\FixerTransformer\ClassElementSorter;
 use Symplify\TokenRunner\Wrapper\FixerWrapper\ClassWrapperFactory;
-use function Safe\usort;
 
 final class PrivateMethodOrderByUseFixer extends AbstractSymplifyFixer
 {

--- a/packages/CodingStandard/src/Fixer/Order/PropertyOrderByComplexityFixer.php
+++ b/packages/CodingStandard/src/Fixer/Order/PropertyOrderByComplexityFixer.php
@@ -14,7 +14,6 @@ use Symplify\TokenRunner\Analyzer\FixerAnalyzer\DocBlockFinder;
 use Symplify\TokenRunner\Transformer\FixerTransformer\ClassElementSorter;
 use Symplify\TokenRunner\Wrapper\FixerWrapper\ClassWrapperFactory;
 use Symplify\TokenRunner\Wrapper\FixerWrapper\DocBlockWrapperFactory;
-use function Safe\usort;
 
 /**
  * Inspiration @see \PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer

--- a/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
+++ b/packages/CodingStandard/src/Fixer/Php/ClassStringToClassConstantFixer.php
@@ -13,7 +13,6 @@ use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
 use Symplify\PackageBuilder\Types\ClassLikeExistenceChecker;
-use function Safe\substr;
 
 final class ClassStringToClassConstantFixer extends AbstractSymplifyFixer implements ConfigurableFixerInterface
 {

--- a/packages/CodingStandard/src/Sniffs/Architecture/ExplicitExceptionSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Architecture/ExplicitExceptionSniff.php
@@ -19,7 +19,6 @@ use RuntimeException;
 use Throwable;
 use UnderflowException;
 use UnexpectedValueException;
-use function Safe\sprintf;
 
 final class ExplicitExceptionSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/Architecture/PreferredClassSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Architecture/PreferredClassSniff.php
@@ -5,7 +5,6 @@ namespace Symplify\CodingStandard\Sniffs\Architecture;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use Symplify\TokenRunner\Analyzer\SnifferAnalyzer\Naming;
-use function Safe\sprintf;
 
 final class PreferredClassSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/CleanCode/CognitiveComplexitySniff.php
+++ b/packages/CodingStandard/src/Sniffs/CleanCode/CognitiveComplexitySniff.php
@@ -5,7 +5,6 @@ namespace Symplify\CodingStandard\Sniffs\CleanCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use Symplify\TokenRunner\Analyzer\SnifferAnalyzer\CognitiveComplexityAnalyzer;
-use function Safe\sprintf;
 
 final class CognitiveComplexitySniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/CleanCode/ForbiddenParentClassSniff.php
+++ b/packages/CodingStandard/src/Sniffs/CleanCode/ForbiddenParentClassSniff.php
@@ -5,7 +5,6 @@ namespace Symplify\CodingStandard\Sniffs\CleanCode;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use Symplify\TokenRunner\Wrapper\SnifferWrapper\ClassWrapperFactory;
-use function Safe\sprintf;
 
 final class ForbiddenParentClassSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/CleanCode/ForbiddenReferenceSniff.php
+++ b/packages/CodingStandard/src/Sniffs/CleanCode/ForbiddenReferenceSniff.php
@@ -4,7 +4,6 @@ namespace Symplify\CodingStandard\Sniffs\CleanCode;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use function Safe\sprintf;
 
 final class ForbiddenReferenceSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/CleanCode/ForbiddenStaticFunctionSniff.php
+++ b/packages/CodingStandard/src/Sniffs/CleanCode/ForbiddenStaticFunctionSniff.php
@@ -4,7 +4,6 @@ namespace Symplify\CodingStandard\Sniffs\CleanCode;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use function Safe\sprintf;
 
 final class ForbiddenStaticFunctionSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/Commenting/AnnotationTypeExistsSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Commenting/AnnotationTypeExistsSniff.php
@@ -10,7 +10,6 @@ use SlevomatCodingStandard\Helpers\AnnotationHelper;
 use SlevomatCodingStandard\Helpers\TypeHelper;
 use SlevomatCodingStandard\Helpers\TypeHintHelper;
 use Symplify\PackageBuilder\Types\ClassLikeExistenceChecker;
-use function Safe\sprintf;
 
 /**
  * @inspiration https://github.com/slevomat/coding-standard/blob/90dbcb3258dd1dcd5fa7d960a8bd30c6cb915b3a/SlevomatCodingStandard/Sniffs/Namespaces/FullyQualifiedClassNameInAnnotationSniff.php

--- a/packages/CodingStandard/src/Sniffs/ControlStructure/SprintfOverContactSniff.php
+++ b/packages/CodingStandard/src/Sniffs/ControlStructure/SprintfOverContactSniff.php
@@ -4,7 +4,6 @@ namespace Symplify\CodingStandard\Sniffs\ControlStructure;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use function Safe\sprintf;
 
 final class SprintfOverContactSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/DeadCode/UnusedPublicMethodSniff.php
+++ b/packages/CodingStandard/src/Sniffs/DeadCode/UnusedPublicMethodSniff.php
@@ -7,7 +7,6 @@ use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use Symplify\EasyCodingStandard\Contract\Application\DualRunInterface;
 use Symplify\TokenRunner\Wrapper\SnifferWrapper\ClassWrapperFactory;
-use function Safe\sprintf;
 
 /**
  * @experimental

--- a/packages/CodingStandard/src/Sniffs/DependencyInjection/NoClassInstantiationSniff.php
+++ b/packages/CodingStandard/src/Sniffs/DependencyInjection/NoClassInstantiationSniff.php
@@ -10,7 +10,6 @@ use SlevomatCodingStandard\Helpers\ClassHelper;
 use SlevomatCodingStandard\Helpers\TokenHelper;
 use Symplify\PackageBuilder\Types\ClassLikeExistenceChecker;
 use Symplify\TokenRunner\Analyzer\SnifferAnalyzer\Naming;
-use function Safe\sprintf;
 
 final class NoClassInstantiationSniff implements Sniff
 {

--- a/packages/CodingStandard/src/Sniffs/Naming/ClassNameSuffixByParentSniff.php
+++ b/packages/CodingStandard/src/Sniffs/Naming/ClassNameSuffixByParentSniff.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use Symplify\TokenRunner\Wrapper\SnifferWrapper\ClassWrapperFactory;
-use function Safe\sprintf;
 
 final class ClassNameSuffixByParentSniff implements Sniff
 {

--- a/packages/EasyCodingStandard/composer.json
+++ b/packages/EasyCodingStandard/composer.json
@@ -25,7 +25,7 @@
         "squizlabs/php_codesniffer": "^3.4",
         "jean85/pretty-package-versions": "^1.2",
         "ocramius/package-versions": "^1.3",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",

--- a/packages/EasyCodingStandard/composer.json
+++ b/packages/EasyCodingStandard/composer.json
@@ -24,8 +24,7 @@
         "friendsofphp/php-cs-fixer": "^2.14",
         "squizlabs/php_codesniffer": "^3.4",
         "jean85/pretty-package-versions": "^1.2",
-        "ocramius/package-versions": "^1.3",
-        "thecodingmachine/safe": "0.1.13"
+        "ocramius/package-versions": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",

--- a/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/Cache/Simple/FilesystemCacheFactory.php
+++ b/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/Cache/Simple/FilesystemCacheFactory.php
@@ -4,7 +4,6 @@ namespace Symplify\EasyCodingStandard\ChangedFilesDetector\Cache\Simple;
 
 use Nette\Utils\Strings;
 use Symfony\Component\Cache\Simple\FilesystemCache;
-use function Safe\getcwd;
 
 final class FilesystemCacheFactory
 {

--- a/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/FileHashComputer.php
+++ b/packages/EasyCodingStandard/packages/ChangedFilesDetector/src/FileHashComputer.php
@@ -5,15 +5,20 @@ namespace Symplify\EasyCodingStandard\ChangedFilesDetector;
 use Nette\Utils\Strings;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symplify\EasyCodingStandard\Exception\Configuration\FileNotFoundException;
 use Symplify\EasyCodingStandard\Yaml\FileLoader\CheckerTolerantYamlFileLoader;
-use function Safe\md5_file;
 
 final class FileHashComputer
 {
     public function compute(string $filePath): string
     {
         if (! Strings::match($filePath, '#\.(yml|yaml)$#')) {
-            return md5_file($filePath);
+            $fileHash = md5_file($filePath);
+            if ($fileHash === false) {
+                throw new FileNotFoundException(sprintf('File "%s" was not found', $fileHash));
+            }
+
+            return $fileHash;
         }
 
         $containerBuilder = new ContainerBuilder();

--- a/packages/EasyCodingStandard/packages/ChangedFilesDetector/tests/ChangedFilesDetectorTest.php
+++ b/packages/EasyCodingStandard/packages/ChangedFilesDetector/tests/ChangedFilesDetectorTest.php
@@ -5,7 +5,6 @@ namespace Symplify\EasyCodingStandard\ChangedFilesDetector\Tests;
 use Symplify\EasyCodingStandard\ChangedFilesDetector\ChangedFilesDetector;
 use Symplify\EasyCodingStandard\Tests\AbstractContainerAwareTestCase;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
 
 final class ChangedFilesDetectorTest extends AbstractContainerAwareTestCase
 {

--- a/packages/EasyCodingStandard/packages/ChangedFilesDetector/tests/FileHashComputerTest.php
+++ b/packages/EasyCodingStandard/packages/ChangedFilesDetector/tests/FileHashComputerTest.php
@@ -7,7 +7,6 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Symfony\Component\Yaml\Yaml;
 use Symplify\EasyCodingStandard\ChangedFilesDetector\FileHashComputer;
 use Symplify\EasyCodingStandard\Tests\AbstractContainerAwareTestCase;
-use function Safe\md5_file;
 
 final class FileHashComputerTest extends AbstractContainerAwareTestCase
 {

--- a/packages/EasyCodingStandard/packages/Configuration/src/Configuration.php
+++ b/packages/EasyCodingStandard/packages/Configuration/src/Configuration.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symplify\EasyCodingStandard\Console\Output\JsonOutputFormatter;
 use Symplify\EasyCodingStandard\Exception\Configuration\SourceNotFoundException;
 use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
-use function Safe\sprintf;
 
 final class Configuration
 {

--- a/packages/EasyCodingStandard/packages/FixerRunner/src/Application/FixerFileProcessor.php
+++ b/packages/EasyCodingStandard/packages/FixerRunner/src/Application/FixerFileProcessor.php
@@ -16,8 +16,6 @@ use Symplify\EasyCodingStandard\FixerRunner\Parser\FileToTokensParser;
 use Symplify\EasyCodingStandard\Skipper;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Throwable;
-use function Safe\sprintf;
-use function Safe\usort;
 
 final class FixerFileProcessor implements FileProcessorInterface
 {

--- a/packages/EasyCodingStandard/packages/FixerRunner/src/WhitespacesFixerConfigFactory.php
+++ b/packages/EasyCodingStandard/packages/FixerRunner/src/WhitespacesFixerConfigFactory.php
@@ -5,7 +5,6 @@ namespace Symplify\EasyCodingStandard\FixerRunner;
 use PhpCsFixer\WhitespacesFixerConfig;
 use Symplify\EasyCodingStandard\Exception\Configuration\WhitespaceConfigurationException;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use function Safe\sprintf;
 
 final class WhitespacesFixerConfigFactory
 {

--- a/packages/EasyCodingStandard/packages/FixerRunner/tests/DependencyInjection/FixerServiceRegistrationTest.php
+++ b/packages/EasyCodingStandard/packages/FixerRunner/tests/DependencyInjection/FixerServiceRegistrationTest.php
@@ -10,7 +10,6 @@ use PHPUnit\Framework\TestCase;
 use Symplify\EasyCodingStandard\DependencyInjection\ContainerFactory;
 use Symplify\EasyCodingStandard\Exception\DependencyInjection\Extension\FixerIsNotConfigurableException;
 use Symplify\EasyCodingStandard\FixerRunner\Application\FixerFileProcessor;
-use function Safe\sprintf;
 
 final class FixerServiceRegistrationTest extends TestCase
 {

--- a/packages/EasyCodingStandard/packages/SniffRunner/src/Application/SniffFileProcessor.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/Application/SniffFileProcessor.php
@@ -20,7 +20,6 @@ use Symplify\EasyCodingStandard\SniffRunner\File\File;
 use Symplify\EasyCodingStandard\SniffRunner\File\FileFactory;
 use Symplify\EasyCodingStandard\SniffRunner\Fixer\Fixer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\define;
 
 final class SniffFileProcessor implements FileProcessorInterface, DualRunAwareFileProcessorInterface
 {

--- a/packages/EasyCodingStandard/packages/SniffRunner/src/File/File.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/File/File.php
@@ -12,7 +12,6 @@ use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\EasyCodingStandard\Skipper;
 use Symplify\EasyCodingStandard\SniffRunner\Exception\File\NotImplementedException;
 use Symplify\EasyCodingStandard\SniffRunner\Fixer\Fixer;
-use function Safe\sprintf;
 
 final class File extends BaseFile
 {

--- a/packages/EasyCodingStandard/packages/SniffRunner/src/Fixer/Fixer.php
+++ b/packages/EasyCodingStandard/packages/SniffRunner/src/Fixer/Fixer.php
@@ -3,7 +3,6 @@
 namespace Symplify\EasyCodingStandard\SniffRunner\Fixer;
 
 use Symplify\EasyCodingStandard\SniffRunner\File\File;
-use function Safe\substr;
 
 final class Fixer
 {

--- a/packages/EasyCodingStandard/src/Application/AppliedCheckersCollector.php
+++ b/packages/EasyCodingStandard/src/Application/AppliedCheckersCollector.php
@@ -5,7 +5,6 @@ namespace Symplify\EasyCodingStandard\Application;
 use SplObjectStorage;
 use Symplify\EasyCodingStandard\Exception\Application\MissingCheckersForChangedFileException;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
 
 final class AppliedCheckersCollector
 {

--- a/packages/EasyCodingStandard/src/Console/Application.php
+++ b/packages/EasyCodingStandard/src/Console/Application.php
@@ -12,7 +12,6 @@ use Symplify\EasyCodingStandard\Console\Command\FindCommand;
 use Symplify\EasyCodingStandard\Console\Output\JsonOutputFormatter;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\HelpfulApplicationTrait;
-use function Safe\realpath;
 
 final class Application extends SymfonyApplication
 {

--- a/packages/EasyCodingStandard/src/Console/Command/FindCommand.php
+++ b/packages/EasyCodingStandard/src/Console/Command/FindCommand.php
@@ -12,9 +12,6 @@ use Symplify\EasyCodingStandard\Finder\CheckerClassFinder;
 use Symplify\PackageBuilder\Composer\VendorDirProvider;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\getcwd;
-use function Safe\sort;
-use function Safe\sprintf;
 
 final class FindCommand extends Command
 {

--- a/packages/EasyCodingStandard/src/Console/Command/ShowCommand.php
+++ b/packages/EasyCodingStandard/src/Console/Command/ShowCommand.php
@@ -13,8 +13,6 @@ use Symplify\EasyCodingStandard\FixerRunner\Application\FixerFileProcessor;
 use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sort;
-use function Safe\sprintf;
 
 final class ShowCommand extends Command
 {

--- a/packages/EasyCodingStandard/src/Console/Output/OutputFormatterCollector.php
+++ b/packages/EasyCodingStandard/src/Console/Output/OutputFormatterCollector.php
@@ -4,7 +4,6 @@ namespace Symplify\EasyCodingStandard\Console\Output;
 
 use Symplify\EasyCodingStandard\Configuration\Exception\OutputFormatterNotFoundException;
 use Symplify\EasyCodingStandard\Contract\Console\Output\OutputFormatterInterface;
-use function Safe\sprintf;
 
 final class OutputFormatterCollector
 {

--- a/packages/EasyCodingStandard/src/Console/Output/TableOutputFormatter.php
+++ b/packages/EasyCodingStandard/src/Console/Output/TableOutputFormatter.php
@@ -8,7 +8,6 @@ use Symplify\EasyCodingStandard\Contract\Console\Output\OutputFormatterInterface
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\EasyCodingStandard\Error\FileDiff;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 final class TableOutputFormatter implements OutputFormatterInterface
 {

--- a/packages/EasyCodingStandard/src/Console/Style/EasyCodingStandardStyle.php
+++ b/packages/EasyCodingStandard/src/Console/Style/EasyCodingStandardStyle.php
@@ -7,8 +7,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symplify\EasyCodingStandard\Error\Error;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class EasyCodingStandardStyle extends SymfonyStyle
 {

--- a/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/ConflictingCheckersCompilerPass.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/ConflictingCheckersCompilerPass.php
@@ -5,7 +5,6 @@ namespace Symplify\EasyCodingStandard\DependencyInjection\CompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symplify\EasyCodingStandard\Configuration\Exception\ConflictingCheckersLoadedException;
-use function Safe\sprintf;
 
 final class ConflictingCheckersCompilerPass implements CompilerPassInterface
 {

--- a/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/RemoveExcludedCheckersCompilerPass.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/RemoveExcludedCheckersCompilerPass.php
@@ -6,7 +6,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symplify\EasyCodingStandard\Configuration\Option;
-use function Safe\sprintf;
 
 final class RemoveExcludedCheckersCompilerPass implements CompilerPassInterface
 {

--- a/packages/EasyCodingStandard/src/DependencyInjection/ContainerFactory.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\EasyCodingStandard\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/EasyCodingStandard/src/Error/ErrorAndDiffCollector.php
+++ b/packages/EasyCodingStandard/src/Error/ErrorAndDiffCollector.php
@@ -6,7 +6,6 @@ use Nette\Utils\Arrays;
 use Nette\Utils\Strings;
 use Symplify\EasyCodingStandard\ChangedFilesDetector\ChangedFilesDetector;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\getcwd;
 
 final class ErrorAndDiffCollector
 {

--- a/packages/EasyCodingStandard/src/Error/ErrorSorter.php
+++ b/packages/EasyCodingStandard/src/Error/ErrorSorter.php
@@ -2,9 +2,6 @@
 
 namespace Symplify\EasyCodingStandard\Error;
 
-use function Safe\ksort;
-use function Safe\usort;
-
 final class ErrorSorter
 {
     /**

--- a/packages/EasyCodingStandard/src/Error/FileDiff.php
+++ b/packages/EasyCodingStandard/src/Error/FileDiff.php
@@ -3,8 +3,6 @@
 namespace Symplify\EasyCodingStandard\Error;
 
 use PhpCsFixer\Differ\DiffConsoleFormatter;
-use function Safe\sort;
-use function Safe\sprintf;
 
 final class FileDiff
 {

--- a/packages/EasyCodingStandard/src/Exception/Configuration/FileNotFoundException.php
+++ b/packages/EasyCodingStandard/src/Exception/Configuration/FileNotFoundException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Exception\Configuration;
+
+use Exception;
+
+final class FileNotFoundException extends Exception
+{
+}

--- a/packages/EasyCodingStandard/src/FileSystem/CachedFileLoader.php
+++ b/packages/EasyCodingStandard/src/FileSystem/CachedFileLoader.php
@@ -4,7 +4,6 @@ namespace Symplify\EasyCodingStandard\FileSystem;
 
 use Psr\SimpleCache\CacheInterface;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\md5_file;
 
 final class CachedFileLoader
 {

--- a/packages/EasyCodingStandard/src/Finder/SourceFinder.php
+++ b/packages/EasyCodingStandard/src/Finder/SourceFinder.php
@@ -5,7 +5,6 @@ namespace Symplify\EasyCodingStandard\Finder;
 use Symfony\Component\Finder\Finder;
 use Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\ksort;
 
 final class SourceFinder
 {

--- a/packages/EasyCodingStandard/src/Yaml/CheckerConfigurationGuardian.php
+++ b/packages/EasyCodingStandard/src/Yaml/CheckerConfigurationGuardian.php
@@ -7,7 +7,6 @@ use Nette\Utils\ObjectHelpers;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use Symplify\EasyCodingStandard\Exception\DependencyInjection\Extension\FixerIsNotConfigurableException;
 use Symplify\EasyCodingStandard\Exception\DependencyInjection\Extension\InvalidSniffPropertyException;
-use function Safe\sprintf;
 
 final class CheckerConfigurationGuardian
 {

--- a/packages/EasyCodingStandard/tests/Yaml/CheckerServiceParametersShifter/CheckerServiceParametersShifterTest.php
+++ b/packages/EasyCodingStandard/tests/Yaml/CheckerServiceParametersShifter/CheckerServiceParametersShifterTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
 use Symplify\EasyCodingStandard\Exception\DependencyInjection\Extension\InvalidSniffPropertyException;
 use Symplify\EasyCodingStandard\Yaml\CheckerServiceParametersShifter;
-use function Safe\sprintf;
 
 final class CheckerServiceParametersShifterTest extends TestCase
 {

--- a/packages/EasyCodingStandardTester/composer.json
+++ b/packages/EasyCodingStandardTester/composer.json
@@ -7,7 +7,7 @@
         "phpunit/phpunit": "^7.5",
         "symplify/easy-coding-standard": "^5.5",
         "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "autoload": {
         "psr-4": {

--- a/packages/EasyCodingStandardTester/composer.json
+++ b/packages/EasyCodingStandardTester/composer.json
@@ -6,8 +6,7 @@
         "php": "^7.1",
         "phpunit/phpunit": "^7.5",
         "symplify/easy-coding-standard": "^5.5",
-        "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "0.1.13"
+        "symplify/package-builder": "^5.5"
     },
     "autoload": {
         "psr-4": {

--- a/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
@@ -16,8 +16,6 @@ use Symplify\EasyCodingStandard\FixerRunner\Application\FixerFileProcessor;
 use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
 use Symplify\PackageBuilder\FileSystem\FileGuard;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\md5_file;
-use function Safe\sprintf;
 
 abstract class AbstractCheckerTestCase extends TestCase
 {

--- a/packages/EasyCodingStandardTester/src/Testing/IntegrationTestCaseTrait.php
+++ b/packages/EasyCodingStandardTester/src/Testing/IntegrationTestCaseTrait.php
@@ -5,8 +5,6 @@ namespace Symplify\EasyCodingStandardTester\Testing;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
-use function Safe\substr;
 
 /**
  * @inspiration https://github.com/rectorphp/rector/blob/7039ce87c666d787c1d744343d449170d1655355/src/Testing/PHPUnit/IntegrationRectorTestCaseTrait.php

--- a/packages/FlexLoader/composer.json
+++ b/packages/FlexLoader/composer.json
@@ -7,7 +7,7 @@
         "nette/utils": "^2.5",
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/routing": "^3.4|^4.1",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "symfony/framework-bundle": "^3.4|^4.1",

--- a/packages/FlexLoader/composer.json
+++ b/packages/FlexLoader/composer.json
@@ -6,8 +6,7 @@
         "php": "^7.1",
         "nette/utils": "^2.5",
         "symfony/dependency-injection": "^3.4|^4.1",
-        "symfony/routing": "^3.4|^4.1",
-        "thecodingmachine/safe": "0.1.13"
+        "symfony/routing": "^3.4|^4.1"
     },
     "require-dev": {
         "symfony/framework-bundle": "^3.4|^4.1",

--- a/packages/FlexLoader/src/Flex/FlexLoader.php
+++ b/packages/FlexLoader/src/Flex/FlexLoader.php
@@ -8,7 +8,6 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use Symplify\FlexLoader\Exception\ConfigurationException;
-use function Safe\sprintf;
 
 final class FlexLoader
 {

--- a/packages/FlexLoader/src/Flex/FlexPathsFactory.php
+++ b/packages/FlexLoader/src/Flex/FlexPathsFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\FlexLoader\Flex;
 
 use Nette\Utils\Strings;
-use function Safe\glob;
 
 final class FlexPathsFactory
 {

--- a/packages/LatteToTwigConverter/composer.json
+++ b/packages/LatteToTwigConverter/composer.json
@@ -12,7 +12,7 @@
         "symfony/console": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
-        "thecodingmachine/safe": "^0.1.13",
+        "thecodingmachine/safe": "0.1.13",
         "symplify/package-builder": "^5.5"
     },
     "require-dev": {

--- a/packages/LatteToTwigConverter/composer.json
+++ b/packages/LatteToTwigConverter/composer.json
@@ -12,7 +12,6 @@
         "symfony/console": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
-        "thecodingmachine/safe": "0.1.13",
         "symplify/package-builder": "^5.5"
     },
     "require-dev": {

--- a/packages/LatteToTwigConverter/src/CaseConverter/FilterCaseConverter.php
+++ b/packages/LatteToTwigConverter/src/CaseConverter/FilterCaseConverter.php
@@ -4,7 +4,6 @@ namespace Symplify\LatteToTwigConverter\CaseConverter;
 
 use Nette\Utils\Strings;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
-use function Safe\sprintf;
 
 final class FilterCaseConverter implements CaseConverterInterface
 {

--- a/packages/LatteToTwigConverter/src/CaseConverter/LoopsCaseConverter.php
+++ b/packages/LatteToTwigConverter/src/CaseConverter/LoopsCaseConverter.php
@@ -4,7 +4,6 @@ namespace Symplify\LatteToTwigConverter\CaseConverter;
 
 use Nette\Utils\Strings;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
-use function Safe\sprintf;
 
 final class LoopsCaseConverter implements CaseConverterInterface
 {

--- a/packages/LatteToTwigConverter/src/CaseConverter/NMacrosCaseConverter.php
+++ b/packages/LatteToTwigConverter/src/CaseConverter/NMacrosCaseConverter.php
@@ -4,7 +4,6 @@ namespace Symplify\LatteToTwigConverter\CaseConverter;
 
 use Nette\Utils\Strings;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
-use function Safe\sprintf;
 
 /**
  * This needs to be run first, since it only move n:sytax to {syntax}...{/syntax} - all in Latte

--- a/packages/LatteToTwigConverter/src/CaseConverter/VariableCaseConverter.php
+++ b/packages/LatteToTwigConverter/src/CaseConverter/VariableCaseConverter.php
@@ -4,7 +4,6 @@ namespace Symplify\LatteToTwigConverter\CaseConverter;
 
 use Nette\Utils\Strings;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
-use function Safe\sprintf;
 
 final class VariableCaseConverter implements CaseConverterInterface
 {

--- a/packages/LatteToTwigConverter/src/Command/ConvertCommand.php
+++ b/packages/LatteToTwigConverter/src/Command/ConvertCommand.php
@@ -14,7 +14,6 @@ use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
 
 final class ConvertCommand extends Command
 {

--- a/packages/LatteToTwigConverter/src/Command/RenameCommand.php
+++ b/packages/LatteToTwigConverter/src/Command/RenameCommand.php
@@ -13,7 +13,6 @@ use Symfony\Component\Finder\Finder;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
-use function Safe\sprintf;
 
 final class RenameCommand extends Command
 {

--- a/packages/LatteToTwigConverter/src/DependencyInjection/ContainerFactory.php
+++ b/packages/LatteToTwigConverter/src/DependencyInjection/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\LatteToTwigConverter\DependencyInjection;
 
 use Psr\Container\ContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/LatteToTwigConverter/src/LatteToTwigConverter.php
+++ b/packages/LatteToTwigConverter/src/LatteToTwigConverter.php
@@ -5,8 +5,6 @@ namespace Symplify\LatteToTwigConverter;
 use Nette\Utils\FileSystem;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
 use Symplify\LatteToTwigConverter\Exception\ConfigurationException;
-use function Safe\krsort;
-use function Safe\sprintf;
 
 final class LatteToTwigConverter
 {

--- a/packages/MonorepoBuilder/composer.json
+++ b/packages/MonorepoBuilder/composer.json
@@ -14,7 +14,7 @@
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/console": "^3.4|^4.1",
         "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/MonorepoBuilder/composer.json
+++ b/packages/MonorepoBuilder/composer.json
@@ -13,8 +13,7 @@
         "symfony/finder": "^3.4|^4.1",
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/console": "^3.4|^4.1",
-        "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "0.1.13"
+        "symplify/package-builder": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/MonorepoBuilder/packages/Init/src/Command/InitCommand.php
+++ b/packages/MonorepoBuilder/packages/Init/src/Command/InitCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\getcwd;
 
 final class InitCommand extends Command
 {

--- a/packages/MonorepoBuilder/packages/Release/src/Command/ReleaseCommand.php
+++ b/packages/MonorepoBuilder/packages/Release/src/Command/ReleaseCommand.php
@@ -15,7 +15,6 @@ use Symplify\MonorepoBuilder\Release\Guard\ReleaseGuard;
 use Symplify\MonorepoBuilder\Release\ReleaseWorkerProvider;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 final class ReleaseCommand extends Command
 {
@@ -71,6 +70,8 @@ final class ReleaseCommand extends Command
     {
         // validation phase
         $stage = $input->getOption(Option::STAGE);
+        $stage = $stage !== null ? (string) $stage : $stage;
+
         $this->releaseGuard->guardStage($stage);
 
         /** @var string $versionArgument */

--- a/packages/MonorepoBuilder/packages/Release/src/Exception/ConflictingPriorityException.php
+++ b/packages/MonorepoBuilder/packages/Release/src/Exception/ConflictingPriorityException.php
@@ -4,7 +4,6 @@ namespace Symplify\MonorepoBuilder\Release\Exception;
 
 use Exception;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
-use function Safe\sprintf;
 
 final class ConflictingPriorityException extends Exception
 {

--- a/packages/MonorepoBuilder/packages/Release/src/Guard/ReleaseGuard.php
+++ b/packages/MonorepoBuilder/packages/Release/src/Guard/ReleaseGuard.php
@@ -9,8 +9,6 @@ use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterfa
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\StageAwareInterface;
 use Symplify\MonorepoBuilder\Release\Exception\ConfigurationException;
 use Symplify\MonorepoBuilder\Split\Git\GitManager;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class ReleaseGuard
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/AddTagToChangelogReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/AddTagToChangelogReleaseWorker.php
@@ -7,8 +7,6 @@ use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use PharIo\Version\Version;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class AddTagToChangelogReleaseWorker implements ReleaseWorkerInterface
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/PushNextDevReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/PushNextDevReleaseWorker.php
@@ -6,7 +6,6 @@ use PharIo\Version\Version;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
 use Symplify\MonorepoBuilder\Utils\Utils;
-use function Safe\sprintf;
 
 final class PushNextDevReleaseWorker implements ReleaseWorkerInterface
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/PushTagReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/PushTagReleaseWorker.php
@@ -5,7 +5,6 @@ namespace Symplify\MonorepoBuilder\Release\ReleaseWorker;
 use PharIo\Version\Version;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
-use function Safe\sprintf;
 
 final class PushTagReleaseWorker implements ReleaseWorkerInterface
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/SetCurrentMutualDependenciesReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/SetCurrentMutualDependenciesReleaseWorker.php
@@ -3,7 +3,6 @@
 namespace Symplify\MonorepoBuilder\Release\ReleaseWorker;
 
 use PharIo\Version\Version;
-use function Safe\sprintf;
 
 final class SetCurrentMutualDependenciesReleaseWorker extends AbstractMutualDependencyReleaseWorker
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/SetNextMutualDependenciesReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/SetNextMutualDependenciesReleaseWorker.php
@@ -3,7 +3,6 @@
 namespace Symplify\MonorepoBuilder\Release\ReleaseWorker;
 
 use PharIo\Version\Version;
-use function Safe\sprintf;
 
 final class SetNextMutualDependenciesReleaseWorker extends AbstractMutualDependencyReleaseWorker
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/TagVersionReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/TagVersionReleaseWorker.php
@@ -5,7 +5,6 @@ namespace Symplify\MonorepoBuilder\Release\ReleaseWorker;
 use PharIo\Version\Version;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
-use function Safe\sprintf;
 
 final class TagVersionReleaseWorker implements ReleaseWorkerInterface
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/UpdateBranchAliasReleaseWorker.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorker/UpdateBranchAliasReleaseWorker.php
@@ -7,7 +7,6 @@ use Symplify\MonorepoBuilder\DevMasterAliasUpdater;
 use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Utils\Utils;
-use function Safe\sprintf;
 
 final class UpdateBranchAliasReleaseWorker implements ReleaseWorkerInterface
 {

--- a/packages/MonorepoBuilder/packages/Release/src/ReleaseWorkerProvider.php
+++ b/packages/MonorepoBuilder/packages/Release/src/ReleaseWorkerProvider.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\StageAwareInterface;
 use Symplify\MonorepoBuilder\Release\Exception\ConflictingPriorityException;
-use function Safe\krsort;
 
 final class ReleaseWorkerProvider
 {

--- a/packages/MonorepoBuilder/packages/Split/src/Command/SplitCommand.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Command/SplitCommand.php
@@ -10,7 +10,6 @@ use Symplify\MonorepoBuilder\Split\Configuration\RepositoryGuard;
 use Symplify\MonorepoBuilder\Split\PackageToRepositorySplitter;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 final class SplitCommand extends Command
 {

--- a/packages/MonorepoBuilder/packages/Split/src/Configuration/RepositoryGuard.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Configuration/RepositoryGuard.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use Symplify\MonorepoBuilder\Split\Exception\DirectoryNotFoundException;
 use Symplify\MonorepoBuilder\Split\Exception\InvalidGitRepositoryException;
 use Symplify\MonorepoBuilder\Split\Exception\InvalidRepositoryFormatException;
-use function Safe\sprintf;
 
 final class RepositoryGuard
 {

--- a/packages/MonorepoBuilder/packages/Split/src/DependencyInjection/CompilerPass/DetectParametersCompilerPass.php
+++ b/packages/MonorepoBuilder/packages/Split/src/DependencyInjection/CompilerPass/DetectParametersCompilerPass.php
@@ -4,7 +4,6 @@ namespace Symplify\MonorepoBuilder\Split\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use function Safe\getcwd;
 
 final class DetectParametersCompilerPass implements CompilerPassInterface
 {

--- a/packages/MonorepoBuilder/packages/Split/src/Git/GitManager.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Git/GitManager.php
@@ -4,8 +4,6 @@ namespace Symplify\MonorepoBuilder\Split\Git;
 
 use Nette\Utils\Strings;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class GitManager
 {

--- a/packages/MonorepoBuilder/packages/Split/src/PackageToRepositorySplitter.php
+++ b/packages/MonorepoBuilder/packages/Split/src/PackageToRepositorySplitter.php
@@ -9,8 +9,6 @@ use Symplify\MonorepoBuilder\Split\Git\GitManager;
 use Symplify\MonorepoBuilder\Split\Process\ProcessFactory;
 use Symplify\MonorepoBuilder\Split\Process\SplitProcessInfo;
 use Symplify\PackageBuilder\FileSystem\FileSystemGuard;
-use function Safe\sleep;
-use function Safe\sprintf;
 
 final class PackageToRepositorySplitter
 {

--- a/packages/MonorepoBuilder/packages/Split/src/Process/ProcessFactory.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Process/ProcessFactory.php
@@ -6,8 +6,6 @@ use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Symfony\Component\Process\Process;
 use Symplify\MonorepoBuilder\Split\Configuration\RepositoryGuard;
-use function Safe\realpath;
-use function Safe\sprintf;
 
 final class ProcessFactory
 {

--- a/packages/MonorepoBuilder/packages/Split/tests/Process/ProcessFactoryTest.php
+++ b/packages/MonorepoBuilder/packages/Split/tests/Process/ProcessFactoryTest.php
@@ -4,7 +4,6 @@ namespace Symplify\MonorepoBuilder\Split\Tests\Process;
 
 use Symplify\MonorepoBuilder\Split\Process\ProcessFactory;
 use Symplify\MonorepoBuilder\Split\Tests\AbstractContainerAwareTestCase;
-use function Safe\realpath;
 
 final class ProcessFactoryTest extends AbstractContainerAwareTestCase
 {

--- a/packages/MonorepoBuilder/src/ArraySorter.php
+++ b/packages/MonorepoBuilder/src/ArraySorter.php
@@ -2,9 +2,6 @@
 
 namespace Symplify\MonorepoBuilder;
 
-use function Safe\ksort;
-use function Safe\sort;
-
 final class ArraySorter
 {
     /**

--- a/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
+++ b/packages/MonorepoBuilder/src/ComposerJsonDecorator/AutoloadRelativePathComposerJsonDecorator.php
@@ -7,7 +7,6 @@ use Symplify\MonorepoBuilder\Composer\Section;
 use Symplify\MonorepoBuilder\Contract\ComposerJsonDecoratorInterface;
 use Symplify\MonorepoBuilder\PackageComposerFinder;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\getcwd;
 
 final class AutoloadRelativePathComposerJsonDecorator implements ComposerJsonDecoratorInterface
 {

--- a/packages/MonorepoBuilder/src/ComposerJsonDecorator/SortAutoloadComposerJsonDecorator.php
+++ b/packages/MonorepoBuilder/src/ComposerJsonDecorator/SortAutoloadComposerJsonDecorator.php
@@ -4,7 +4,6 @@ namespace Symplify\MonorepoBuilder\ComposerJsonDecorator;
 
 use Symplify\MonorepoBuilder\Composer\Section;
 use Symplify\MonorepoBuilder\Contract\ComposerJsonDecoratorInterface;
-use function Safe\ksort;
 
 final class SortAutoloadComposerJsonDecorator implements ComposerJsonDecoratorInterface
 {

--- a/packages/MonorepoBuilder/src/ComposerJsonDecorator/SortComposerJsonDecorator.php
+++ b/packages/MonorepoBuilder/src/ComposerJsonDecorator/SortComposerJsonDecorator.php
@@ -3,7 +3,6 @@
 namespace Symplify\MonorepoBuilder\ComposerJsonDecorator;
 
 use Symplify\MonorepoBuilder\Contract\ComposerJsonDecoratorInterface;
-use function Safe\uksort;
 
 final class SortComposerJsonDecorator implements ComposerJsonDecoratorInterface
 {

--- a/packages/MonorepoBuilder/src/Console/Command/BumpInterdependencyCommand.php
+++ b/packages/MonorepoBuilder/src/Console/Command/BumpInterdependencyCommand.php
@@ -11,7 +11,6 @@ use Symplify\MonorepoBuilder\DependencyUpdater;
 use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 final class BumpInterdependencyCommand extends Command
 {

--- a/packages/MonorepoBuilder/src/Console/Command/MergeCommand.php
+++ b/packages/MonorepoBuilder/src/Console/Command/MergeCommand.php
@@ -13,7 +13,6 @@ use Symplify\MonorepoBuilder\Package\PackageComposerJsonMerger;
 use Symplify\MonorepoBuilder\VersionValidator;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\getcwd;
 
 final class MergeCommand extends Command
 {

--- a/packages/MonorepoBuilder/src/Console/Command/PackageAliasCommand.php
+++ b/packages/MonorepoBuilder/src/Console/Command/PackageAliasCommand.php
@@ -11,7 +11,6 @@ use Symplify\MonorepoBuilder\PackageComposerFinder;
 use Symplify\MonorepoBuilder\Utils\Utils;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
-use function Safe\sprintf;
 
 final class PackageAliasCommand extends Command
 {

--- a/packages/MonorepoBuilder/src/Console/Reporter/ConflictingPackageVersionsReporter.php
+++ b/packages/MonorepoBuilder/src/Console/Reporter/ConflictingPackageVersionsReporter.php
@@ -3,7 +3,6 @@
 namespace Symplify\MonorepoBuilder\Console\Reporter;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
-use function Safe\sprintf;
 
 final class ConflictingPackageVersionsReporter
 {

--- a/packages/MonorepoBuilder/src/DependencyInjection/ContainerFactory.php
+++ b/packages/MonorepoBuilder/src/DependencyInjection/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\MonorepoBuilder\DependencyInjection;
 
 use Psr\Container\ContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/MonorepoBuilder/src/FileSystem/ComposerJsonProvider.php
+++ b/packages/MonorepoBuilder/src/FileSystem/ComposerJsonProvider.php
@@ -4,7 +4,6 @@ namespace Symplify\MonorepoBuilder\FileSystem;
 
 use Symplify\MonorepoBuilder\PackageComposerFinder;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\getcwd;
 
 final class ComposerJsonProvider
 {

--- a/packages/MonorepoBuilder/src/Package/PackageComposerJsonMerger.php
+++ b/packages/MonorepoBuilder/src/Package/PackageComposerJsonMerger.php
@@ -8,7 +8,6 @@ use Symplify\MonorepoBuilder\Configuration\MergedPackagesCollector;
 use Symplify\MonorepoBuilder\FileSystem\JsonFileManager;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Symplify\PackageBuilder\Yaml\ParametersMerger;
-use function Safe\getcwd;
 
 final class PackageComposerJsonMerger
 {

--- a/packages/MonorepoBuilder/src/Validator/SourcesPresenceValidator.php
+++ b/packages/MonorepoBuilder/src/Validator/SourcesPresenceValidator.php
@@ -4,7 +4,6 @@ namespace Symplify\MonorepoBuilder\Validator;
 
 use Symplify\MonorepoBuilder\Exception\Validator\InvalidComposerJsonSetupException;
 use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
-use function Safe\sprintf;
 
 final class SourcesPresenceValidator
 {

--- a/packages/MonorepoBuilder/src/VersionValidator.php
+++ b/packages/MonorepoBuilder/src/VersionValidator.php
@@ -5,7 +5,6 @@ namespace Symplify\MonorepoBuilder;
 use Symplify\MonorepoBuilder\Composer\Section;
 use Symplify\MonorepoBuilder\FileSystem\JsonFileManager;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\asort;
 
 final class VersionValidator
 {

--- a/packages/PHPStanExtensions/composer.json
+++ b/packages/PHPStanExtensions/composer.json
@@ -5,8 +5,7 @@
     "require": {
         "php": "^7.1",
         "nette/utils": "^2.5",
-        "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "0.1.13"
+        "symplify/package-builder": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/PHPStanExtensions/composer.json
+++ b/packages/PHPStanExtensions/composer.json
@@ -6,7 +6,7 @@
         "php": "^7.1",
         "nette/utils": "^2.5",
         "symplify/package-builder": "^5.5",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/PHPStanExtensions/config/config.neon
+++ b/packages/PHPStanExtensions/config/config.neon
@@ -20,3 +20,6 @@ services:
 
     # Symfony Kernel::getContainer() after Kernel::boot() => ContainerInterface type
     - { class: Symplify\PHPStanExtensions\Symfony\Type\KernelGetContainerAfterBootReturnTypeExtension, tags: [phpstan.broker.dynamicMethodReturnTypeExtension] }
+
+    # getcwd -> string
+    - { class: Symplify\PHPStanExtensions\Php\Type\NativeFunctionDynamicFunctionReturnTypeExtension, tags: [phpstan.broker.dynamicFunctionReturnTypeExtension] }

--- a/packages/PHPStanExtensions/src/Error/ErrorGrouper.php
+++ b/packages/PHPStanExtensions/src/Error/ErrorGrouper.php
@@ -3,7 +3,6 @@
 namespace Symplify\PHPStanExtensions\Error;
 
 use PHPStan\Analyser\Error;
-use function Safe\usort;
 
 final class ErrorGrouper
 {

--- a/packages/PHPStanExtensions/src/ErrorFormatter/StatsErrorFormatter.php
+++ b/packages/PHPStanExtensions/src/ErrorFormatter/StatsErrorFormatter.php
@@ -8,8 +8,6 @@ use PHPStan\Command\ErrorFormatter\ErrorFormatter;
 use Symfony\Component\Console\Style\OutputStyle;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PHPStanExtensions\Error\ErrorGrouper;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class StatsErrorFormatter implements ErrorFormatter
 {

--- a/packages/PHPStanExtensions/src/ErrorFormatter/SymplifyErrorFormatter.php
+++ b/packages/PHPStanExtensions/src/ErrorFormatter/SymplifyErrorFormatter.php
@@ -9,8 +9,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Terminal;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class SymplifyErrorFormatter implements ErrorFormatter
 {

--- a/packages/PHPStanExtensions/src/Php/Type/NativeFunctionDynamicFunctionReturnTypeExtension.php
+++ b/packages/PHPStanExtensions/src/Php/Type/NativeFunctionDynamicFunctionReturnTypeExtension.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PHPStanExtensions\Php\Type;
+
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\ResourceType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+final class NativeFunctionDynamicFunctionReturnTypeExtension implements DynamicFunctionReturnTypeExtension
+{
+    public function isFunctionSupported(FunctionReflection $functionReflection): bool
+    {
+        if (in_array($functionReflection->getName(), ['getcwd', 'tmpfile', 'dirname'], true)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getTypeFromFunctionCall(
+        FunctionReflection $functionReflection,
+        FuncCall $functionCall,
+        Scope $scope
+    ): Type {
+        if ($functionReflection->getName() === 'tmpfile') {
+            return new ResourceType();
+        }
+
+        return new StringType();
+    }
+}

--- a/packages/PHPStanExtensions/src/Rules/Classes/MatchingTypeConstantRule.php
+++ b/packages/PHPStanExtensions/src/Rules/Classes/MatchingTypeConstantRule.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassConst;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-use function Safe\sprintf;
 
 final class MatchingTypeConstantRule implements Rule
 {

--- a/packages/PackageBuilder/composer.json
+++ b/packages/PackageBuilder/composer.json
@@ -12,8 +12,7 @@
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
-        "symfony/yaml": "^3.4|^4.1",
-        "thecodingmachine/safe": "0.1.13"
+        "symfony/yaml": "^3.4|^4.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/PackageBuilder/composer.json
+++ b/packages/PackageBuilder/composer.json
@@ -13,7 +13,7 @@
         "symfony/finder": "^3.4|^4.1",
         "symfony/http-kernel": "^3.4|^4.1",
         "symfony/yaml": "^3.4|^4.1",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/PackageBuilder/src/Configuration/ConfigFileFinder.php
+++ b/packages/PackageBuilder/src/Configuration/ConfigFileFinder.php
@@ -5,8 +5,6 @@ namespace Symplify\PackageBuilder\Configuration;
 use Nette\Utils\Strings;
 use Symfony\Component\Console\Input\InputInterface;
 use Symplify\PackageBuilder\Exception\Configuration\FileNotFoundException;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class ConfigFileFinder
 {

--- a/packages/PackageBuilder/src/Configuration/LevelFileFinder.php
+++ b/packages/PackageBuilder/src/Configuration/LevelFileFinder.php
@@ -7,8 +7,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symplify\PackageBuilder\Exception\Configuration\LevelNotFoundException;
-use function Safe\sort;
-use function Safe\sprintf;
 
 final class LevelFileFinder
 {

--- a/packages/PackageBuilder/src/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass.php
+++ b/packages/PackageBuilder/src/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass.php
@@ -6,7 +6,6 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Throwable;
-use function Safe\class_implements;
 
 /**
  * Inspired by https://github.com/symfony/symfony/pull/25282/files

--- a/packages/PackageBuilder/src/DependencyInjection/DefinitionFinder.php
+++ b/packages/PackageBuilder/src/DependencyInjection/DefinitionFinder.php
@@ -5,7 +5,6 @@ namespace Symplify\PackageBuilder\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symplify\PackageBuilder\Exception\DependencyInjection\DefinitionForTypeNotFoundException;
-use function Safe\sprintf;
 
 final class DefinitionFinder
 {

--- a/packages/PackageBuilder/src/FileSystem/FileGuard.php
+++ b/packages/PackageBuilder/src/FileSystem/FileGuard.php
@@ -3,7 +3,6 @@
 namespace Symplify\PackageBuilder\FileSystem;
 
 use Symplify\PackageBuilder\Exception\Configuration\FileNotFoundException;
-use function Safe\sprintf;
 
 final class FileGuard
 {

--- a/packages/PackageBuilder/src/FileSystem/FileSystemGuard.php
+++ b/packages/PackageBuilder/src/FileSystem/FileSystemGuard.php
@@ -3,7 +3,6 @@
 namespace Symplify\PackageBuilder\FileSystem;
 
 use Symplify\PackageBuilder\Exception\FileSystem\DirectoryNotFoundException;
-use function Safe\sprintf;
 
 final class FileSystemGuard
 {

--- a/packages/PackageBuilder/src/FileSystem/FinderSanitizer.php
+++ b/packages/PackageBuilder/src/FileSystem/FinderSanitizer.php
@@ -6,7 +6,6 @@ use Nette\Utils\Finder as NetteFinder;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder as SymfonyFinder;
 use Symfony\Component\Finder\SplFileInfo as SymfonySplFileInfo;
-use function Safe\filesize;
 
 final class FinderSanitizer
 {

--- a/packages/PackageBuilder/src/Parameter/ParameterTypoProofreader.php
+++ b/packages/PackageBuilder/src/Parameter/ParameterTypoProofreader.php
@@ -8,7 +8,6 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symplify\PackageBuilder\Exception\Parameter\ParameterTypoException;
-use function Safe\sprintf;
 
 final class ParameterTypoProofreader
 {

--- a/packages/PackageBuilder/src/Strings/SymplifyStrings.php
+++ b/packages/PackageBuilder/src/Strings/SymplifyStrings.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\Strings;
+
+final class SymplifyStrings
+{
+    /**
+     * @param int|string|float|bool|null ...$ars
+     */
+    public function sprintf(string $format, ...$ars): string
+    {
+        // @todo validate argument number - e.g. %s, [1, 2] should fail
+        return sprintf($format, ...$ars);
+    }
+}

--- a/packages/PackageBuilder/src/Yaml/FileLoader/AbstractParameterMergingYamlFileLoader.php
+++ b/packages/PackageBuilder/src/Yaml/FileLoader/AbstractParameterMergingYamlFileLoader.php
@@ -8,7 +8,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symplify\PackageBuilder\Exception\Yaml\InvalidParametersValueException;
 use Symplify\PackageBuilder\Reflection\PrivatesCaller;
 use Symplify\PackageBuilder\Yaml\ParametersMerger;
-use function Safe\sprintf;
 
 /**
  * The need:

--- a/packages/PackageBuilder/src/Yaml/ParameterInImportResolver.php
+++ b/packages/PackageBuilder/src/Yaml/ParameterInImportResolver.php
@@ -4,7 +4,6 @@ namespace Symplify\PackageBuilder\Yaml;
 
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symplify\PackageBuilder\Composer\VendorDirProvider;
-use function Safe\getcwd;
 
 /**
  * This service resolve parameters in import section, e.g:

--- a/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
+++ b/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
@@ -7,8 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
 use Symplify\PackageBuilder\Exception\Configuration\FileNotFoundException;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class ConfigFileFinderTest extends TestCase
 {

--- a/packages/PackageBuilder/tests/Console/ThrowableRendererTest.php
+++ b/packages/PackageBuilder/tests/Console/ThrowableRendererTest.php
@@ -9,9 +9,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symplify\PackageBuilder\Console\ThrowableRenderer;
-use function Safe\fclose;
-use function Safe\fread;
-use function Safe\tmpfile;
 
 final class ThrowableRendererTest extends TestCase
 {
@@ -79,6 +76,6 @@ final class ThrowableRendererTest extends TestCase
         $output = fread($this->tempFile, 4096);
         fclose($this->tempFile);
 
-        return $output;
+        return (string) $output;
     }
 }

--- a/packages/Statie/composer.json
+++ b/packages/Statie/composer.json
@@ -27,7 +27,7 @@
         "symplify/package-builder": "^5.5",
         "jean85/pretty-package-versions": "^1.2",
         "ocramius/package-versions": "^1.3",
-        "thecodingmachine/safe": "0.1.13"
+
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/Statie/composer.json
+++ b/packages/Statie/composer.json
@@ -27,7 +27,7 @@
         "symplify/package-builder": "^5.5",
         "jean85/pretty-package-versions": "^1.2",
         "ocramius/package-versions": "^1.3",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/Statie/packages/Generator/src/Configuration/GeneratorElementFactory.php
+++ b/packages/Statie/packages/Generator/src/Configuration/GeneratorElementFactory.php
@@ -6,7 +6,6 @@ use Nette\Utils\FileSystem;
 use Symplify\Statie\Configuration\StatieConfiguration;
 use Symplify\Statie\Generator\FileNameObjectSorter;
 use Symplify\Statie\Generator\Renderable\File\GeneratorFile;
-use function Safe\realpath;
 
 final class GeneratorElementFactory
 {

--- a/packages/Statie/packages/Generator/src/Configuration/GeneratorElementGuard.php
+++ b/packages/Statie/packages/Generator/src/Configuration/GeneratorElementGuard.php
@@ -5,7 +5,6 @@ namespace Symplify\Statie\Generator\Configuration;
 use Symplify\Statie\Generator\Contract\ObjectSorterInterface;
 use Symplify\Statie\Generator\Exception\Configuration\InvalidGeneratorElementDefinitionException;
 use Symplify\Statie\Renderable\File\AbstractFile;
-use function Safe\sprintf;
 
 final class GeneratorElementGuard
 {

--- a/packages/Statie/packages/Generator/src/FileNameObjectSorter.php
+++ b/packages/Statie/packages/Generator/src/FileNameObjectSorter.php
@@ -4,7 +4,6 @@ namespace Symplify\Statie\Generator;
 
 use Symplify\Statie\Generator\Contract\ObjectSorterInterface;
 use Symplify\Statie\Generator\Renderable\File\AbstractGeneratorFile;
-use function Safe\uasort;
 
 final class FileNameObjectSorter implements ObjectSorterInterface
 {

--- a/packages/Statie/packages/Generator/src/Generator.php
+++ b/packages/Statie/packages/Generator/src/Generator.php
@@ -10,7 +10,6 @@ use Symplify\Statie\Generator\Exception\Configuration\GeneratorException;
 use Symplify\Statie\Generator\Renderable\File\AbstractGeneratorFile;
 use Symplify\Statie\Generator\Renderable\File\GeneratorFileFactory;
 use Symplify\Statie\Renderable\RenderableFilesProcessor;
-use function Safe\sprintf;
 
 final class Generator
 {

--- a/packages/Statie/packages/Generator/src/Renderable/File/GeneratorFileGuard.php
+++ b/packages/Statie/packages/Generator/src/Renderable/File/GeneratorFileGuard.php
@@ -4,7 +4,6 @@ namespace Symplify\Statie\Generator\Renderable\File;
 
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Symplify\Statie\Generator\Exception\Configuration\GeneratorException;
-use function Safe\sprintf;
 
 final class GeneratorFileGuard
 {

--- a/packages/Statie/packages/Generator/tests/Configuration/GeneratorElementGuardForObjectSorterTest.php
+++ b/packages/Statie/packages/Generator/tests/Configuration/GeneratorElementGuardForObjectSorterTest.php
@@ -6,7 +6,6 @@ use Symplify\Statie\Generator\Contract\ObjectSorterInterface;
 use Symplify\Statie\Generator\Exception\Configuration\InvalidGeneratorElementDefinitionException;
 use Symplify\Statie\Generator\Tests\AbstractGeneratorTest;
 use Symplify\Statie\Generator\Tests\Configuration\GeneratorElementGuardSource\InvalidLectureSorter;
-use function Safe\sprintf;
 
 final class GeneratorElementGuardForObjectSorterTest extends AbstractGeneratorTest
 {

--- a/packages/Statie/packages/Generator/tests/Configuration/GeneratorElementGuardForObjectTest.php
+++ b/packages/Statie/packages/Generator/tests/Configuration/GeneratorElementGuardForObjectTest.php
@@ -6,7 +6,6 @@ use Symplify\Statie\Generator\Exception\Configuration\InvalidGeneratorElementDef
 use Symplify\Statie\Generator\Tests\AbstractGeneratorTest;
 use Symplify\Statie\Generator\Tests\Configuration\GeneratorElementGuardSource\InvalidObject;
 use Symplify\Statie\Renderable\File\AbstractFile;
-use function Safe\sprintf;
 
 final class GeneratorElementGuardForObjectTest extends AbstractGeneratorTest
 {

--- a/packages/Statie/packages/Generator/tests/GeneratorExceptionsTest.php
+++ b/packages/Statie/packages/Generator/tests/GeneratorExceptionsTest.php
@@ -5,7 +5,6 @@ namespace Symplify\Statie\Generator\Tests;
 use Symplify\Statie\Exception\Renderable\File\AccessKeyNotAvailableException;
 use Symplify\Statie\Exception\Renderable\File\UnsupportedMethodException;
 use Symplify\Statie\Renderable\File\PostFile;
-use function Safe\sprintf;
 
 final class GeneratorExceptionsTest extends AbstractGeneratorTest
 {

--- a/packages/Statie/packages/GithubContributorsThanker/src/Api/GithubApi.php
+++ b/packages/Statie/packages/GithubContributorsThanker/src/Api/GithubApi.php
@@ -3,8 +3,6 @@
 namespace Symplify\Statie\GithubContributorsThanker\Api;
 
 use Symplify\PackageBuilder\Http\BetterGuzzleClient;
-use function Safe\rsort;
-use function Safe\sprintf;
 
 final class GithubApi
 {

--- a/packages/Statie/packages/GithubContributorsThanker/src/Command/DumpContributorsCommand.php
+++ b/packages/Statie/packages/GithubContributorsThanker/src/Command/DumpContributorsCommand.php
@@ -10,7 +10,6 @@ use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\FileSystem\GeneratedFilesDumper;
 use Symplify\Statie\GithubContributorsThanker\Api\GithubApi;
-use function Safe\sprintf;
 
 final class DumpContributorsCommand extends Command
 {

--- a/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
@@ -3,7 +3,6 @@
 namespace Symplify\Statie\HeadlineAnchorLinker;
 
 use Nette\Utils\Strings;
-use function Safe\sprintf;
 
 final class HeadlineAnchorLinker
 {

--- a/packages/Statie/packages/JoindIn/src/Api/JoindInApi.php
+++ b/packages/Statie/packages/JoindIn/src/Api/JoindInApi.php
@@ -4,7 +4,6 @@ namespace Symplify\Statie\JoindIn\Api;
 
 use Symplify\PackageBuilder\Http\BetterGuzzleClient;
 use Symplify\Statie\JoindIn\Exception\JoindInException;
-use function Safe\sprintf;
 
 final class JoindInApi
 {

--- a/packages/Statie/packages/JoindIn/src/Command/DumpJoindInCommand.php
+++ b/packages/Statie/packages/JoindIn/src/Command/DumpJoindInCommand.php
@@ -10,7 +10,6 @@ use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\FileSystem\GeneratedFilesDumper;
 use Symplify\Statie\JoindIn\Api\JoindInApi;
-use function Safe\sprintf;
 
 final class DumpJoindInCommand extends Command
 {

--- a/packages/Statie/packages/Latte/src/LatteRenderer.php
+++ b/packages/Statie/packages/Latte/src/LatteRenderer.php
@@ -10,7 +10,6 @@ use Symplify\Statie\Latte\Exception\InvalidLatteSyntaxException;
 use Symplify\Statie\Latte\Loader\ArrayLoader;
 use Symplify\Statie\Renderable\CodeBlocksProtector;
 use Symplify\Statie\Renderable\File\AbstractFile;
-use function Safe\sprintf;
 
 final class LatteRenderer implements RendererInterface
 {

--- a/packages/Statie/packages/Latte/src/Loader/ArrayLoader.php
+++ b/packages/Statie/packages/Latte/src/Loader/ArrayLoader.php
@@ -6,7 +6,6 @@ use Latte\ILoader;
 use Nette\Utils\ObjectHelpers;
 use Nette\Utils\Strings;
 use Symplify\Statie\Latte\Exception\MissingLatteTemplateException;
-use function Safe\sprintf;
 
 /**
  * Inspired by @see \Latte\Loaders\StringLoader.

--- a/packages/Statie/packages/Latte/tests/Renderable/LatteFileDecoratorTest.php
+++ b/packages/Statie/packages/Latte/tests/Renderable/LatteFileDecoratorTest.php
@@ -11,7 +11,6 @@ use Symplify\Statie\Latte\Renderable\LatteFileDecorator;
 use Symplify\Statie\Renderable\File\File;
 use Symplify\Statie\Renderable\File\FileFactory;
 use Symplify\Statie\Tests\AbstractContainerAwareTestCase;
-use function Safe\sprintf;
 
 final class LatteFileDecoratorTest extends AbstractContainerAwareTestCase
 {

--- a/packages/Statie/packages/Migrator/src/Command/Reporter/MigrateReporter.php
+++ b/packages/Statie/packages/Migrator/src/Command/Reporter/MigrateReporter.php
@@ -3,7 +3,6 @@
 namespace Symplify\Statie\Migrator\Command\Reporter;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
-use function Safe\sprintf;
 
 final class MigrateReporter
 {

--- a/packages/Statie/packages/Migrator/src/Filesystem/FilesystemRegularApplicator.php
+++ b/packages/Statie/packages/Migrator/src/Filesystem/FilesystemRegularApplicator.php
@@ -6,7 +6,6 @@ use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
 
 final class FilesystemRegularApplicator
 {

--- a/packages/Statie/packages/Migrator/src/Filesystem/MigratorFilesystem.php
+++ b/packages/Statie/packages/Migrator/src/Filesystem/MigratorFilesystem.php
@@ -6,7 +6,6 @@ use Nette\Utils\FileSystem;
 use Symfony\Component\Finder\Finder;
 use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\glob;
 
 final class MigratorFilesystem
 {

--- a/packages/Statie/packages/Migrator/src/Worker/IncludePathsCompleter.php
+++ b/packages/Statie/packages/Migrator/src/Worker/IncludePathsCompleter.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
 use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
-use function Safe\sprintf;
 
 final class IncludePathsCompleter implements MigratorWorkerInterface
 {

--- a/packages/Statie/packages/Migrator/src/Worker/ParametersAdder.php
+++ b/packages/Statie/packages/Migrator/src/Worker/ParametersAdder.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Yaml;
 use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
 use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
-use function Safe\sprintf;
 
 final class ParametersAdder implements MigratorWorkerInterface
 {

--- a/packages/Statie/packages/Migrator/src/Worker/PostIdsAdder.php
+++ b/packages/Statie/packages/Migrator/src/Worker/PostIdsAdder.php
@@ -7,7 +7,6 @@ use Nette\Utils\Strings;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
 use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
-use function Safe\sprintf;
 
 final class PostIdsAdder implements MigratorWorkerInterface
 {

--- a/packages/Statie/packages/Migrator/src/Worker/StatieImportsAdder.php
+++ b/packages/Statie/packages/Migrator/src/Worker/StatieImportsAdder.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Yaml;
 use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
 use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
-use function Safe\sprintf;
 
 final class StatieImportsAdder implements MigratorWorkerInterface
 {

--- a/packages/Statie/packages/Migrator/src/Worker/TwigSuffixChanger.php
+++ b/packages/Statie/packages/Migrator/src/Worker/TwigSuffixChanger.php
@@ -7,7 +7,6 @@ use Nette\Utils\Strings;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
 use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
-use function Safe\sprintf;
 
 final class TwigSuffixChanger implements MigratorWorkerInterface
 {

--- a/packages/Statie/packages/Migrator/tests/AbstractProjectToStatieMigratorTest.php
+++ b/packages/Statie/packages/Migrator/tests/AbstractProjectToStatieMigratorTest.php
@@ -10,7 +10,6 @@ use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Symplify\Statie\Migrator\Contract\MigratorInterface;
 use Symplify\Statie\Tests\AbstractContainerAwareTestCase;
-use function Safe\sprintf;
 
 abstract class AbstractProjectToStatieMigratorTest extends AbstractContainerAwareTestCase
 {

--- a/packages/Statie/packages/MigratorJekyll/src/Command/MigrateJekyllCommand.php
+++ b/packages/Statie/packages/MigratorJekyll/src/Command/MigrateJekyllCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\MigratorJekyll\JekyllToStatieMigrator;
-use function Safe\getcwd;
 
 final class MigrateJekyllCommand extends Command
 {

--- a/packages/Statie/packages/MigratorSculpin/src/Command/MigrateSculpinCommand.php
+++ b/packages/Statie/packages/MigratorSculpin/src/Command/MigrateSculpinCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\MigratorJekyll\JekyllToStatieMigrator;
-use function Safe\getcwd;
 
 final class MigrateSculpinCommand extends Command
 {

--- a/packages/Statie/packages/MigratorSculpin/src/Worker/RoutePrefixMigrateWorker.php
+++ b/packages/Statie/packages/MigratorSculpin/src/Worker/RoutePrefixMigrateWorker.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Yaml;
 use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
 use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
-use function Safe\sprintf;
 
 final class RoutePrefixMigrateWorker implements MigratorWorkerInterface
 {

--- a/packages/Statie/packages/Tweeter/src/Command/TweetPostCommand.php
+++ b/packages/Statie/packages/Tweeter/src/Command/TweetPostCommand.php
@@ -13,7 +13,6 @@ use Symplify\Statie\Tweeter\Tweet\PostTweet;
 use Symplify\Statie\Tweeter\TweetFilter\TweetsFilter;
 use Symplify\Statie\Tweeter\TweetProvider\PostTweetsProvider;
 use Symplify\Statie\Tweeter\TwitterApi\TwitterApiWrapper;
-use function Safe\sprintf;
 
 final class TweetPostCommand extends Command
 {

--- a/packages/Statie/packages/Tweeter/src/TweetGuard.php
+++ b/packages/Statie/packages/Tweeter/src/TweetGuard.php
@@ -6,8 +6,6 @@ use Symplify\Statie\Renderable\File\PostFile;
 use Symplify\Statie\Tweeter\Configuration\Keys;
 use Symplify\Statie\Tweeter\Exception\TweetImageNotFoundException;
 use Symplify\Statie\Tweeter\Exception\TweetTooLongException;
-use function Safe\realpath;
-use function Safe\sprintf;
 
 final class TweetGuard
 {

--- a/packages/Statie/packages/Tweeter/src/TwitterApi/TwitterApiWrapper.php
+++ b/packages/Statie/packages/Tweeter/src/TwitterApi/TwitterApiWrapper.php
@@ -9,7 +9,6 @@ use Symplify\Statie\Tweeter\Exception\TwitterApi\TwitterApiException;
 use Symplify\Statie\Tweeter\Tweet\PublishedTweet;
 use Symplify\Statie\Tweeter\TweetEntityCompleter;
 use TwitterAPIExchange;
-use function Safe\sprintf;
 
 final class TwitterApiWrapper
 {

--- a/packages/Statie/packages/Twig/src/TwigRenderer.php
+++ b/packages/Statie/packages/Twig/src/TwigRenderer.php
@@ -9,7 +9,6 @@ use Symplify\Statie\Twig\Exception\InvalidTwigSyntaxException;
 use Throwable;
 use Twig\Environment;
 use Twig\Loader\ArrayLoader;
-use function Safe\sprintf;
 
 final class TwigRenderer implements RendererInterface
 {

--- a/packages/Statie/src/Application/StatieApplication.php
+++ b/packages/Statie/src/Application/StatieApplication.php
@@ -15,7 +15,6 @@ use Symplify\Statie\Renderable\File\VirtualFile;
 use Symplify\Statie\Renderable\RedirectGenerator;
 use Symplify\Statie\Renderable\RenderableFilesProcessor;
 use Symplify\Statie\Templating\LayoutsAndSnippetsLoader;
-use function Safe\sprintf;
 
 final class StatieApplication
 {

--- a/packages/Statie/src/Configuration/Parser/YamlParser.php
+++ b/packages/Statie/src/Configuration/Parser/YamlParser.php
@@ -4,7 +4,6 @@ namespace Symplify\Statie\Configuration\Parser;
 
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
-use function Safe\sprintf;
 
 final class YamlParser
 {

--- a/packages/Statie/src/Configuration/StatieConfiguration.php
+++ b/packages/Statie/src/Configuration/StatieConfiguration.php
@@ -2,12 +2,10 @@
 
 namespace Symplify\Statie\Configuration;
 
+use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\Statie\Exception\Configuration\MissingGithubRepositorySlugException;
 use Symplify\Statie\FileSystem\FileSystemGuard;
-use function Safe\getcwd;
-use function Safe\realpath;
-use function Safe\sprintf;
 
 final class StatieConfiguration
 {
@@ -51,7 +49,7 @@ final class StatieConfiguration
     {
         $sourceDirectory = rtrim($sourceDirectory, '/');
         $this->fileSystemGuard->ensureDirectoryExists($sourceDirectory);
-        $this->sourceDirectory = realpath($sourceDirectory);
+        $this->sourceDirectory = (new SmartFileInfo($sourceDirectory))->getRealPath();
     }
 
     public function setOutputDirectory(string $outputDirectory): void

--- a/packages/Statie/src/Console/Command/CreatePostCommand.php
+++ b/packages/Statie/src/Console/Command/CreatePostCommand.php
@@ -15,7 +15,6 @@ use Symplify\Statie\Exception\Configuration\ConfigurationException;
 use Symplify\Statie\FileSystem\CreatePostFileSystem;
 use Symplify\Statie\Generator\Configuration\GeneratorConfiguration;
 use Symplify\Statie\Generator\Configuration\GeneratorElement;
-use function Safe\sprintf;
 
 final class CreatePostCommand extends Command
 {

--- a/packages/Statie/src/Console/Command/DumpFileDecoratorsCommand.php
+++ b/packages/Statie/src/Console/Command/DumpFileDecoratorsCommand.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\Renderable\RenderableFilesProcessor;
-use function Safe\sprintf;
 
 final class DumpFileDecoratorsCommand extends Command
 {

--- a/packages/Statie/src/Console/Command/GenerateCommand.php
+++ b/packages/Statie/src/Console/Command/GenerateCommand.php
@@ -11,8 +11,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\Application\StatieApplication;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class GenerateCommand extends Command
 {

--- a/packages/Statie/src/Console/Command/InitCommand.php
+++ b/packages/Statie/src/Console/Command/InitCommand.php
@@ -11,8 +11,6 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\Statie\Exception\Configuration\ConfigurationException;
-use function Safe\getcwd;
-use function Safe\sprintf;
 
 final class InitCommand extends Command
 {

--- a/packages/Statie/src/DependencyInjection/ContainerFactory.php
+++ b/packages/Statie/src/DependencyInjection/ContainerFactory.php
@@ -3,7 +3,6 @@
 namespace Symplify\Statie\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use function Safe\putenv;
 
 final class ContainerFactory
 {

--- a/packages/Statie/src/Exception/Templating/InvalidSortByCriteriaException.php
+++ b/packages/Statie/src/Exception/Templating/InvalidSortByCriteriaException.php
@@ -3,7 +3,6 @@
 namespace Symplify\Statie\Exception\Templating;
 
 use Exception;
-use function Safe\sprintf;
 
 final class InvalidSortByCriteriaException extends Exception
 {

--- a/packages/Statie/src/FileSystem/CreatePostFileSystem.php
+++ b/packages/Statie/src/FileSystem/CreatePostFileSystem.php
@@ -7,7 +7,6 @@ use Symplify\PackageBuilder\FileSystem\FinderSanitizer;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
 use Symplify\Statie\Exception\Configuration\DuplicatedPostException;
 use Symplify\Statie\Generator\Configuration\GeneratorElement;
-use function Safe\sprintf;
 
 final class CreatePostFileSystem
 {

--- a/packages/Statie/src/FileSystem/FileSystemGuard.php
+++ b/packages/Statie/src/FileSystem/FileSystemGuard.php
@@ -3,7 +3,6 @@
 namespace Symplify\Statie\FileSystem;
 
 use Symplify\Statie\Exception\Utils\MissingDirectoryException;
-use function Safe\sprintf;
 
 final class FileSystemGuard
 {

--- a/packages/Statie/src/FileSystem/GeneratedFilesDumper.php
+++ b/packages/Statie/src/FileSystem/GeneratedFilesDumper.php
@@ -6,7 +6,6 @@ use Nette\Utils\DateTime;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 use Symplify\Statie\Configuration\StatieConfiguration;
-use function Safe\sprintf;
 
 final class GeneratedFilesDumper
 {

--- a/packages/Statie/src/Renderable/ConfigurationFileDecorator.php
+++ b/packages/Statie/src/Renderable/ConfigurationFileDecorator.php
@@ -9,7 +9,6 @@ use Symplify\Statie\Contract\Renderable\FileDecoratorInterface;
 use Symplify\Statie\Generator\Configuration\GeneratorElement;
 use Symplify\Statie\Generator\Renderable\File\AbstractGeneratorFile;
 use Symplify\Statie\Renderable\File\AbstractFile;
-use function Safe\sprintf;
 
 final class ConfigurationFileDecorator implements FileDecoratorInterface
 {

--- a/packages/Statie/src/Renderable/File/PostFile.php
+++ b/packages/Statie/src/Renderable/File/PostFile.php
@@ -10,7 +10,6 @@ use Nette\Utils\Strings;
 use Symplify\Statie\Exception\Renderable\File\AccessKeyNotAvailableException;
 use Symplify\Statie\Exception\Renderable\File\UnsupportedMethodException;
 use Symplify\Statie\Generator\Renderable\File\AbstractGeneratorFile;
-use function Safe\sprintf;
 
 final class PostFile extends AbstractGeneratorFile implements ArrayAccess
 {

--- a/packages/Statie/src/Renderable/RenderableFilesProcessor.php
+++ b/packages/Statie/src/Renderable/RenderableFilesProcessor.php
@@ -9,7 +9,6 @@ use Symplify\Statie\Generator\Configuration\GeneratorElement;
 use Symplify\Statie\Generator\Renderable\File\AbstractGeneratorFile;
 use Symplify\Statie\Renderable\File\AbstractFile;
 use Symplify\Statie\Renderable\File\FileFactory;
-use function Safe\usort;
 
 final class RenderableFilesProcessor
 {

--- a/packages/Statie/src/Templating/ArrayUtils.php
+++ b/packages/Statie/src/Templating/ArrayUtils.php
@@ -3,8 +3,6 @@
 namespace Symplify\Statie\Templating;
 
 use Symplify\Statie\Exception\Templating\InvalidSortByCriteriaException;
-use function Safe\ksort;
-use function Safe\usort;
 
 final class ArrayUtils
 {

--- a/packages/Statie/src/Templating/FilterProvider/GeneratorFilterProvider.php
+++ b/packages/Statie/src/Templating/FilterProvider/GeneratorFilterProvider.php
@@ -5,7 +5,6 @@ namespace Symplify\Statie\Templating\FilterProvider;
 use Symplify\Statie\Contract\Templating\FilterProviderInterface;
 use Symplify\Statie\Exception\Configuration\ConfigurationException;
 use Symplify\Statie\Generator\Renderable\File\AbstractGeneratorFile;
-use function Safe\sprintf;
 
 final class GeneratorFilterProvider implements FilterProviderInterface
 {

--- a/packages/Statie/src/Utils/PathAnalyzer.php
+++ b/packages/Statie/src/Utils/PathAnalyzer.php
@@ -6,7 +6,6 @@ use DateTimeInterface;
 use Nette\Utils\DateTime;
 use Nette\Utils\Strings;
 use Symplify\PackageBuilder\FileSystem\SmartFileInfo;
-use function Safe\sprintf;
 
 final class PathAnalyzer
 {

--- a/packages/Statie/tests/Configuration/Parser/YamlParserTest.php
+++ b/packages/Statie/tests/Configuration/Parser/YamlParserTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser;
 use Symplify\Statie\Configuration\Parser\YamlParser;
-use function Safe\sprintf;
 
 final class YamlParserTest extends TestCase
 {

--- a/packages/Statie/tests/Console/Command/GenerateCommandTest.php
+++ b/packages/Statie/tests/Console/Command/GenerateCommandTest.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\Statie\Console\Application;
 use Symplify\Statie\Exception\Utils\MissingDirectoryException;
 use Symplify\Statie\Tests\AbstractContainerAwareTestCase;
-use function Safe\sprintf;
 
 final class GenerateCommandTest extends AbstractContainerAwareTestCase
 {

--- a/packages/Statie/tests/Renderable/Configuration/ConfigurationFileDecoratorTest.php
+++ b/packages/Statie/tests/Renderable/Configuration/ConfigurationFileDecoratorTest.php
@@ -9,7 +9,6 @@ use Symplify\Statie\Configuration\StatieConfiguration;
 use Symplify\Statie\Renderable\ConfigurationFileDecorator;
 use Symplify\Statie\Renderable\File\FileFactory;
 use Symplify\Statie\Tests\AbstractContainerAwareTestCase;
-use function Safe\sprintf;
 
 final class ConfigurationFileDecoratorTest extends AbstractContainerAwareTestCase
 {

--- a/packages/TokenRunner/composer.json
+++ b/packages/TokenRunner/composer.json
@@ -9,8 +9,7 @@
         "symplify/package-builder": "^5.5",
         "symplify/better-phpdoc-parser": "^5.5",
         "friendsofphp/php-cs-fixer": "^2.14",
-        "squizlabs/php_codesniffer": "^3.4",
-        "thecodingmachine/safe": "0.1.13"
+        "squizlabs/php_codesniffer": "^3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/TokenRunner/composer.json
+++ b/packages/TokenRunner/composer.json
@@ -10,7 +10,7 @@
         "symplify/better-phpdoc-parser": "^5.5",
         "friendsofphp/php-cs-fixer": "^2.14",
         "squizlabs/php_codesniffer": "^3.4",
-        "thecodingmachine/safe": "^0.1.13"
+        "thecodingmachine/safe": "0.1.13"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/packages/TokenRunner/src/Analyzer/FixerAnalyzer/BlockFinder.php
+++ b/packages/TokenRunner/src/Analyzer/FixerAnalyzer/BlockFinder.php
@@ -7,7 +7,6 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symplify\TokenRunner\Exception\MissingImplementationException;
 use Throwable;
-use function Safe\sprintf;
 
 final class BlockFinder
 {

--- a/packages/TokenRunner/src/DocBlock/DescriptionAnalyzer.php
+++ b/packages/TokenRunner/src/DocBlock/DescriptionAnalyzer.php
@@ -6,7 +6,6 @@ use Nette\Utils\Strings;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use Symplify\BetterPhpDocParser\PhpDocParser\TypeNodeAnalyzer;
 use Symplify\BetterPhpDocParser\PhpDocParser\TypeNodeToStringsConverter;
-use function Safe\sprintf;
 
 final class DescriptionAnalyzer
 {

--- a/packages/TokenRunner/src/Guard/TokenTypeGuard.php
+++ b/packages/TokenRunner/src/Guard/TokenTypeGuard.php
@@ -4,7 +4,6 @@ namespace Symplify\TokenRunner\Guard;
 
 use PhpCsFixer\Tokenizer\Token;
 use Symplify\TokenRunner\Exception\UnexpectedTokenException;
-use function Safe\sprintf;
 
 final class TokenTypeGuard
 {

--- a/packages/TokenRunner/src/Wrapper/FixerWrapper/ClassWrapper.php
+++ b/packages/TokenRunner/src/Wrapper/FixerWrapper/ClassWrapper.php
@@ -11,8 +11,6 @@ use Symplify\PackageBuilder\Reflection\PrivatesCaller;
 use Symplify\PackageBuilder\Types\ClassLikeExistenceChecker;
 use Symplify\TokenRunner\Analyzer\FixerAnalyzer\DocBlockFinder;
 use Symplify\TokenRunner\Naming\Name\NameFactory;
-use function Safe\class_implements;
-use function Safe\class_parents;
 
 final class ClassWrapper
 {

--- a/packages/TokenRunner/tests/Wrapper/FixerWrapper/ClassWrapper/ClassWrapperTest.php
+++ b/packages/TokenRunner/tests/Wrapper/FixerWrapper/ClassWrapper/ClassWrapperTest.php
@@ -9,7 +9,6 @@ use Symplify\TokenRunner\Tests\Wrapper\FixerWrapper\ClassWrapper\Source\SomeClas
 use Symplify\TokenRunner\Tests\Wrapper\FixerWrapper\ClassWrapper\Source\SomeInterface;
 use Symplify\TokenRunner\Wrapper\FixerWrapper\ClassWrapper;
 use Symplify\TokenRunner\Wrapper\FixerWrapper\ClassWrapperFactory;
-use function Safe\file_get_contents;
 
 final class ClassWrapperTest extends AbstractContainerAwareTestCase
 {

--- a/packages/TokenRunner/tests/bootstrap.php
+++ b/packages/TokenRunner/tests/bootstrap.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 use PHP_CodeSniffer\Util\Tokens;
-use function Safe\define;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 includes:
     - 'packages/PHPStanExtensions/config/config.neon'
     - 'vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon'
-    - 'vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon'
 
 parameters:
     level: max
@@ -134,3 +133,11 @@ parameters:
 
         # intentionally - array_search return false is needed, as key might be missed
         - '#Function array_search is unsafe to use#'
+
+        # console argument/option
+        - '#Cannot cast array<string\>\|bool\|string to string#'
+
+        # known values
+        - '#Method Symplify\\EasyCodingStandardTester\\Testing\\AbstractCheckerTestCase\:\:getConfigHash\(\) should return string but returns string\|false#'
+        - '#Parameter \#1 \$code of static method PhpCsFixer\\Tokenizer\\Tokens\:\:fromCode\(\) expects string, string\|false given#'
+        - '#Method Symplify\\PackageBuilder\\DependencyInjection\\CompilerPass\\AutowireSinglyImplementedCompilerPass\:\:filterSinglyImplementedInterfaces\(\) should return array<string\> but returns array<string, int\|string\>#'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,6 @@
 <?php declare(strict_types=1);
 
 use PHP_CodeSniffer\Util\Tokens;
-use function Safe\define;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php';


### PR DESCRIPTION
I gave this package a try and after short evaluation.

## Pros

- less potential errors
- less phpstan reporting

But it had costs.

## Cons

- huge maintenance overload, mainly in monorepo with 12 packages
- cannot say the error count wen't low, didn't notice in issues or practical usage

- 3rd party tool are not ready for function autoloading, probably because it's very rare out in the wild; I personal don't know about any other function-based package, I got stuck due to this for a week - https://github.com/humbug/box/issues/352

- the api changes very fast, BC breaks even on patch versions caused many symplify package to let down

- I really have to think about it on every adding of PHP function, it's the [memory lock](https://www.tomasvotruba.cz/blog/2018/08/27/why-and-how-to-avoid-the-memory-lock/). I add function, run phpstan, get the many errors to use safe version, fix it manually for each one. Having Rector in local CI would solve this, but it kills developer experience.

- It's doesn't report issues like `sprintf('This is "%s", 1, 2))`, which needs a custom services. I prefere Nette\String here, that practically handles most of PHP-falsy functions in elegant and funciton-specific way

For these, I've decided to remove it for now and use specific custom static calls that reflect specific function needs.