### PR TITLE
fix SmartFileInfo getRelativePath on Windows - use normalized path

### DIFF
--- a/packages/PackageBuilder/src/FileSystem/SmartFileInfo.php
+++ b/packages/PackageBuilder/src/FileSystem/SmartFileInfo.php
@@ -55,7 +55,7 @@ final class SmartFileInfo extends SplFileInfo
             ));
         }
 
-        return Strings::substring($this->getRealPath(), Strings::length(realpath($directory)) + 1);
+        return Strings::substring($this->getNormalizedRealPath(), Strings::length(realpath($directory)) + 1);
     }
 
     public function endsWith(string $string): bool


### PR DESCRIPTION
originally I found this as problem on Windows with Statie, see #1408 ; please see discussion in issue first