### PR TITLE
Remove token-runner dependency from coding-standard

### DIFF
--- a/packages/CodingStandard/composer.json
+++ b/packages/CodingStandard/composer.json
@@ -8,7 +8,6 @@
         "nette/finder": "^2.4",
         "squizlabs/php_codesniffer": "^3.4",
         "friendsofphp/php-cs-fixer": "^2.14",
-        "symplify/token-runner": "^5.5",
         "slam/php-cs-fixer-extensions": "^1.17",
         "symplify/package-builder": "^5.5",
         "symplify/better-phpdoc-parser": "^5.5"


### PR DESCRIPTION
Remove token-runner dependency from coding-standard because it is already directly included