### PR TITLE
[PackageBuilder] Fix LevelFinder bundled in phar file

### DIFF
--- a/packages/PackageBuilder/src/Configuration/LevelFileFinder.php
+++ b/packages/PackageBuilder/src/Configuration/LevelFileFinder.php
@@ -24,6 +24,10 @@ final class LevelFileFinder
 
         $firstFile = $this->getFirstFileFromFinder($finder);
         if ($firstFile) {
+            if ($firstFile->getRealPath() === false) {
+                return $firstFile->getPathname();
+            }
+
             return $firstFile->getRealPath();
         }
 


### PR DESCRIPTION
getRealPath fails on phar paths. So I added a fallback. Its required for rector