### PR TITLE
[Statie] Take care of elements in anchor linker

### DIFF
--- a/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
@@ -12,6 +12,11 @@ final class HeadlineAnchorLinker
     private const HEADLINE_PATTERN = '#<h(?<level>[1-6])>(?<title>.*?)<\/h[1-6]>#';
 
     /**
+     * @var string
+     */
+    private const LINK_PATTERN = '#<a.*>(.*)<\/a>#';
+
+    /**
      * Before:
      * - <h1>Some headline</h1>
      *
@@ -21,7 +26,20 @@ final class HeadlineAnchorLinker
     public function processContent(string $content): string
     {
         return Strings::replace($content, self::HEADLINE_PATTERN, function (array $result): string {
-            $headlineId = Strings::webalize($result['title']);
+            $titleWithoutTags = strip_tags($result['title']);
+            $headlineId = Strings::webalize($titleWithoutTags);
+            $titleHasLink = count(Strings::match($result['title'], self::LINK_PATTERN)) > 0;
+
+            // Title contains <a> element
+            if ($result['title'] !== $titleWithoutTags && $titleHasLink) {
+                return sprintf(
+                    '<h%s id="%s">%s</h%s>',
+                    $result['level'],
+                    $headlineId,
+                    $result['title'],
+                    $result['level']
+                );
+            }
 
             return sprintf(
                 '<h%s id="%s"><a href="#%s">%s</a></h%s>',

--- a/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
@@ -28,7 +28,8 @@ final class HeadlineAnchorLinker
         return Strings::replace($content, self::HEADLINE_PATTERN, function (array $result): string {
             $titleWithoutTags = strip_tags($result['title']);
             $headlineId = Strings::webalize($titleWithoutTags);
-            $titleHasLink = count(Strings::match($result['title'], self::LINK_PATTERN)) > 0;
+            $titleWithLink = Strings::match($result['title'], self::LINK_PATTERN);
+            $titleHasLink = is_array($titleWithLink) ? count($titleWithLink) > 0 : false;
 
             // Title contains <a> element
             if ($result['title'] !== $titleWithoutTags && $titleHasLink) {

--- a/packages/Statie/packages/HeadlineAnchorLinker/tests/HeadlineAnchorLinkerTest.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/tests/HeadlineAnchorLinkerTest.php
@@ -16,8 +16,23 @@ final class HeadlineAnchorLinkerTest extends TestCase
             $headlineAnchorLinker->processContent('<h2>Hey</h2>')
         );
         $this->assertSame(
-            '<h3 id="hi-tom"><a href="#hi-tom">Hi Tom</a></h3>',
-            $headlineAnchorLinker->processContent('<h3>Hi Tom</h3>')
+            '<h3 id="hi-tom"><a href="#hi-tom">Hi <b>Tom<b></a></h3>',
+            $headlineAnchorLinker->processContent('<h3>Hi <b>Tom<b></h3>')
+        );
+    }
+
+    public function testHeadingWithLink(): void
+    {
+        $headlineAnchorLinker = new HeadlineAnchorLinker();
+
+        $this->assertSame(
+            '<h2 id="hey"><a href="http://example.com">Hey</a></h2>',
+            $headlineAnchorLinker->processContent('<h2><a href="http://example.com">Hey</a></h2>')
+        );
+
+        $this->assertSame(
+            '<h3 id="hi-tom">Hi <a href="http://example.com"><b>Tom<b></a></h3>',
+            $headlineAnchorLinker->processContent('<h3>Hi <a href="http://example.com"><b>Tom<b></a></h3>')
         );
     }
 }


### PR DESCRIPTION
New code strips all tags from `id` attribute and does not generate `<a>` element when title contains some (in any part of the title).

Let's have a look on two possible cases:

## 1. heading contains some html element

Consider heading on input

```html
<h3>Hi <b>Tom<b></h3>
```

### Before:

```html
<h3 id="hi-b-tom-b">
  <a href="#hi-tom">Hi <b>Tom<b></a>
</h3>
```

### After:

```html
<h3 id="hi-tom">
  <a href="#hi-tom">Hi <b>Tom<b></a>
</h3>
```

## 2. heading contains `<a>` element

Consider heading on input

```html
<h4>
  <a href="https://www.webexpo.net/prague2018/talk?id=impactful-storytelling-for-innovators-and-disruptors">Impactful Storytelling for Innovators and Disruptors</a>
</h4>
```

### Before:

```html
<h4 id="a-href-https-www-webexpo-net-prague2018-talk-id-impactful-storytelling-for-innovators-and-disruptors-impactful-storytelling-for-innovators-and-disruptors-a">
  <a href="#a-href-https-www-webexpo-net-prague2018-talk-id-impactful-storytelling-for-innovators-and-disruptors-impactful-storytelling-for-innovators-and-disruptors-a"></a>
  <a href="https://www.webexpo.net/prague2018/talk?id=impactful-storytelling-for-innovators-and-disruptors">Impactful Storytelling for Innovators and Disruptors</a>
</h4>
```

### After:

```html
<h4 id="impactful-storytelling-for-innovators-and-disruptors">
  <a href="https://www.webexpo.net/prague2018/talk?id=impactful-storytelling-for-innovators-and-disruptors">Impactful Storytelling for Innovators and Disruptors</a>
</h4>
```


