### PR TITLE
[CL] added support for resolving repository name from URL with user name included

### DIFF
--- a/packages/ChangelogLinker/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/ChangelogLinker/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -10,7 +10,10 @@ final class GithubRepositoryFromRemoteResolver
     public function resolveFromUrl(string $url): string
     {
         if (Strings::startsWith($url, 'https://')) {
-            return rtrim($url, '.git');
+            $url = rtrim($url, '.git');
+            $url = substr($url, strpos($url, 'github.com'));
+
+            return 'https://' . $url;
         }
 
         // turn SSH format to "https"

--- a/packages/ChangelogLinker/tests/Github/GithubRepositoryFromRemoteResolverTest.php
+++ b/packages/ChangelogLinker/tests/Github/GithubRepositoryFromRemoteResolverTest.php
@@ -31,6 +31,7 @@ final class GithubRepositoryFromRemoteResolverTest extends TestCase
     {
         yield ['git@github.com:Symplify/Symplify.git', 'https://github.com/Symplify/Symplify'];
         yield ['https://github.com/Symplify/Symplify.git', 'https://github.com/Symplify/Symplify'];
+        yield ['https://UserName@github.com/Symplify/Symplify.git', 'https://github.com/Symplify/Symplify'];
     }
 
     public function testInvalid(): void


### PR DESCRIPTION
Hello, I experienced issue with repository remote url that includes user name in it. I have added test and fix to solve my issue.