### PR TITLE
[Statie] Headline linker

### DIFF
--- a/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
@@ -21,7 +21,7 @@ final class HeadlineAnchorLinker
      * - <h2>Some headline</h2>
      *
      * After:
-     * - <h2 id="some-headline"><a href="#some-headline">Some headline</a></h2>
+     * - <h2 id="some-headline"><a href="#some-headline" class="heading-anchor">Some headline</a></h2>
      */
     public function processContent(string $content): string
     {
@@ -43,7 +43,7 @@ final class HeadlineAnchorLinker
             }
 
             return sprintf(
-                '<h%s id="%s"><a href="#%s">%s</a></h%s>',
+                '<h%s id="%s"><a href="#%s" class="heading-anchor">%s</a></h%s>',
                 $result['level'],
                 $headlineId,
                 $headlineId,

--- a/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/src/HeadlineAnchorLinker.php
@@ -9,7 +9,7 @@ final class HeadlineAnchorLinker
     /**
      * @var string
      */
-    private const HEADLINE_PATTERN = '#<h(?<level>[1-6])>(?<title>.*?)<\/h[1-6]>#';
+    private const HEADLINE_PATTERN = '#<h(?<level>[2-6])>(?<title>.*?)<\/h[2-6]>#';
 
     /**
      * @var string
@@ -18,10 +18,10 @@ final class HeadlineAnchorLinker
 
     /**
      * Before:
-     * - <h1>Some headline</h1>
+     * - <h2>Some headline</h2>
      *
      * After:
-     * - <h1 id="some-headline"><a href="#some-headline">Some headline</a></h1>
+     * - <h2 id="some-headline"><a href="#some-headline">Some headline</a></h2>
      */
     public function processContent(string $content): string
     {

--- a/packages/Statie/packages/HeadlineAnchorLinker/tests/HeadlineAnchorLinkerTest.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/tests/HeadlineAnchorLinkerTest.php
@@ -17,21 +17,21 @@ final class HeadlineAnchorLinkerTest extends TestCase
         );
     }
 
-    public function testLowerLevelHeading(): void
+    public function testLowerLevelHeadingWithoutLink(): void
     {
         $headlineAnchorLinker = new HeadlineAnchorLinker();
 
         $this->assertSame(
-            '<h2 id="hey"><a href="#hey">Hey</a></h2>',
+            '<h2 id="hey"><a href="#hey" class="heading-anchor">Hey</a></h2>',
             $headlineAnchorLinker->processContent('<h2>Hey</h2>')
         );
         $this->assertSame(
-            '<h3 id="hi-tom"><a href="#hi-tom">Hi <b>Tom<b></a></h3>',
+            '<h3 id="hi-tom"><a href="#hi-tom" class="heading-anchor">Hi <b>Tom<b></a></h3>',
             $headlineAnchorLinker->processContent('<h3>Hi <b>Tom<b></h3>')
         );
     }
 
-    public function testHeadingWithLink(): void
+    public function testLowerLevelHeadingWithLink(): void
     {
         $headlineAnchorLinker = new HeadlineAnchorLinker();
 

--- a/packages/Statie/packages/HeadlineAnchorLinker/tests/HeadlineAnchorLinkerTest.php
+++ b/packages/Statie/packages/HeadlineAnchorLinker/tests/HeadlineAnchorLinkerTest.php
@@ -7,7 +7,17 @@ use Symplify\Statie\HeadlineAnchorLinker\HeadlineAnchorLinker;
 
 final class HeadlineAnchorLinkerTest extends TestCase
 {
-    public function test(): void
+    public function testLevelOneHeading(): void
+    {
+        $headlineAnchorLinker = new HeadlineAnchorLinker();
+
+        $this->assertSame(
+            '<h1>Hey</h1>',
+            $headlineAnchorLinker->processContent('<h1>Hey</h1>')
+        );
+    }
+
+    public function testLowerLevelHeading(): void
     {
         $headlineAnchorLinker = new HeadlineAnchorLinker();
 


### PR DESCRIPTION
According to https://github.com/crazko/statie-web/pull/38, this PR does:

- exclude `h1` from having anchors
- add `class="headline-anchor"` to headings without links