### PR TITLE
Removes illuminate dependency

### DIFF
--- a/packages/PackageBuilder/composer.json
+++ b/packages/PackageBuilder/composer.json
@@ -4,7 +4,6 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "illuminate/support": "^5.7",
         "nette/utils": "^2.5|^3.0",
         "nette/finder": "^2.4",
         "symfony/config": "^3.4|^4.1",


### PR DESCRIPTION
Thanks for creating this package.

Just removed the illuminate dependency and tests seem be passing. There any reason to have `illuminate/support` within  `symplify/package-builder`? The downside is that this package can't be installed in Laravel < 5.6 + adds global functions to the project.