### PR TITLE
AutowireSinglyImplementedCompilerPass - Skipping singly implemented service if alias for interface is already registered

### DIFF
--- a/packages/PackageBuilder/src/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass.php
+++ b/packages/PackageBuilder/src/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass.php
@@ -57,12 +57,16 @@ final class AutowireSinglyImplementedCompilerPass implements CompilerPassInterfa
 
             $class = $definition->getClass();
             foreach (class_implements($class, false) as $interface) {
+                if (isset($singlyImplemented[$interface])) {
+                    $singlyImplemented[$interface] = false;
+                }
+
                 // An alias can not reference itself, it would cause circular reference
                 if ($interface === $name) {
                     continue;
                 }
 
-                $singlyImplemented[$interface] = isset($singlyImplemented[$interface]) ? false : $name;
+                $singlyImplemented[$interface] = $name;
             }
         }
 

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/AutowireSinglyImplementedCompilerPassTest.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/AutowireSinglyImplementedCompilerPassTest.php
@@ -1,4 +1,4 @@
-<?php declare (strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
 

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/AutowireSinglyImplementedCompilerPassTest.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/AutowireSinglyImplementedCompilerPassTest.php
@@ -1,0 +1,22 @@
+<?php declare (strict_types=1);
+
+namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\AutowireSinglyImplementedInterfaceKernel;
+use Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceB;
+use Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceInterface;
+
+class AutowireSinglyImplementedCompilerPassTest extends TestCase
+{
+    public function test(): void
+    {
+        $autoBindParametersKernel = new AutowireSinglyImplementedInterfaceKernel();
+        $autoBindParametersKernel->boot();
+
+        $container = $autoBindParametersKernel->getContainer();
+        $service = $container->get(ServiceInterface::class);
+
+        $this->assertInstanceOf(ServiceB::class, $service);
+    }
+}

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/AutowireSinglyImplementedInterfaceKernel.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/AutowireSinglyImplementedInterfaceKernel.php
@@ -1,11 +1,10 @@
-<?php declare (strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
-use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
 use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
 

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/AutowireSinglyImplementedInterfaceKernel.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/AutowireSinglyImplementedInterfaceKernel.php
@@ -1,0 +1,25 @@
+<?php declare (strict_types=1);
+
+namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutoBindParametersCompilerPass;
+use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass;
+use Symplify\PackageBuilder\HttpKernel\SimpleKernelTrait;
+
+final class AutowireSinglyImplementedInterfaceKernel extends Kernel
+{
+    use SimpleKernelTrait;
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(__DIR__ . '/config.yml');
+    }
+
+    protected function build(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->addCompilerPass(new AutowireSinglyImplementedCompilerPass());
+    }
+}

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceA.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceA.php
@@ -1,0 +1,7 @@
+<?php declare (strict_types=1);
+
+namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
+
+final class ServiceA implements ServiceInterface
+{
+}

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceA.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceA.php
@@ -1,4 +1,4 @@
-<?php declare (strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
 

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceB.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceB.php
@@ -1,4 +1,4 @@
-<?php declare (strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
 

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceB.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceB.php
@@ -1,0 +1,7 @@
+<?php declare (strict_types=1);
+
+namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
+
+final class ServiceB implements ServiceInterface
+{
+}

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceInterface.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceInterface.php
@@ -1,0 +1,8 @@
+<?php declare (strict_types=1);
+
+namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
+
+interface ServiceInterface
+{
+
+}

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceInterface.php
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/ServiceInterface.php
@@ -1,8 +1,7 @@
-<?php declare (strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source;
 
 interface ServiceInterface
 {
-
 }

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/config.yml
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/config.yml
@@ -1,0 +1,5 @@
+services:
+    Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceA: ~
+
+    Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceInterface:
+        class: Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceB

--- a/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/config.yml
+++ b/packages/PackageBuilder/tests/DependencyInjection/CompilerPass/AutowireSinglyImplementedCompilerPass/Source/config.yml
@@ -1,4 +1,7 @@
 services:
+    _defaults:
+        public: true
+
     Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceA: ~
 
     Symplify\PackageBuilder\Tests\DependencyInjection\CompilerPass\AutowireSinglyImplementedCompilerPass\Source\ServiceInterface:


### PR DESCRIPTION
Fixes #1562 