### PR TITLE
[PackageBuilder] Allow custom vendor path on windows system (#1577)

### DIFF
--- a/packages/PackageBuilder/src/Composer/VendorDirProvider.php
+++ b/packages/PackageBuilder/src/Composer/VendorDirProvider.php
@@ -10,12 +10,14 @@ final class VendorDirProvider
 {
     public static function provide(): string
     {
+		$rootFolder = getenv('SystemDrive', true) . DIRECTORY_SEPARATOR;
+		
         $path = __DIR__;
-        while (! Strings::endsWith($path, 'vendor') && $path !== '/') {
+        while (! Strings::endsWith($path, 'vendor') && $path !== $rootFolder) {
             $path = dirname($path);
         }
 
-        if ($path !== '/') {
+        if ($path !== $rootFolder) {
             return $path;
         }
 


### PR DESCRIPTION
I tried to stay with the same logic to get the composer vendor directory, but other solution is to remove all the code and let the call of the fallback method :
```
    public static function provide(): string
    {
        return self::reflectionFallback();
    }
```

PS : tested on linux & windows