### PR TITLE
[Statie] Canonicalise md suffix for jekyll migrations

### DIFF
--- a/packages/Statie/packages/Migrator/src/Filesystem/MigratorFilesystem.php
+++ b/packages/Statie/packages/Migrator/src/Filesystem/MigratorFilesystem.php
@@ -51,6 +51,22 @@ final class MigratorFilesystem
         return $this->finderSanitizer->sanitize($finder);
     }
 
+    /**
+     * @return SmartFileInfo[]
+     */
+    public function getIncorrectlyNamedMarkdownFiles(string $directory): array
+    {
+        if (! file_exists($directory)) {
+            return [];
+        }
+
+        $finder = $this->createBasicFinder()
+            ->name('#\.(markdown|mkdown|mkdn|mkd)$#')
+            ->in($directory);
+
+        return $this->finderSanitizer->sanitize($finder);
+    }
+
     public function absolutizePath(string $path, string $workingDirectory): string
     {
         if (FileSystem::isAbsolute($path)) {

--- a/packages/Statie/packages/Migrator/src/Worker/MarkdownSuffixCanonicaliser.php
+++ b/packages/Statie/packages/Migrator/src/Worker/MarkdownSuffixCanonicaliser.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\Statie\Migrator\Worker;
+
+use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\Statie\Migrator\Contract\MigratorWorkerInterface;
+use Symplify\Statie\Migrator\Filesystem\MigratorFilesystem;
+
+/**
+ * Canonicalise suffix of markdown files
+ *
+ * Statie requires that markdown files are suffixed with .md, jekyll allows a variety of suffixes. Files using the
+ * suffixes from jekyll that Statie does not, are canonicalised here.
+ */
+final class MarkdownSuffixCanonicaliser implements MigratorWorkerInterface
+{
+    /**
+     * @var SymfonyStyle
+     */
+    private $symfonyStyle;
+
+    /**
+     * @var MigratorFilesystem
+     */
+    private $migratorFilesystem;
+
+    public function __construct(SymfonyStyle $symfonyStyle, MigratorFilesystem $migratorFilesystem)
+    {
+        $this->symfonyStyle = $symfonyStyle;
+        $this->migratorFilesystem = $migratorFilesystem;
+    }
+
+    public function processSourceDirectory(string $sourceDirectory, string $workingDirectory): void
+    {
+        $markdownFileInfos = $this->migratorFilesystem->getIncorrectlyNamedMarkdownFiles($sourceDirectory);
+
+        foreach ($markdownFileInfos as $markdownFileInfo) {
+            $oldPath = $markdownFileInfo->getRealPath();
+
+            $newPath = Strings::replace($oldPath, '#\.(markdown|mkdown|mkdn|mkd)$#', '.md');
+            if ($oldPath === $newPath) {
+                continue;
+            }
+
+            FileSystem::rename($oldPath, $newPath);
+
+            $this->symfonyStyle->note(sprintf('File "%s" suffix renamed to "%s"', $oldPath, $newPath));
+        }
+
+        $this->symfonyStyle->success('Suffixes changed to .md');
+    }
+}

--- a/packages/Statie/packages/MigratorJekyll/src/JekyllToStatieMigrator.php
+++ b/packages/Statie/packages/MigratorJekyll/src/JekyllToStatieMigrator.php
@@ -8,6 +8,7 @@ use Symplify\Statie\Migrator\Filesystem\FilesystemMover;
 use Symplify\Statie\Migrator\Filesystem\FilesystemRegularApplicator;
 use Symplify\Statie\Migrator\Filesystem\FilesystemRemover;
 use Symplify\Statie\Migrator\Worker\IncludePathsCompleter;
+use Symplify\Statie\Migrator\Worker\MarkdownSuffixCanonicaliser;
 use Symplify\Statie\Migrator\Worker\ParametersAdder;
 use Symplify\Statie\Migrator\Worker\PostIdsAdder;
 use Symplify\Statie\Migrator\Worker\StatieImportsAdder;
@@ -40,6 +41,11 @@ final class JekyllToStatieMigrator implements MigratorInterface
      * @var TwigSuffixChanger
      */
     private $twigSuffixChanger;
+
+    /**
+     * @var MarkdownSuffixCanonicaliser
+     */
+    private $markdownSuffixCanonicaliser;
 
     /**
      * @var ParametersAdder
@@ -75,6 +81,7 @@ final class JekyllToStatieMigrator implements MigratorInterface
         IncludePathsCompleter $includePathsCompleter,
         PostIdsAdder $postIdsAdder,
         TwigSuffixChanger $twigSuffixChanger,
+        MarkdownSuffixCanonicaliser $markdownSuffixCanonicaliser,
         ParametersAdder $parametersAdder,
         FilesystemMover $filesystemMover,
         FilesystemRemover $filesystemRemover,
@@ -85,6 +92,7 @@ final class JekyllToStatieMigrator implements MigratorInterface
         $this->includePathsCompleter = $includePathsCompleter;
         $this->postIdsAdder = $postIdsAdder;
         $this->twigSuffixChanger = $twigSuffixChanger;
+        $this->markdownSuffixCanonicaliser = $markdownSuffixCanonicaliser;
         $this->parametersAdder = $parametersAdder;
         $this->filesystemMover = $filesystemMover;
         $this->filesystemRemover = $filesystemRemover;
@@ -115,6 +123,9 @@ final class JekyllToStatieMigrator implements MigratorInterface
 
         // now all website files are in "/source" directory
         $sourceDirectory = $workingDirectory . '/source';
+
+        // change suffixes - markdown/mkdown/mkdn/mkd → md
+        $this->markdownSuffixCanonicaliser->processSourceDirectory($sourceDirectory, $workingDirectory);
 
         // change suffixes - html/md → twig, where there is a "{% X %}" also inside files to be included
         $this->twigSuffixChanger->processSourceDirectory($sourceDirectory, $workingDirectory);


### PR DESCRIPTION
Statie requires markdown files to be suffixed with .md, by default
jekyll has a variety of markdown file suffixes, change them all to .md.

Fixes #1586 