### PR TITLE
[ChangelogLinker] allow releasing in multiple branches

### DIFF
--- a/packages/ChangelogLinker/README.md
+++ b/packages/ChangelogLinker/README.md
@@ -128,6 +128,13 @@ vendor/bin/changelog-linker dump-merges --in-categories --in-packages
 - [#860] Add test case for #855, Thanks to @OndraM
 ```
 
+Do you want to dump only such pull requests that were merged into a particular branch? Just use `base-branch` option:
+
+```
+vendor/bin/changelog-linker dump-merges --base-branch=7.3
+```
+This is very handy when you support multiple versions of your project.
+
 ### Github API Overload?
 
 In case you cross the API rate limit and get denied, create [new Github Token](https://github.com/settings/tokens) and run it via `GITHUB_TOKEN` ENV variable.

--- a/packages/ChangelogLinker/src/Analyzer/IdsAnalyzer.php
+++ b/packages/ChangelogLinker/src/Analyzer/IdsAnalyzer.php
@@ -17,13 +17,20 @@ final class IdsAnalyzer
 
     public function getHighestIdInChangelog(string $content): ?int
     {
+        $ids = $this->getAllIdsInChangelog($content);
+        return (int) max($ids);
+    }
+
+    /**
+     * @param string $content
+     * @return array|null
+     */
+    public function getAllIdsInChangelog(string $content): ?array
+    {
         $matches = Strings::matchAll($content, self::PR_REFERENCE_IN_LIST);
         if (! $matches) {
             return null;
         }
-
-        $ids = array_column($matches, 'id');
-
-        return (int) max($ids);
+        return array_column($matches, 'id');
     }
 }

--- a/packages/ChangelogLinker/src/Configuration/Option.php
+++ b/packages/ChangelogLinker/src/Configuration/Option.php
@@ -33,4 +33,9 @@ final class Option
      * @var string
      */
     public const SINCE_ID = 'since-id';
+
+    /**
+     * @var string
+     */
+    public const BASE_BRANCH = 'base-branch';
 }

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -131,6 +131,13 @@ final class DumpMergesCommand extends Command
             InputOption::VALUE_REQUIRED,
             'Include pull-request with provided ID and higher. The ID is detected in CHANGELOG.md otherwise.'
         );
+
+        $this->addOption(
+            Option::BASE_BRANCH,
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Base branch towards which the pull requests are targeted'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -140,7 +147,10 @@ final class DumpMergesCommand extends Command
         $this->changelogFileSystemGuard->ensurePlaceholderIsPresent($content, self::CHANGELOG_PLACEHOLDER_TO_WRITE);
 
         $sinceId = $this->getSinceIdFromInputAndContent($input, $content) ?: 1;
-        $pullRequests = $this->githubApi->getMergedPullRequestsSinceId($sinceId);
+        $pullRequests = $this->githubApi->getMergedPullRequestsSinceId(
+            $sinceId,
+            $input->getOption(Option::BASE_BRANCH)
+        );
         if (count($pullRequests) === 0) {
             $this->symfonyStyle->note(
                 sprintf('There are no new pull requests to be added since ID "%d".', $sinceId)
@@ -187,6 +197,29 @@ final class DumpMergesCommand extends Command
             return (int) $sinceId;
         }
 
+        $baseBranch = $input->getOption(Option::BASE_BRANCH);
+        if ($baseBranch !== null) {
+            return $this->findHighestIdMergedInBranch($content, $baseBranch);
+        }
+
         return $this->idsAnalyzer->getHighestIdInChangelog($content);
+    }
+
+    /**
+     * @param string $content
+     * @param string $branch
+     * @return int|null
+     */
+    private function findHighestIdMergedInBranch(string $content, string $branch): ?int
+    {
+        $allIdsInChangelog = $this->idsAnalyzer->getAllIdsInChangelog($content);
+        rsort($allIdsInChangelog);
+        foreach ($allIdsInChangelog as $id) {
+            $idInt = (int) $id;
+            if ($this->githubApi->isPullRequestMergedToBaseBranch($idInt, $branch)) {
+                return $idInt;
+            }
+        }
+        return null;
     }
 }

--- a/packages/ChangelogLinker/src/Github/GithubApi.php
+++ b/packages/ChangelogLinker/src/Github/GithubApi.php
@@ -65,9 +65,9 @@ final class GithubApi
     /**
      * @return mixed[]
      */
-    public function getMergedPullRequestsSinceId(int $id): array
+    public function getMergedPullRequestsSinceId(int $id, ?string $baseBranch = null): array
     {
-        $pullRequests = $this->getPullRequestsSinceId($id);
+        $pullRequests = $this->getPullRequestsSinceId($id, $baseBranch);
 
         $mergedPullRequests = $this->filterMergedPullRequests($pullRequests);
 
@@ -86,15 +86,29 @@ final class GithubApi
     }
 
     /**
+     * @param int $pullRequestId
+     * @param string $baseBranch
+     * @return bool
+     */
+    public function isPullRequestMergedToBaseBranch(int $pullRequestId, string $baseBranch): bool
+    {
+        $json = $this->getSinglePullRequestJson($pullRequestId);
+        return $json['base']['ref'] === $baseBranch;
+    }
+
+    /**
      * @return mixed[]
      */
-    private function getPullRequestsSinceId(int $id): array
+    private function getPullRequestsSinceId(int $id, ?string $baseBranch = null): array
     {
         $maxPage = 10; // max. 1000 merge requests to dump
 
         $pullRequests = [];
         for ($i = 1; $i <= $maxPage; ++$i) {
             $url = sprintf(self::URL_CLOSED_PULL_REQUESTS, $this->repositoryName) . '&page=' . $i;
+            if ($baseBranch !== null) {
+                $url .= '&base=' . $baseBranch;
+            }
             $response = $this->getResponseToUrl($url);
 
             // already no more pages → stop
@@ -128,9 +142,7 @@ final class GithubApi
 
     private function getMergedAtByPullRequest(int $id): ?string
     {
-        $url = sprintf(self::URL_PULL_REQUEST_BY_ID, $this->repositoryName, $id);
-        $response = $this->getResponseToUrl($url);
-        $json = $this->responseFormatter->formatToJson($response);
+        $json = $this->getSinglePullRequestJson($id);
 
         return $json['merged_at'] ?? null;
     }
@@ -176,5 +188,16 @@ final class GithubApi
         $message = $reason . PHP_EOL . 'Create a token at https://github.com/settings/tokens/new with only repository scope and use it as ENV variable: "GITHUB_TOKEN=... vendor/bin/changelog-linker ..." option.';
 
         return new GithubApiException($message, $throwable->getCode(), $throwable);
+    }
+
+    /**
+     * @param int $pullRequestId
+     * @return array
+     */
+    private function getSinglePullRequestJson(int $pullRequestId): array
+    {
+        $url = sprintf(self::URL_PULL_REQUEST_BY_ID, $this->repositoryName, $pullRequestId);
+        $response = $this->getResponseToUrl($url);
+        return $this->responseFormatter->formatToJson($response);
     }
 }


### PR DESCRIPTION
These modifications enable you to release versions in multiple branches, for more information, see the following pull requests:
- https://github.com/Symplify/ChangelogLinker/pull/3
- https://github.com/shopsys/shopsys/pull/1244

~https://github.com/Symplify/MonorepoBuilder/pull/4~ - unnecessary in the end, achievable using `stages_to_allow_existing_tag` config option