### PR TITLE
[MonorepoBuilder] Stop requiring the remote URL to end with '.git'

### DIFF
--- a/packages/MonorepoBuilder/packages/Split/src/Configuration/RepositoryGuard.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Configuration/RepositoryGuard.php
@@ -12,7 +12,7 @@ final class RepositoryGuard
     /**
      * @var string
      */
-    private const GIT_REPOSITORY_PATTERN = '#((git|ssh|http(s)?)|(git@[\w\.]+)|[\w]+)(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?#';
+    private const GIT_REPOSITORY_PATTERN = '#((git|ssh|http(s)?)|(git@[\w\.]+)|[\w]+)(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?#';
 
     public function ensureIsRepository(string $possibleRepository): void
     {

--- a/packages/MonorepoBuilder/packages/Split/tests/Configuration/RepositoryGuardTest.php
+++ b/packages/MonorepoBuilder/packages/Split/tests/Configuration/RepositoryGuardTest.php
@@ -37,12 +37,7 @@ final class RepositoryGuardTest extends AbstractKernelTestCase
         yield ['git@github.com:Symplify/Symplify.git'];
         yield ['secretToken@github.com:Symplify/Symplify.git'];
         yield ['https://github.com/Symplify/Symplify.git'];
-    }
-
-    public function testInvalid(): void
-    {
-        $this->expectException(InvalidRepositoryFormatException::class);
-
-        $this->repositoryGuard->ensureIsRepository('http://github.com/Symplify/Symplify');
+        yield ['AUTHTOKEN@ssh.dev.azure.com:v3/username/Symplify/Symplify'];
+        yield ['https://AUTHTOKEN@dev.azure.com/username/Symplify/_git/Symplify'];
     }
 }


### PR DESCRIPTION
Fixes #1594 

Change the remote URL validation regex to not require the URL to end with `.git`.

I had to remove the `RepositoryGuardTest::testInvalid` unit test because there is now no way to differentiate between a GitHub project home and a GitHub repository. If I have enough free time, I might split the RepositoryGuard into several classes, one for each possible host (GitHub and Azure DevOps for now, but it would make it extensible to other hosts).