### PR TITLE
[MonorepoBuilder] Dynamic monorepo-builder version in Init templates

### DIFF
--- a/packages/MonorepoBuilder/packages/Init/templates/monorepo/monorepo-builder.yml
+++ b/packages/MonorepoBuilder/packages/Init/templates/monorepo/monorepo-builder.yml
@@ -3,7 +3,7 @@ parameters:
     data_to_append:
         require-dev:
             phpunit/phpunit: '^7.3'
-            symplify/monorepo-builder: '^4.7'
+            symplify/monorepo-builder: '<version>'
 
     # for "split" command
     directories_to_repositories:

--- a/packages/MonorepoBuilder/src/Composer/ComposerFactory.php
+++ b/packages/MonorepoBuilder/src/Composer/ComposerFactory.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Composer;
+
+use Composer\Composer;
+use Composer\Factory;
+use Composer\IO\NullIO;
+
+final class ComposerFactory
+{
+    public function create(): Composer
+    {
+        return Factory::create(new NullIO(), __DIR__ . '/../../composer.json');
+    }
+}


### PR DESCRIPTION
This PR will allow the `init` command to resolve the current version of MonorepoBuilder and set it in the generated files.