### PR TITLE
[PackageBuilder] Skip parameters following an end of options (--) signal

### DIFF
--- a/packages/PackageBuilder/src/Configuration/ConfigFileFinder.php
+++ b/packages/PackageBuilder/src/Configuration/ConfigFileFinder.php
@@ -66,8 +66,8 @@ final class ConfigFileFinder
     public static function getOptionValue(InputInterface $input, array $optionNames): ?string
     {
         foreach ($optionNames as $optionName) {
-            if ($input->hasParameterOption($optionName)) {
-                return $input->getParameterOption($optionName);
+            if ($input->hasParameterOption($optionName, true)) {
+                return $input->getParameterOption($optionName, null, true);
             }
         }
 

--- a/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
+++ b/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
@@ -16,7 +16,7 @@ final class ConfigFileFinderTest extends TestCase
      */
     public function testDetectFromInputAndProvideWithAbsolutePath(
         array $options,
-        string $expectedConfig,
+        ?string $expectedConfig,
         string $message
     ): void {
         $name = md5(serialize($options));
@@ -31,6 +31,7 @@ final class ConfigFileFinderTest extends TestCase
         yield [['-c' => '.travis.yml'], getcwd() . '/.travis.yml', 'Short option with relative path'];
         yield [['--config' => getcwd() . '/.travis.yml'], getcwd() . '/.travis.yml', 'Full option with relative path'];
         yield [['-c' => getcwd() . '/.travis.yml'], getcwd() . '/.travis.yml', 'Short option with relative path'];
+        yield [['--', 'sh', '-c' => '/bin/true'], null, 'Skip parameters following an end of options (--) signal'];
     }
 
     public function testProvide(): void


### PR DESCRIPTION
For another pull request, I discovered that I would need to be able to pass `-c` as a parameter to a new console command. My first attempts failed because it was always parsed as an option for the monorepo-builder configuration file.
A deeper look revealed that symfony itself has support to stop option parsing for parameters following `--` which was just what I needed.
I thought it may make sense even in the case my other pull request would be denied, so I created a pull request for this change only.

Hope you find it useful, too.