### PR TITLE
[MonorepoBuilder] Add foreach command

### DIFF
--- a/packages/MonorepoBuilder/README.md
+++ b/packages/MonorepoBuilder/README.md
@@ -190,6 +190,17 @@ parameters:
     enable_default_release_workers: false
 ```
 
+### 8. Execute Commands Foreach contained Package
+
+While working with multiple packages in a monorepo you may feel the need to run arbitrary commands for each contained package.
+For example, you may want to run the tests for each package in isolation:
+
+```bash
+vendor/bin/monorepo-builder foreach -- sh -c 'composer install && vendor/bin/phpunit'
+```
+
+**Note:** If the command requires options that may interfere with the options of the `monorepo-builder` command itself, option parsing can be ended by using `--` as shown in the example above.
+
 ## Contributing
 
 Open an [issue](https://github.com/Symplify/Symplify/issues) or send a [pull-request](https://github.com/Symplify/Symplify/pulls) to main repository.

--- a/packages/MonorepoBuilder/src/Console/Command/ForeachCommand.php
+++ b/packages/MonorepoBuilder/src/Console/Command/ForeachCommand.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+use Symplify\PackageBuilder\Console\ShellCode;
+
+final class ForeachCommand extends Command
+{
+    /**
+     * @var ComposerJsonProvider
+     */
+    private $composerJsonProvider;
+
+    public function __construct(ComposerJsonProvider $composerJsonProvider)
+    {
+        parent::__construct();
+
+        $this->composerJsonProvider = $composerJsonProvider;
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(CommandNaming::classToName(self::class));
+        $this->setDescription('Execute a given command for each package');
+        $this->addArgument('cmd', InputArgument::REQUIRED, 'Command to execute for each package');
+        $this->addArgument('args', InputArgument::IS_ARRAY, 'Optional arguments for the given command');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $stdErrOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
+        $command = array_merge([$input->getArgument('cmd')], $input->getArgument('args'));
+        $fileInfos = $this->composerJsonProvider->getPackagesFileInfos();
+
+        foreach ($fileInfos as $fileInfo) {
+            $process = new Process($command, $fileInfo->getPath());
+
+            $process->mustRun(static function ($type, $data) use ($output, $stdErrOutput): void {
+                if ($type === Process::ERR) {
+                    $stdErrOutput->write($data);
+                } else {
+                    $output->write($data);
+                }
+            });
+        }
+
+        return ShellCode::SUCCESS;
+    }
+}

--- a/packages/PackageBuilder/src/Configuration/ConfigFileFinder.php
+++ b/packages/PackageBuilder/src/Configuration/ConfigFileFinder.php
@@ -66,8 +66,8 @@ final class ConfigFileFinder
     public static function getOptionValue(InputInterface $input, array $optionNames): ?string
     {
         foreach ($optionNames as $optionName) {
-            if ($input->hasParameterOption($optionName)) {
-                return $input->getParameterOption($optionName);
+            if ($input->hasParameterOption($optionName, true)) {
+                return $input->getParameterOption($optionName, null, true);
             }
         }
 

--- a/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
+++ b/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
@@ -16,7 +16,7 @@ final class ConfigFileFinderTest extends TestCase
      */
     public function testDetectFromInputAndProvideWithAbsolutePath(
         array $options,
-        string $expectedConfig,
+        ?string $expectedConfig,
         string $message
     ): void {
         $name = md5(serialize($options));
@@ -31,6 +31,7 @@ final class ConfigFileFinderTest extends TestCase
         yield [['-c' => '.travis.yml'], getcwd() . '/.travis.yml', 'Short option with relative path'];
         yield [['--config' => getcwd() . '/.travis.yml'], getcwd() . '/.travis.yml', 'Full option with relative path'];
         yield [['-c' => getcwd() . '/.travis.yml'], getcwd() . '/.travis.yml', 'Short option with relative path'];
+        yield [['--', 'sh', '-c' => '/bin/true'], null, 'Skip parameters following an end of options (--) signal'];
     }
 
     public function testProvide(): void


### PR DESCRIPTION
This pull request introduces a new command `foreach` for the monorepo-builder console command.

The command is quite simple and just iterates over all packages of the monorepo and runs a command for each of the packages with the path of the package set as the current working directory. So, it is (in some way) similar to `git submodule foreach`.

While working with the monorepo-builder for quite some while now, I often felt the need to perform some actions for each package. For example, to test each package on its own, one could issue a command like `monorepo-builder foreach -- sh -c "composer install && vendor/bin/phpunit"` and for cleaning up `monorepo-builder foreach rm -rf composer.lock vendor`.
These are just examples from my personal requirements, I'm sure there may be many more use cases to discover. :wink:

In order to support command arguments like `sh -c ...` or `bash -c ...`, I created a separate pull request https://github.com/Symplify/Symplify/pull/1608 to stop option parsing after `--` parameter was found.

I hope you find it as interesting as I do. :v: 