### PR TITLE
Apply lowercase to compose dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "J7mbo/twitter-api-php": "^1.0",
+        "j7mbo/twitter-api-php": "^1.0",
         "composer/composer": "^1.8",
         "composer/xdebug-handler": "^1.3",
         "erusev/parsedown": "^1.7",


### PR DESCRIPTION
Composer 2.0+ requires a lowercase dependency