### PR TITLE
Fix reading GIT tags in Windows OS

### DIFF
--- a/packages/MonorepoBuilder/packages/Split/src/Git/GitManager.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Git/GitManager.php
@@ -35,8 +35,12 @@ final class GitManager
             $command[] = $gitDirectory;
         }
 
-        $tags = $this->processRunner->run($command);
-        $tagList = explode(PHP_EOL, trim($tags));
+        $tags = trim($this->processRunner->run($command));
+        // Remove all "\r" chars in case the CLI env like the Windows OS.
+        // Otherwise (ConEmu, git bash, mingw cli, e.g.), leave as is.
+        $tags = \str_replace("\r", '', $tags);
+
+        $tagList = explode("\n", $tags);
 
         /** @var string $theMostRecentTag */
         $theMostRecentTag = array_pop($tagList);

--- a/packages/MonorepoBuilder/packages/Split/src/Git/GitManager.php
+++ b/packages/MonorepoBuilder/packages/Split/src/Git/GitManager.php
@@ -35,12 +35,7 @@ final class GitManager
             $command[] = $gitDirectory;
         }
 
-        $tags = trim($this->processRunner->run($command));
-        // Remove all "\r" chars in case the CLI env like the Windows OS.
-        // Otherwise (ConEmu, git bash, mingw cli, e.g.), leave as is.
-        $tags = \str_replace("\r", '', $tags);
-
-        $tagList = explode("\n", $tags);
+        $tagList = $this->parseTags($this->processRunner->run($command));
 
         /** @var string $theMostRecentTag */
         $theMostRecentTag = array_pop($tagList);
@@ -50,6 +45,21 @@ final class GitManager
         }
 
         return $theMostRecentTag;
+    }
+
+    /**
+     * @param string $commandResult
+     * @return array|string[]
+     */
+    private function parseTags(string $commandResult): array
+    {
+        $tags = trim($commandResult);
+
+        // Remove all "\r" chars in case the CLI env like the Windows OS.
+        // Otherwise (ConEmu, git bash, mingw cli, e.g.), leave as is.
+        $tags = \str_replace("\r", '', $tags);
+
+        return explode("\n", $tags);
     }
 
     /**


### PR DESCRIPTION
Fix reading GIT tags in Windows non-Terminal (ConEmu, git bash, mingw cli, e.g.) CLI interfaces.