### PR TITLE
Fix test on windows 

### DIFF
--- a/packages/EasyCodingStandard/tests/Console/Output/JsonOutputFormatterTest.php
+++ b/packages/EasyCodingStandard/tests/Console/Output/JsonOutputFormatterTest.php
@@ -45,9 +45,9 @@ final class JsonOutputFormatterTest extends AbstractKernelTestCase
     {
         $stringInput = [
             'check',
-            __DIR__ . '/wrong/wrong.php.inc',
+            addslashes(__DIR__) . '/wrong/wrong.php.inc',
             '--config',
-            __DIR__ . '/config/config.yml',
+            addslashes(__DIR__) . '/config/config.yml',
             '--' . Option::OUTPUT_FORMAT_OPTION,
             JsonOutputFormatter::NAME,
         ];


### PR DESCRIPTION
I got a lot of weird errors while trying to run the complete-check on windows.

This PR is to fix one of them:
`[Symplify\EasyCodingStandard\Exception\Configuration\SourceNotFoundException]
sernamePhpstormProjectsSymplifypackagesEasyCodingStandard  estsConsoleOutput/wrong/wrong.php.inc" does not exist`

This is due to `__DIR__` being used to create a command. It works well on *nix, but on windows, `__DIR__` uses \ as directory separator, so it interpets it as escape char in the command.

I'm really not sure my fix is good (That's why I create the PR, it will show me the result on Travis). To be discussed.