### PR TITLE
[ECS] Add "sets" parameter for shorter imports of native configs

### DIFF
--- a/ecs.yaml
+++ b/ecs.yaml
@@ -1,10 +1,3 @@
-imports:
-    - { resource: 'packages/EasyCodingStandard/config/set/php71.yaml' }
-    - { resource: 'packages/EasyCodingStandard/config/set/clean-code.yaml' }
-    - { resource: 'packages/EasyCodingStandard/config/set/symplify.yaml' }
-    - { resource: 'packages/EasyCodingStandard/config/set/common.yaml' }
-    - { resource: 'packages/EasyCodingStandard/config/set/psr12.yaml' }
-
 services:
     Symplify\CodingStandard\Sniffs\Architecture\PreferredClassSniff:
         old_to_preferred_classes:
@@ -29,6 +22,13 @@ services:
             - 'FileDecorator'
 
 parameters:
+    sets:
+        - 'php71'
+        - 'clean-code'
+        - 'symplify'
+        - 'common'
+        - 'psr12'
+
     exclude_files:
         # tests
         - 'packages/*/tests/**Source/*.php'

--- a/packages/EasyCodingStandard/README.md
+++ b/packages/EasyCodingStandard/README.md
@@ -12,12 +12,7 @@
     <img src="/docs/logos/space.png">
     <a href="https://github.com/nette/coding-standard"><img src="/docs/logos/nette.png"></a>
     <img src="/docs/logos/space.png">
-    <a href="https://github.com/php-ai/php-ml/"><img src="/docs/logos/phpai.png"></a>
-    <br>
-    <br>
     <a href="https://github.com/shopsys/coding-standards"><img src="/docs/logos/shopsys.png"></a>
-    <img src="/docs/logos/space.png">
-    <a href="https://github.com/sunfoxcz/coding-standard"><img src="/docs/logos/sunfox.jpg"></a>
     <img src="/docs/logos/space.png">
     <a href="https://github.com/SyliusLabs/CodingStandard"><img src="/docs/logos/sylius.png"></a>
 </p>
@@ -27,7 +22,7 @@
 - Use [PHP_CodeSniffer || PHP-CS-Fixer](https://www.tomasvotruba.cz/blog/2017/05/03/combine-power-of-php-code-sniffer-and-php-cs-fixer-in-3-lines/) - anything you like
 - **2nd run under few seconds** with caching
 - [Skipping files](#ignore-what-you-cant-fix) for specific checkers
-- [Prepared checker sets](#use-prepared-checker-sets) - PSR2, Symfony, Common, Symplify and more...
+- [Prepared checker sets](#use-prepared-checker-sets) - PSR12, Symfony, Common, Symplify and more...
 
 Are you already using another tool?
 
@@ -37,18 +32,19 @@ Are you already using another tool?
 ## Install
 
 ```bash
-composer require --dev symplify/easy-coding-standard
+composer require symplify/easy-coding-standard --dev
 ```
 
 ## Usage
 
 ### 1. Create Configuration and Setup Checkers
 
-Create an `easy-coding-standard.yaml` in your root directory and add [Sniffs](https://github.com/squizlabs/PHP_CodeSniffer) or [Fixers](https://github.com/FriendsOfPHP/PHP-CS-Fixer) you'd love to use.
+Create an `ecs.yaml` in your root directory and add [Sniffs](https://github.com/squizlabs/PHP_CodeSniffer) or [Fixers](https://github.com/FriendsOfPHP/PHP-CS-Fixer) you'd love to use.
 
 Let's start with the most common one - `array()` => `[]`:
 
 ```yaml
+# ecs.yaml
 services:
     PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer:
         syntax: short
@@ -77,7 +73,7 @@ There are prepared sets in [`/config/set` directory](config/set) that you can us
 - [clean-code.yaml](config/set/clean-code.yaml)
 - [common.yaml](config/set/common.yaml)
 - [php71.yaml](config/set/php71.yaml)
-- [psr2.yaml](config/set/psr2.yaml)
+- [psr12.yaml](config/set/psr12.yaml)
 - ...
 
 You pick config in CLI with `--config`:
@@ -95,33 +91,35 @@ vendor/bin/ecs check src --level clean-code
 or include more of them in config:
 
 ```yaml
-# easy-coding-standard.yaml
-imports:
-    - { resource: 'vendor/symplify/easy-coding-standard/config/set/clean-code.yaml' }
-    - { resource: 'vendor/symplify/easy-coding-standard/config/set/psr2.yaml' }
+# ecs.yaml
+parameters:
+    sets:
+        - 'clean-code'
+        - 'psr12'
 ```
 
-In case of [custom coding standard and include](https://github.com/lmc-eu/php-coding-standard/pull/6/files#diff-a8b950982764fcffe4b7b3acd261cf91) e.g. `psr2.yaml` form this package, you might want to use `%vendor_dir%` or `%current_working_dir%` for:
+In case of [custom coding standard and include](https://github.com/lmc-eu/php-coding-standard/pull/6/files#diff-a8b950982764fcffe4b7b3acd261cf91), you can use `%vendor_dir%` or `%current_working_dir%` for:
 
 ```yaml
 # lmc-coding-standard.yaml
 imports:
-    - { resource: '%vendor_dir%/symplify/easy-coding-standard/config/set/psr2.yaml' }
+    - { resource: '%vendor_dir%/your-vendor/coding-standard/config/set/your-vendor.yaml' }
     # or
-    - { resource: '%current_working_dir%/vendor/symplify/easy-coding-standard/config/set/psr2.yaml' }
+    - { resource: '%current_working_dir%/vendor/your-vendodr/coding-standard/config/set/your-vendor.yaml' }
 ```
 
 That would load file always from vendor dir, no matter where you are.
 
 ### Exclude Checkers
 
-What if you add `symfony.yaml` set, but don't like `PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer`?
+What if you add `symfony` set, but don't like `PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer`?
 
 ```yaml
-imports:
-    - { resource: 'vendor/symplify/easy-coding-standard/config/set/symfony.yaml' }
-
+# ecs.yaml
 parameters:
+    sets:
+        - 'symfony'
+
     skip:
         PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer: ~
 ```
@@ -193,7 +191,7 @@ Let's say you want to include `*.phpt` files.
 
 - Create a class in `src/Finder/PhpAndPhptFilesProvider.php`
 - Implement `Symplify\EasyCodingStandard\Contract\Finder\CustomSourceProviderInterface`
-- Register it as services to `easy-coding-standard.yaml` like any other Symfony service:
+- Register it as services to `ecs.yaml` like any other Symfony service:
 
     ```yaml
     services:

--- a/packages/EasyCodingStandard/bin/ecs
+++ b/packages/EasyCodingStandard/bin/ecs
@@ -3,7 +3,7 @@
 
 use Composer\XdebugHandler\XdebugHandler;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\DependencyInjection\Container;
+use Symplify\EasyCodingStandard\Bootstrap\ConfigResolver;
 use Symplify\EasyCodingStandard\Console\EasyCodingStandardConsoleApplication;
 use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
 use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
@@ -53,6 +53,11 @@ $configs[] = ConfigFileFinder::provide(
 // remove empty values
 $configs = array_filter($configs);
 
+// resolve: parameters > sets
+$configResolver = new ConfigResolver();
+$parameterSetsConfigs = $configResolver->resolveFromParameterSetsFromConfigFiles($configs);
+$configs = array_merge($configs, $parameterSetsConfigs);
+
 /**
  * @param string[] $configs
  */
@@ -66,7 +71,7 @@ function computeConfigHash(array $configs): string
     return $hash;
 }
 
-$environment = 'prod' . computeConfigHash($configs) . random_int(1, 100000);
+$environment = 'prod' . md5(computeConfigHash($configs) . random_int(1, 100000));
 $easyCodingStandardKernel = new EasyCodingStandardKernel($environment, InputDetector::isDebug());
 if ($configs !== []) {
     $easyCodingStandardKernel->setConfigs($configs);

--- a/packages/EasyCodingStandard/config/set/php71.yaml
+++ b/packages/EasyCodingStandard/config/set/php71.yaml
@@ -1,6 +1,3 @@
-imports:
-    - { resource: 'php70.yaml' }
-
 services:
     # All elements should have visibility
     PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:

--- a/packages/EasyCodingStandard/src/Bootstrap/ConfigResolver.php
+++ b/packages/EasyCodingStandard/src/Bootstrap/ConfigResolver.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Bootstrap;
+
+use Symplify\EasyCodingStandard\Set\Set;
+
+final class ConfigResolver
+{
+    /**
+     * @var SetOptionResolver
+     */
+    private $setOptionResolver;
+
+    /**
+     * @var SetsResolver
+     */
+    private $setsResolver;
+
+    public function __construct()
+    {
+        $this->setOptionResolver = new SetOptionResolver();
+        $this->setsResolver = new SetsResolver();
+    }
+
+    /**
+     * @param string[] $configFiles
+     * @return string[]
+     */
+    public function resolveFromParameterSetsFromConfigFiles(array $configFiles): array
+    {
+        $configs = [];
+
+        $sets = $this->setsResolver->resolveFromConfigFiles($configFiles);
+        return array_merge($configs, $this->resolveFromSets($sets));
+    }
+
+    /**
+     * @param string[] $sets
+     * @return string[]
+     */
+    private function resolveFromSets(array $sets): array
+    {
+        $configs = [];
+        foreach ($sets as $set) {
+            $configs[] = $this->setOptionResolver->detectFromNameAndDirectory($set, Set::SET_DIRECTORY);
+        }
+
+        return $configs;
+    }
+}

--- a/packages/EasyCodingStandard/src/Bootstrap/SetOptionResolver.php
+++ b/packages/EasyCodingStandard/src/Bootstrap/SetOptionResolver.php
@@ -1,0 +1,200 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Bootstrap;
+
+use Nette\Utils\ObjectHelpers;
+use Nette\Utils\Strings;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
+use Symplify\EasyCodingStandard\Exception\Configuration\SetNotFoundException;
+use Symplify\PackageBuilder\Configuration\ConfigFileFinder;
+
+final class SetOptionResolver
+{
+    /**
+     * @var string
+     */
+    private $keyName;
+
+    /**
+     * @var string[]
+     */
+    private $optionNames = [];
+
+    /**
+     * @param string[] $optionNames
+     */
+    public function __construct(array $optionNames = ['--set', '-s'], string $keyName = 'set')
+    {
+        $this->optionNames = $optionNames;
+        $this->keyName = $keyName;
+    }
+
+    public function detectFromInputAndDirectory(InputInterface $input, string $configDirectory): ?string
+    {
+        $setName = ConfigFileFinder::getOptionValue($input, $this->optionNames);
+        if ($setName === null) {
+            return null;
+        }
+
+        return $this->detectFromNameAndDirectory($setName, $configDirectory);
+    }
+
+    public function detectFromNameAndDirectory(string $setName, string $configDirectory): string
+    {
+        $nearestMatches = $this->findNearestMatchingFiles($configDirectory, $setName);
+        if (count($nearestMatches) === 0) {
+            $this->reportSetNotFound($configDirectory, $setName);
+        }
+
+        /** @var SplFileInfo $nearestMatch */
+        $nearestMatch = array_shift($nearestMatches);
+
+        return $nearestMatch->getRealPath();
+    }
+
+    /**
+     * @return SplFileInfo[]
+     */
+    private function findNearestMatchingFiles(string $configDirectory, string $setName): array
+    {
+        $configFiles = Finder::create()
+            ->files()
+            ->in($configDirectory)
+            ->getIterator();
+
+        $nearestMatches = [];
+
+        $setName = Strings::lower($setName);
+
+        // the version must match, so 401 is not compatible with 40
+        $setVersion = $this->matchVersionInTheEnd($setName);
+
+        foreach ($configFiles as $configFile) {
+            // only similar configs, not too far
+            // this allows to match "Symfony.40" to "symfony40" config
+            $fileNameWithoutExtension = pathinfo($configFile->getFilename(), PATHINFO_FILENAME);
+            $distance = levenshtein($fileNameWithoutExtension, $setName);
+            if ($distance > 2) {
+                continue;
+            }
+
+            if ($setVersion) {
+                $fileVersion = $this->matchVersionInTheEnd($fileNameWithoutExtension);
+                if ($setVersion !== $fileVersion) {
+                    // not a version match
+                    continue;
+                }
+            }
+
+            $nearestMatches[$distance] = $configFile;
+        }
+
+        ksort($nearestMatches);
+
+        return $nearestMatches;
+    }
+
+    private function reportSetNotFound(string $configDirectory, string $setName): void
+    {
+        $allSets = $this->findAllSetsInDirectory($configDirectory);
+
+        $suggestedSet = ObjectHelpers::getSuggestion($allSets, $setName);
+
+        [$versionedSets, $unversionedSets] = $this->separateVersionedAndUnversionedSets($allSets);
+
+        /** @var string[] $unversionedSets */
+        /** @var string[][] $versionedSets */
+        $setsListInString = $this->createSetListInString($unversionedSets, $versionedSets);
+
+        $setNotFoundMessage = sprintf(
+            '%s "%s" was not found.%s%s',
+            ucfirst($this->keyName),
+            $setName,
+            PHP_EOL,
+            $suggestedSet ? sprintf('Did you mean "%s"?', $suggestedSet) . PHP_EOL : ''
+        );
+
+        $pickOneOfMessage = sprintf('Pick "--%s" of:%s%s', $this->keyName, PHP_EOL . PHP_EOL, $setsListInString);
+
+        throw new SetNotFoundException($setNotFoundMessage . PHP_EOL . $pickOneOfMessage);
+    }
+
+    private function matchVersionInTheEnd(string $setName): ?string
+    {
+        $match = Strings::match($setName, '#(?<version>[\d\.]+$)#');
+        if (! $match) {
+            return null;
+        }
+
+        $version = $match['version'];
+        return Strings::replace($version, '#\.#');
+    }
+
+    /**
+     * @return string[]
+     */
+    private function findAllSetsInDirectory(string $configDirectory): array
+    {
+        $finder = Finder::create()
+            ->files()
+            ->in($configDirectory);
+
+        $sets = [];
+        foreach ($finder->getIterator() as $fileInfo) {
+            $sets[] = $fileInfo->getBasename('.' . $fileInfo->getExtension());
+        }
+
+        sort($sets);
+
+        return array_unique($sets);
+    }
+
+    /**
+     * @param string[] $allSets
+     * @return string[][]|string[][][]
+     */
+    private function separateVersionedAndUnversionedSets(array $allSets): array
+    {
+        $versionedSets = [];
+        $unversionedSets = [];
+
+        foreach ($allSets as $set) {
+            $hasVersion = (bool) Strings::match($set, '#\d#');
+
+            if (! $hasVersion) {
+                $unversionedSets[] = $set;
+                continue;
+            }
+
+            $match = Strings::match($set, '#^(?<set>[A-Za-z\-]+)#');
+            $setWithoutVersion = $match['set'];
+
+            if ($setWithoutVersion !== $set) {
+                $versionedSets[$setWithoutVersion][] = $set;
+            }
+        }
+
+        return [$versionedSets, $unversionedSets];
+    }
+
+    /**
+     * @param string[] $unversionedSets
+     * @param string[][] $versionedSets
+     */
+    private function createSetListInString(array $unversionedSets, array $versionedSets): string
+    {
+        $setsListInString = '';
+
+        foreach ($unversionedSets as $unversionedSet) {
+            $setsListInString .= ' * ' . $unversionedSet . PHP_EOL;
+        }
+
+        foreach ($versionedSets as $groupName => $configNames) {
+            $setsListInString .= ' * ' . $groupName . ': ' . implode(', ', $configNames) . PHP_EOL;
+        }
+
+        return $setsListInString;
+    }
+}

--- a/packages/EasyCodingStandard/src/Bootstrap/SetsResolver.php
+++ b/packages/EasyCodingStandard/src/Bootstrap/SetsResolver.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Bootstrap;
+
+use Symfony\Component\Yaml\Yaml;
+
+final class SetsResolver
+{
+    /**
+     * @param string[] $configFiles
+     * @return string[]
+     */
+    public function resolveFromConfigFiles(array $configFiles): array
+    {
+        $sets = [];
+        foreach ($configFiles as $configFile) {
+            $configContent = Yaml::parseFile($configFile);
+            $sets += $configContent['parameters']['sets'] ?? [];
+        }
+        return $sets;
+    }
+}

--- a/packages/EasyCodingStandard/src/Exception/Configuration/SetNotFoundException.php
+++ b/packages/EasyCodingStandard/src/Exception/Configuration/SetNotFoundException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Exception\Configuration;
+
+use Exception;
+
+final class SetNotFoundException extends Exception
+{
+}

--- a/packages/EasyCodingStandard/src/Set/Set.php
+++ b/packages/EasyCodingStandard/src/Set/Set.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Set;
+
+final class Set
+{
+    /**
+     * @var string
+     */
+    public const SET_DIRECTORY = __DIR__ . '/../../config/set';
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -139,9 +139,16 @@ parameters:
             path: packages/Statie/packages/Migrator/src/Filesystem/MigratorFilesystem.php
 
         -
-             message: '#Parameter \#1 \$filename of function filesize expects string, string\|false given#'
-             path: packages/SmartFileSystem/src/Finder/FinderSanitizer.php
+            message: '#Parameter \#1 \$filename of function filesize expects string, string\|false given#'
+            path: packages/SmartFileSystem/src/Finder/FinderSanitizer.php
 
         -
-             message: '#Parameter \#1 \$files of method Symplify\\SmartFileSystem\\Finder\\FinderSanitizer\:\:sanitize\(\) expects \(iterable<SplFileInfo\|string\>&Nette\\Utils\\Finder\)\|Symfony\\Component\\Finder\\Finder, iterable<SplFileInfo\|string\> given#'
-             path: packages/EasyCodingStandard/src/Finder/SourceFinder.php
+            message: '#Parameter \#1 \$files of method Symplify\\SmartFileSystem\\Finder\\FinderSanitizer\:\:sanitize\(\) expects \(iterable<SplFileInfo\|string\>&Nette\\Utils\\Finder\)\|Symfony\\Component\\Finder\\Finder, iterable<SplFileInfo\|string\> given#'
+            path: packages/EasyCodingStandard/src/Finder/SourceFinder.php
+
+        -
+            message: '#Parameter \#1 \$unversionedSets of method Symplify\\EasyCodingStandard\\Bootstrap\\SetOptionResolver\:\:createSetListInString\(\) expects array<string\>, array<array<string\>\|string\> given#'
+            path: packages/EasyCodingStandard/src/Bootstrap/SetOptionResolver.php
+        -
+            message: '#Parameter \#2 \$versionedSets of method Symplify\\EasyCodingStandard\\Bootstrap\\SetOptionResolver\:\:createSetListInString\(\) expects array<array<string\>\>, array<array<string\>\|string\> given#'
+            path: packages/EasyCodingStandard/src/Bootstrap/SetOptionResolver.php


### PR DESCRIPTION
Closes #1651

## Before

```yaml
# ecs.yaml
imports:
    - { resource: 'vendor/symplify/easy-coding-standard/config/set/psr12.yaml' }
    - { resource: 'vendor/symplify/easy-coding-standard/config/set/php71.yaml' }
    - { resource: 'vendor/symplify/easy-coding-standard/config/set/common.yaml' }
    - { resource: 'vendor/symplify/easy-coding-standard/config/set/clean-code.yaml' }
```

## Now

```yaml
# ecs.yaml
parameters:
   sets:
       - 'psr12'
       - 'php71'
       - 'common'
       - 'clean-code'
```


Inspiration:  https://github.com/rectorphp/rector/pull/2221