### PR TITLE
Windows test fixing

### DIFF
--- a/packages/ChangelogLinker/src/ChangelogFormatter.php
+++ b/packages/ChangelogLinker/src/ChangelogFormatter.php
@@ -10,7 +10,7 @@ final class ChangelogFormatter
      * @see https://regex101.com/r/JmKFH1/1
      * @var string
      */
-    private const HEADLINE_PATTERN = '#^(?<headline>[\#]{2,} [\w\d.\-/ ]+)$#m';
+    private const HEADLINE_PATTERN = '#(*ANYCRLF)^(?<headline>[\#]{2,} [\w\d.\-/ ]+)$#m';
 
     public function format(string $content): string
     {
@@ -38,9 +38,9 @@ final class ChangelogFormatter
     private function removeSuperfluousSpaces(string $content): string
     {
         // 2 lines from the start
-        $content = Strings::replace($content, '#^(\n){2,}#', PHP_EOL);
+        $content = Strings::replace($content, '#^(\r?\n){2,}#', PHP_EOL);
 
         // 3 lines to 2
-        return Strings::replace($content, '#(\n){3,}#', PHP_EOL . PHP_EOL);
+        return Strings::replace($content, '#(\r?\n){3,}#', PHP_EOL . PHP_EOL);
     }
 }

--- a/packages/ChangelogLinker/src/Git/GitCommitDateTagResolver.php
+++ b/packages/ChangelogLinker/src/Git/GitCommitDateTagResolver.php
@@ -4,6 +4,7 @@ namespace Symplify\ChangelogLinker\Git;
 
 use Nette\Utils\Strings;
 use Symfony\Component\Process\Process;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class GitCommitDateTagResolver
 {
@@ -22,7 +23,7 @@ final class GitCommitDateTagResolver
      */
     public function __construct()
     {
-        $datesWithTags = explode(PHP_EOL, $this->getDatesWithTagsInString());
+        $datesWithTags = explode(EolConfiguration::getEolChar(), $this->getDatesWithTagsInString());
 
         foreach ($datesWithTags as $datesWithTag) {
             $dateMatch = Strings::match($datesWithTag, '#(?<date>\d{4}-\d{2}-\d{2})#');

--- a/packages/PackageBuilder/src/Configuration/EolConfiguration.php
+++ b/packages/PackageBuilder/src/Configuration/EolConfiguration.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\Configuration;
+
+final class EolConfiguration
+{
+    /**
+     * @var string
+     */
+    private static $eolChar = "\n";
+
+    public static function getEolChar(): string{
+        return self::$eolChar;
+    }
+
+    public static function setEolChar(string $eolChar): void{
+        self::$eolChar = $eolChar;
+    }
+}


### PR DESCRIPTION
Adding some fixes in tests related to CRLF.

BTW, I just learned that git has a config that will mess with line feeds depending on your OS:
https://stackoverflow.com/questions/10418975/how-to-change-line-ending-settings

PHPStorm must have set the default to true because I don't remember changing it myself.
However, depending on this config, Git can replace all the LF into CRLF in **text files**. Since I reused the SPLIT_LINE, one of my test in local was broken because Git consider .php files as text, but not .yaml

This means, even if the tests in travis are correct, people may have issues running the tests in local.

I will set my config to false, as the default to ensure I get the same result as travis