### PR TITLE
Windows tests fixing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: php
 # see https://github.com/travis-ci/travis-ci/issues/7422
 git:
     depth: false
+    # To ensure the line feeds aren't modified by git
+    # see https://docs.travis-ci.com/user/customizing-the-build/#git-end-of-line-conversion-control
+    autocrlf: false
 
 php:
     - '7.2'
@@ -153,7 +156,6 @@ jobs:
                 - export PATH=/c/tools/php:$PATH
                 - composer update $COMPOSER_FLAGS
             script:
-                # @todo this is probably broken, needs fixing
                 - vendor/bin/phpunit
 
         -   <<: *STANDARD_WINDOWS_JOB

--- a/packages/Autodiscovery/tests/Yaml/ExplicitToAutodiscoveryConverterTest.php
+++ b/packages/Autodiscovery/tests/Yaml/ExplicitToAutodiscoveryConverterTest.php
@@ -14,7 +14,7 @@ final class ExplicitToAutodiscoveryConverterTest extends AbstractKernelTestCase
     /**
      * @var string
      */
-    private const SPLIT_LINE = '#-----' . PHP_EOL . '#';
+    private const SPLIT_LINE = "#-----\n#";
 
     /**
      * @var ExplicitToAutodiscoveryConverter

--- a/packages/ChangelogLinker/src/ChangelogDumper.php
+++ b/packages/ChangelogLinker/src/ChangelogDumper.php
@@ -5,6 +5,7 @@ namespace Symplify\ChangelogLinker;
 use Symplify\ChangelogLinker\ChangeTree\Change;
 use Symplify\ChangelogLinker\ChangeTree\ChangeSorter;
 use Symplify\ChangelogLinker\Git\GitCommitDateTagResolver;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class ChangelogDumper
 {
@@ -55,16 +56,17 @@ final class ChangelogDumper
         bool $withPackages,
         ?string $priority
     ): string {
-        $this->content .= PHP_EOL;
+        $eolChar = EolConfiguration::getEolChar();
+        $this->content .= $eolChar;
 
         foreach ($changes as $change) {
             $this->displayHeadlines($withCategories, $withPackages, $priority, $change);
 
             $message = $withPackages ? $change->getMessageWithoutPackage() : $change->getMessage();
-            $this->content .= $message . PHP_EOL;
+            $this->content .= $message . $eolChar;
         }
 
-        $this->content .= PHP_EOL;
+        $this->content .= $eolChar;
 
         return $this->changelogFormatter->format($this->content);
     }
@@ -92,7 +94,8 @@ final class ChangelogDumper
             return;
         }
 
-        $this->content .= '## ' . $this->createTagLine($change) . PHP_EOL;
+        $eolChar = EolConfiguration::getEolChar();
+        $this->content .= '## ' . $this->createTagLine($change) . $eolChar;
         $this->previousTag = $change->getTag();
     }
 
@@ -102,8 +105,9 @@ final class ChangelogDumper
             return;
         }
 
+        $eolChar = EolConfiguration::getEolChar();
         $headlineLevel = $priority === ChangeSorter::PRIORITY_CATEGORIES ? 4 : 3;
-        $this->content .= str_repeat('#', $headlineLevel) . ' ' . $change->getPackage() . PHP_EOL;
+        $this->content .= str_repeat('#', $headlineLevel) . ' ' . $change->getPackage() . $eolChar;
         $this->previousPackage = $change->getPackage();
     }
 
@@ -113,8 +117,9 @@ final class ChangelogDumper
             return;
         }
 
+        $eolChar = EolConfiguration::getEolChar();
         $headlineLevel = $priority === ChangeSorter::PRIORITY_PACKAGES ? 4 : 3;
-        $this->content .= str_repeat('#', $headlineLevel) . ' ' . $change->getCategory() . PHP_EOL;
+        $this->content .= str_repeat('#', $headlineLevel) . ' ' . $change->getCategory() . $eolChar;
         $this->previousCategory = $change->getCategory();
     }
 

--- a/packages/ChangelogLinker/src/ChangelogFormatter.php
+++ b/packages/ChangelogLinker/src/ChangelogFormatter.php
@@ -3,6 +3,7 @@
 namespace Symplify\ChangelogLinker;
 
 use Nette\Utils\Strings;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class ChangelogFormatter
 {
@@ -31,16 +32,19 @@ final class ChangelogFormatter
     private function wrapHeadlinesWithEmptyLines(string $content): string
     {
         return Strings::replace($content, self::HEADLINE_PATTERN, function (array $match): string {
-            return PHP_EOL . $match['headline'] . PHP_EOL;
+            $eolChar = EolConfiguration::getEolChar();
+            return $eolChar . $match['headline'] . $eolChar;
         });
     }
 
     private function removeSuperfluousSpaces(string $content): string
     {
+        $eolChar = EolConfiguration::getEolChar();
+
         // 2 lines from the start
-        $content = Strings::replace($content, '#^(\n){2,}#', PHP_EOL);
+        $content = Strings::replace($content, '#^(\n){2,}#', $eolChar);
 
         // 3 lines to 2
-        return Strings::replace($content, '#(\n){3,}#', PHP_EOL . PHP_EOL);
+        return Strings::replace($content, '#(\n){3,}#', $eolChar . $eolChar);
     }
 }

--- a/packages/ChangelogLinker/src/ChangelogLinker.php
+++ b/packages/ChangelogLinker/src/ChangelogLinker.php
@@ -5,6 +5,7 @@ namespace Symplify\ChangelogLinker;
 use Symplify\ChangelogLinker\Analyzer\LinksAnalyzer;
 use Symplify\ChangelogLinker\Analyzer\VersionsAnalyzer;
 use Symplify\ChangelogLinker\Contract\Worker\WorkerInterface;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class ChangelogLinker
 {
@@ -77,10 +78,11 @@ final class ChangelogLinker
 
     private function appendLinksToContentIfAny(string $content): string
     {
+        $eolChar = EolConfiguration::getEolChar();
         if ($this->linkAppender->getLinksToAppend() !== []) {
-            $content = rtrim($content) . PHP_EOL;
-            $content .= $this->linkAppender->hadExistingLinks() ? '' : PHP_EOL;
-            $content .= implode(PHP_EOL, $this->linkAppender->getLinksToAppend()) . PHP_EOL;
+            $content = rtrim($content) . $eolChar;
+            $content .= $this->linkAppender->hadExistingLinks() ? '' : $eolChar;
+            $content .= implode($eolChar, $this->linkAppender->getLinksToAppend()) . $eolChar;
         }
 
         return $content;

--- a/packages/ChangelogLinker/src/Git/GitCommitDateTagResolver.php
+++ b/packages/ChangelogLinker/src/Git/GitCommitDateTagResolver.php
@@ -4,6 +4,7 @@ namespace Symplify\ChangelogLinker\Git;
 
 use Nette\Utils\Strings;
 use Symfony\Component\Process\Process;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class GitCommitDateTagResolver
 {
@@ -22,7 +23,7 @@ final class GitCommitDateTagResolver
      */
     public function __construct()
     {
-        $datesWithTags = explode(PHP_EOL, $this->getDatesWithTagsInString());
+        $datesWithTags = explode(EolConfiguration::getEolChar(), $this->getDatesWithTagsInString());
 
         foreach ($datesWithTags as $datesWithTag) {
             $dateMatch = Strings::match($datesWithTag, '#(?<date>\d{4}-\d{2}-\d{2})#');

--- a/packages/CodingStandard/packages/TokenRunner/src/DocBlock/DocBlockManipulator.php
+++ b/packages/CodingStandard/packages/TokenRunner/src/DocBlock/DocBlockManipulator.php
@@ -11,6 +11,7 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Symplify\CodingStandard\TokenRunner\Analyzer\FixerAnalyzer\DocBlockFinder;
 use Symplify\CodingStandard\TokenRunner\DocBlockParser;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class DocBlockManipulator
 {
@@ -66,7 +67,7 @@ final class DocBlockManipulator
 
         $docBlockContent = $tokens[$docBlockPosition]->getContent();
 
-        if (substr_count($docBlockContent, PHP_EOL) > 1) {
+        if (substr_count($docBlockContent, EolConfiguration::getEolChar()) > 1) {
             return null;
         }
 

--- a/packages/CodingStandard/packages/TokenRunner/src/DocBlock/MalformWorker/InlineVariableDocBlockMalformWorker.php
+++ b/packages/CodingStandard/packages/TokenRunner/src/DocBlock/MalformWorker/InlineVariableDocBlockMalformWorker.php
@@ -4,6 +4,7 @@ namespace Symplify\CodingStandard\TokenRunner\DocBlock\MalformWorker;
 
 use Nette\Utils\Strings;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class InlineVariableDocBlockMalformWorker extends AbstractMalformWorker
 {
@@ -19,7 +20,7 @@ final class InlineVariableDocBlockMalformWorker extends AbstractMalformWorker
         }
 
         // more than 2 newlines - keep it
-        if (substr_count($docContent, PHP_EOL) > 2) {
+        if (substr_count($docContent, EolConfiguration::getEolChar()) > 2) {
             return $docContent;
         }
 

--- a/packages/CodingStandard/packages/TokenRunner/src/DocBlock/MalformWorker/MissingParamNameMalformWorker.php
+++ b/packages/CodingStandard/packages/TokenRunner/src/DocBlock/MalformWorker/MissingParamNameMalformWorker.php
@@ -6,6 +6,7 @@ use Nette\Utils\Strings;
 use PhpCsFixer\DocBlock\DocBlock;
 use PhpCsFixer\DocBlock\Line;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class MissingParamNameMalformWorker extends AbstractMalformWorker
 {
@@ -110,7 +111,7 @@ final class MissingParamNameMalformWorker extends AbstractMalformWorker
             return Strings::replace($line->getContent(), $missingDollarSignPattern, '$1$$3');
         }
 
-        $replacement = '@param $1 ' . $newArgumentName . '$2' . PHP_EOL;
+        $replacement = '@param $1 ' . $newArgumentName . '$2' . EolConfiguration::getEolChar();
 
         return Strings::replace($line->getContent(), self::PARAM_WITHOUT_NAME_PATTERN, $replacement);
     }

--- a/packages/CodingStandard/packages/TokenRunner/src/Transformer/FixerTransformer/LineLengthTransformer.php
+++ b/packages/CodingStandard/packages/TokenRunner/src/Transformer/FixerTransformer/LineLengthTransformer.php
@@ -10,6 +10,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
 use Symplify\CodingStandard\TokenRunner\Analyzer\FixerAnalyzer\BlockInfo;
 use Symplify\CodingStandard\TokenRunner\Analyzer\FixerAnalyzer\IndentDetector;
 use Symplify\CodingStandard\TokenRunner\Analyzer\FixerAnalyzer\TokenSkipper;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class LineLengthTransformer
 {
@@ -122,8 +123,8 @@ final class LineLengthTransformer
         // includes indent in the beginning
         $lineLength += strlen($currentToken->getContent());
 
-        // minus end of lines, do not count PHP_EOL as characters
-        $endOfLineCount = substr_count($currentToken->getContent(), PHP_EOL);
+        // minus end of lines, do not count line feeds as characters
+        $endOfLineCount = substr_count($currentToken->getContent(), EolConfiguration::getEolChar());
         $lineLength -= $endOfLineCount;
 
         // compute from here to end of line
@@ -179,7 +180,7 @@ final class LineLengthTransformer
 
     private function inlineItems(BlockInfo $blockInfo, Tokens $tokens): void
     {
-        // replace PHP_EOL with " "
+        // replace line feeds with " "
         for ($i = $blockInfo->getStart() + 1; $i < $blockInfo->getEnd(); ++$i) {
             $currentToken = $tokens[$i];
             $i = $this->tokenSkipper->skipBlocks($tokens, $i);
@@ -285,7 +286,7 @@ final class LineLengthTransformer
 
     private function isEndOFArgumentsLine(Tokens $tokens, int $position): bool
     {
-        if (Strings::startsWith($tokens[$position]->getContent(), PHP_EOL)) {
+        if (Strings::startsWith($tokens[$position]->getContent(), EolConfiguration::getEolChar())) {
             return true;
         }
 
@@ -294,7 +295,7 @@ final class LineLengthTransformer
 
     private function isNewLineOrOpenTag(Tokens $tokens, int $position): bool
     {
-        if (Strings::startsWith($tokens[$position]->getContent(), PHP_EOL)) {
+        if (Strings::startsWith($tokens[$position]->getContent(), EolConfiguration::getEolChar())) {
             return true;
         }
 
@@ -330,7 +331,7 @@ final class LineLengthTransformer
         $length = 0;
 
         $currentPosition = $blockInfo->getEnd();
-        while (! Strings::startsWith($tokens[$currentPosition]->getContent(), PHP_EOL)) {
+        while (! Strings::startsWith($tokens[$currentPosition]->getContent(), EolConfiguration::getEolChar())) {
             $currentToken = $tokens[$currentPosition];
 
             $length += strlen($currentToken->getContent());

--- a/packages/CodingStandard/packages/TokenRunner/src/Wrapper/FixerWrapper/ArrayWrapper.php
+++ b/packages/CodingStandard/packages/TokenRunner/src/Wrapper/FixerWrapper/ArrayWrapper.php
@@ -6,6 +6,7 @@ use Nette\Utils\Strings;
 use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
 use Symplify\CodingStandard\TokenRunner\Analyzer\FixerAnalyzer\TokenSkipper;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class ArrayWrapper
 {
@@ -99,7 +100,7 @@ final class ArrayWrapper
 
         // compute from here to start of line
         $currentPosition = $this->startIndex;
-        while (! Strings::startsWith($this->tokens[$currentPosition]->getContent(), PHP_EOL)) {
+        while (! Strings::startsWith($this->tokens[$currentPosition]->getContent(), EolConfiguration::getEolChar())) {
             $lineLength += strlen($this->tokens[$currentPosition]->getContent());
             --$currentPosition;
         }
@@ -110,12 +111,12 @@ final class ArrayWrapper
         $lineLength += strlen($currentToken->getContent());
 
         // minus end of lines, do not count PHP_EOL as characters
-        $endOfLineCount = substr_count($currentToken->getContent(), PHP_EOL);
+        $endOfLineCount = substr_count($currentToken->getContent(), EolConfiguration::getEolChar());
         $lineLength -= $endOfLineCount;
 
         // compute from here to end of line
         $currentPosition = $this->startIndex + 1;
-        while (! Strings::startsWith($this->tokens[$currentPosition]->getContent(), PHP_EOL)) {
+        while (! Strings::startsWith($this->tokens[$currentPosition]->getContent(), EolConfiguration::getEolChar())) {
             $lineLength += strlen($this->tokens[$currentPosition]->getContent());
             ++$currentPosition;
         }

--- a/packages/CodingStandard/packages/TokenRunner/tests/Analyzer/SniffAnalyzer/CognitiveComplexityAnalyzer/CognitiveComplexityAnalyzerTest.php
+++ b/packages/CodingStandard/packages/TokenRunner/tests/Analyzer/SniffAnalyzer/CognitiveComplexityAnalyzer/CognitiveComplexityAnalyzerTest.php
@@ -9,6 +9,7 @@ use PHP_CodeSniffer\Tokenizers\PHP;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Symplify\CodingStandard\TokenRunner\Analyzer\SnifferAnalyzer\CognitiveComplexityAnalyzer;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class CognitiveComplexityAnalyzerTest extends TestCase
 {
@@ -65,7 +66,7 @@ final class CognitiveComplexityAnalyzerTest extends TestCase
      */
     private function fileToTokens(string $fileContent): array
     {
-        return (new PHP($fileContent, $this->getLegacyConfig(), PHP_EOL))->getTokens();
+        return (new PHP($fileContent, $this->getLegacyConfig(), EolConfiguration::getEolChar()))->getTokens();
     }
 
     /**

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveEmptyDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveEmptyDocBlockFixer.php
@@ -10,6 +10,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 /**
  * Inspired by https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.8/src/Fixer/Phpdoc/NoEmptyPhpdocFixer.php
@@ -21,7 +22,7 @@ final class RemoveEmptyDocBlockFixer extends AbstractSymplifyFixer
     {
         return new FixerDefinition(
             'There should not be empty PHPDoc blocks.',
-            [new CodeSample('<?php 
+            [new CodeSample('<?php
 
 /**  */
 ')]
@@ -49,7 +50,7 @@ final class RemoveEmptyDocBlockFixer extends AbstractSymplifyFixer
 
             $previousWhitespaceContent = $previousToken->getContent();
 
-            $lastLineBreak = strrpos($previousWhitespaceContent, PHP_EOL);
+            $lastLineBreak = strrpos($previousWhitespaceContent, EolConfiguration::getEolChar());
             // nothing found
             if (is_bool($lastLineBreak)) {
                 continue;

--- a/packages/CodingStandard/src/Fixer/Commenting/RemoveEmptyDocBlockFixer.php
+++ b/packages/CodingStandard/src/Fixer/Commenting/RemoveEmptyDocBlockFixer.php
@@ -22,7 +22,7 @@ final class RemoveEmptyDocBlockFixer extends AbstractSymplifyFixer
     {
         return new FixerDefinition(
             'There should not be empty PHPDoc blocks.',
-            [new CodeSample('<?php
+            [new CodeSample('<?php 
 
 /**  */
 ')]

--- a/packages/EasyCodingStandard/config/config.yaml
+++ b/packages/EasyCodingStandard/config/config.yaml
@@ -9,7 +9,7 @@ imports:
 parameters:
     # defaults for "PhpCsFixer\WhitespacesFixerConfig"
     indentation: 'spaces'
-    line_ending: \n
+    line_ending: !php/const PHP_EOL
 
     cache_directory: '%sys_get_temp_dir%/_changed_files_detector%env(TEST_SUFFIX)%'
     cache_namespace: '%getcwd_webalized%'

--- a/packages/EasyCodingStandard/config/config.yaml
+++ b/packages/EasyCodingStandard/config/config.yaml
@@ -9,7 +9,7 @@ imports:
 parameters:
     # defaults for "PhpCsFixer\WhitespacesFixerConfig"
     indentation: 'spaces'
-    line_ending: !php/const PHP_EOL
+    line_ending: \n
 
     cache_directory: '%sys_get_temp_dir%/_changed_files_detector%env(TEST_SUFFIX)%'
     cache_namespace: '%getcwd_webalized%'

--- a/packages/EasyCodingStandard/tests/Indentation/IndentationTest.php
+++ b/packages/EasyCodingStandard/tests/Indentation/IndentationTest.php
@@ -8,6 +8,7 @@ use PhpCsFixer\WhitespacesFixerConfig;
 use Psr\Container\ContainerInterface;
 use Symplify\EasyCodingStandard\FixerRunner\Application\FixerFileProcessor;
 use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
 
@@ -33,7 +34,7 @@ final class IndentationTest extends AbstractKernelTestCase
         $indentationTypeFixer = $this->getIndentationTypeFixerFromContainer(self::$container);
 
         $this->assertInstanceOf(WhitespacesAwareFixerInterface::class, $indentationTypeFixer);
-        $spacesConfig = new WhitespacesFixerConfig('    ', PHP_EOL);
+        $spacesConfig = new WhitespacesFixerConfig('    ', EolConfiguration::getEolChar());
 
         $fixerWhitespaceConfig = $this->privatesAccessor->getPrivateProperty(
             $indentationTypeFixer,
@@ -52,7 +53,7 @@ final class IndentationTest extends AbstractKernelTestCase
         $indentationTypeFixer = $this->getIndentationTypeFixerFromContainer(self::$container);
 
         $this->assertInstanceOf(WhitespacesAwareFixerInterface::class, $indentationTypeFixer);
-        $tabsConfig = new WhitespacesFixerConfig('	', PHP_EOL);
+        $tabsConfig = new WhitespacesFixerConfig('	', EolConfiguration::getEolChar());
 
         $fixerWhitespaceConfig = $this->privatesAccessor->getPrivateProperty(
             $indentationTypeFixer,

--- a/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/EasyCodingStandardTester/src/Testing/AbstractCheckerTestCase.php
@@ -22,7 +22,7 @@ abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
     /**
      * @var string
      */
-    public const SPLIT_LINE = '#-----' . PHP_EOL . '#';
+    public const SPLIT_LINE = "#-----\n#";
 
     /**
      * To invalidate new versions

--- a/packages/LatteToTwigConverter/src/CaseConverter/NMacrosCaseConverter.php
+++ b/packages/LatteToTwigConverter/src/CaseConverter/NMacrosCaseConverter.php
@@ -4,6 +4,7 @@ namespace Symplify\LatteToTwigConverter\CaseConverter;
 
 use Nette\Utils\Strings;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 /**
  * This needs to be run first, since it only move n:sytax to {syntax}...{/syntax} - all in Latte
@@ -25,15 +26,16 @@ final class NMacrosCaseConverter implements CaseConverterInterface
             $content,
             $this->createPattern('if'),
             function (array $match): string {
+                $eolChar = EolConfiguration::getEolChar();
                 return sprintf(
                     '{if %s}%s%s%s%s%s%s{/if}',
                     $match['expression'],
-                    PHP_EOL,
+                    $eolChar,
                     $match['openTagStart'],
                     $match['openTagEnd'],
                     $match['inner'],
                     $match['closeTag'],
-                    PHP_EOL
+                    $eolChar
                 );
             }
         );
@@ -43,15 +45,16 @@ final class NMacrosCaseConverter implements CaseConverterInterface
             $content,
             $this->createPattern('ifset'),
             function (array $match): string {
+                $eolChar = EolConfiguration::getEolChar();
                 return sprintf(
                     '{ifset %s}%s%s%s%s%s%s{/ifset}',
                     $match['expression'],
-                    PHP_EOL,
+                    $eolChar,
                     $match['openTagStart'],
                     $match['openTagEnd'],
                     $match['inner'],
                     $match['closeTag'],
-                    PHP_EOL
+                    $eolChar
                 );
             }
         );
@@ -61,15 +64,16 @@ final class NMacrosCaseConverter implements CaseConverterInterface
             $content,
             $this->createPattern('foreach'),
             function (array $match): string {
+                $eolChar = EolConfiguration::getEolChar();
                 return sprintf(
                     '{foreach %s}%s%s%s%s%s%s{/foreach}',
                     $match['expression'],
-                    PHP_EOL,
+                    $eolChar,
                     $match['openTagStart'],
                     $match['openTagEnd'],
                     $match['inner'],
                     $match['closeTag'],
-                    PHP_EOL
+                    $eolChar
                 );
             }
         );
@@ -79,14 +83,15 @@ final class NMacrosCaseConverter implements CaseConverterInterface
             $content,
             $this->createPattern('inner-foreach'),
             function (array $match): string {
+                $eolChar = EolConfiguration::getEolChar();
                 return sprintf(
                     '%s%s%s{foreach %s}%s{/foreach}%s%s',
                     $match['openTagStart'],
                     $match['openTagEnd'],
-                    PHP_EOL,
+                    $eolChar,
                     $match['expression'],
                     $match['inner'],
-                    PHP_EOL,
+                    $eolChar,
                     $match['closeTag']
                 );
             }

--- a/packages/MonorepoBuilder/src/FileSystem/JsonFileManager.php
+++ b/packages/MonorepoBuilder/src/FileSystem/JsonFileManager.php
@@ -6,6 +6,7 @@ use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 use Nette\Utils\Strings;
 use Symfony\Component\Filesystem\Filesystem as SymfonyFilesystem;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class JsonFileManager
@@ -69,7 +70,7 @@ final class JsonFileManager
      */
     public function encodeJsonToFileContent(array $json, array $inlineSections = []): string
     {
-        $jsonContent = Json::encode($json, Json::PRETTY) . PHP_EOL;
+        $jsonContent = Json::encode($json, Json::PRETTY) . EolConfiguration::getEolChar();
 
         foreach ($inlineSections as $inlineSection) {
             $pattern = '#("' . preg_quote($inlineSection, '#') . '": )\[(.*?)\](,)#ms';

--- a/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
+++ b/packages/MonorepoBuilder/tests/VersionValidator/VersionValidatorTest.php
@@ -43,8 +43,8 @@ final class VersionValidatorTest extends AbstractKernelTestCase
         $this->assertArrayHasKey('some/package', $conflictingPackageVersionsPerFile);
 
         $expectedConflictingPackageVersionsPerFile = [
-            __DIR__ . '/Source/first.json' => '^1.0',
-            __DIR__ . '/Source/second.json' => '^2.0',
+            __DIR__ . DIRECTORY_SEPARATOR . 'Source' . DIRECTORY_SEPARATOR . 'first.json' => '^1.0',
+            __DIR__ . DIRECTORY_SEPARATOR . 'Source' . DIRECTORY_SEPARATOR . 'second.json' => '^2.0',
         ];
 
         $this->assertSame(

--- a/packages/NeonToYamlConverter/src/Formatter/YamlOutputFormatter.php
+++ b/packages/NeonToYamlConverter/src/Formatter/YamlOutputFormatter.php
@@ -3,20 +3,23 @@
 namespace Symplify\NeonToYamlConverter\Formatter;
 
 use Nette\Utils\Strings;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 
 final class YamlOutputFormatter
 {
     public function format(string $content): string
     {
+        $eolChar = EolConfiguration::getEolChar();
+
         // new lines between main parts
-        $content = Strings::replace($content, '#^(\w)#ms', PHP_EOL . '$1');
+        $content = Strings::replace($content, '#^(\w)#ms', $eolChar . '$1');
 
         // factory inline
-        $content = Strings::replace($content, '#factory:\s+- (.*?)\n\s+- (.*?)\n#ms', 'factory: [$1, $2]' . PHP_EOL);
+        $content = Strings::replace($content, '#factory:\s+- (.*?)\n\s+- (.*?)\n#ms', 'factory: [$1, $2]' . $eolChar);
 
         // calls inline fixup
         $content = Strings::replace($content, '#(calls|imports):\s\|#', '$1:');
 
-        return trim($content) . PHP_EOL;
+        return trim($content) . $eolChar;
     }
 }

--- a/packages/NeonToYamlConverter/src/NeonToYamlConverter.php
+++ b/packages/NeonToYamlConverter/src/NeonToYamlConverter.php
@@ -9,6 +9,7 @@ use Symfony\Component\Yaml\Yaml;
 use Symplify\NeonToYamlConverter\ConverterWorker\ParameterConverterWorker;
 use Symplify\NeonToYamlConverter\ConverterWorker\ServiceConverterWorker;
 use Symplify\NeonToYamlConverter\Formatter\YamlOutputFormatter;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
@@ -154,9 +155,10 @@ final class NeonToYamlConverter
 
     private function replaceTilda(string $content): string
     {
-        $content = Strings::replace($content, "#: '~'\n#", ': ~' . PHP_EOL);
+        $eolChar = EolConfiguration::getEolChar();
+        $content = Strings::replace($content, "#: '~'\n#", ': ~' . $eolChar);
 
-        return Strings::replace($content, "#: null\n#", ': ~' . PHP_EOL);
+        return Strings::replace($content, "#: null\n#", ': ~' . $eolChar);
     }
 
     private function replaceOldToNewParameters(string $content): string

--- a/packages/PackageBuilder/src/Configuration/EolConfiguration.php
+++ b/packages/PackageBuilder/src/Configuration/EolConfiguration.php
@@ -9,11 +9,13 @@ final class EolConfiguration
      */
     private static $eolChar = "\n";
 
-    public static function getEolChar(): string{
+    public static function getEolChar(): string
+    {
         return self::$eolChar;
     }
 
-    public static function setEolChar(string $eolChar): void{
+    public static function setEolChar(string $eolChar): void
+    {
         self::$eolChar = $eolChar;
     }
 }

--- a/packages/PackageBuilder/src/Configuration/EolConfiguration.php
+++ b/packages/PackageBuilder/src/Configuration/EolConfiguration.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\Configuration;
+
+final class EolConfiguration
+{
+    /**
+     * @var string
+     */
+    private static $eolChar = "\n";
+
+    public static function getEolChar(): string{
+        return self::$eolChar;
+    }
+
+    public static function setEolChar(string $eolChar): void{
+        self::$eolChar = $eolChar;
+    }
+}

--- a/packages/PackageBuilder/src/Parameter/ParameterTypoProofreader.php
+++ b/packages/PackageBuilder/src/Parameter/ParameterTypoProofreader.php
@@ -7,6 +7,7 @@ use Nette\Utils\Strings;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 use Symplify\PackageBuilder\Exception\Parameter\ParameterTypoException;
 
 final class ParameterTypoProofreader
@@ -90,7 +91,7 @@ final class ParameterTypoProofreader
         throw new ParameterTypoException(sprintf(
             'Parameter "parameters > %s" does not exist.%sUse "parameters > %s" instead.',
             $providedParameterName,
-            PHP_EOL,
+            EolConfiguration::getEolChar(),
             $correctParameterName
         ));
     }

--- a/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
+++ b/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
@@ -47,7 +47,7 @@ final class ConfigFileFinderTest extends TestCase
     {
         $this->expectException(FileNotFoundException::class);
         $this->expectExceptionMessage(
-            sprintf('File "%s" not found in "%s"', getcwd() . '/someFile.yml', 'someFile.yml')
+            sprintf('File "%s" not found in "%s"', getcwd() . DIRECTORY_SEPARATOR . 'someFile.yml', 'someFile.yml')
         );
 
         ConfigFileFinder::detectFromInput('name', new ArrayInput(['--config' => 'someFile.yml']));

--- a/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
+++ b/packages/PackageBuilder/tests/Configuration/ConfigFileFinderTest.php
@@ -27,20 +27,20 @@ final class ConfigFileFinderTest extends TestCase
 
     public function provideOptionsAndExpectedConfig(): Iterator
     {
-        yield [['--config' => '.travis.yml'], getcwd() . '/.travis.yml', 'Full option with relative path'];
-        yield [['-c' => '.travis.yml'], getcwd() . '/.travis.yml', 'Short option with relative path'];
-        yield [['--config' => getcwd() . '/.travis.yml'], getcwd() . '/.travis.yml', 'Full option with relative path'];
-        yield [['-c' => getcwd() . '/.travis.yml'], getcwd() . '/.travis.yml', 'Short option with relative path'];
+        yield [['--config' => '.travis.yml'], getcwd() . DIRECTORY_SEPARATOR . '.travis.yml', 'Full option with relative path'];
+        yield [['-c' => '.travis.yml'], getcwd() . DIRECTORY_SEPARATOR . '.travis.yml', 'Short option with relative path'];
+        yield [['--config' => getcwd() . DIRECTORY_SEPARATOR . '.travis.yml'], getcwd() . DIRECTORY_SEPARATOR . '.travis.yml', 'Full option with relative path'];
+        yield [['-c' => getcwd() . DIRECTORY_SEPARATOR . '.travis.yml'], getcwd() . DIRECTORY_SEPARATOR . '.travis.yml', 'Short option with relative path'];
         yield [['--', 'sh', '-c' => '/bin/true'], null, 'Skip parameters following an end of options (--) signal'];
     }
 
     public function testProvide(): void
     {
         $config = ConfigFileFinder::provide('some-value', ['.travis.yml']);
-        $this->assertSame(getcwd() . '/.travis.yml', $config);
+        $this->assertSame(getcwd() . DIRECTORY_SEPARATOR . '.travis.yml', $config);
 
         $config = ConfigFileFinder::provide('some-value', ['.travis.yaml', '.travis.yml']);
-        $this->assertSame(getcwd() . '/.travis.yml', $config);
+        $this->assertSame(getcwd() . DIRECTORY_SEPARATOR . '.travis.yml', $config);
     }
 
     public function testMissingFileInInput(): void

--- a/packages/PackageBuilder/tests/Configuration/LevelFileFinderTest.php
+++ b/packages/PackageBuilder/tests/Configuration/LevelFileFinderTest.php
@@ -12,7 +12,7 @@ final class LevelFileFinderTest extends TestCase
     /**
      * @var string
      */
-    private $sourceDirectory = __DIR__ . '/LevelFileFinderSource/nested';
+    private $sourceDirectory = __DIR__ . DIRECTORY_SEPARATOR . 'LevelFileFinderSource' . DIRECTORY_SEPARATOR . 'nested';
 
     /**
      * @var LevelFileFinder
@@ -37,8 +37,8 @@ final class LevelFileFinderTest extends TestCase
 
     public function provideOptionsAndExpectedConfig(): Iterator
     {
-        yield [['-l' => 'someConfig'], $this->sourceDirectory . '/someConfig.yml'];
-        yield [['--level' => 'someConfig'], $this->sourceDirectory . '/someConfig.yml'];
-        yield [['--level' => 'anotherConfig'], $this->sourceDirectory . '/anotherConfig.yml'];
+        yield [['-l' => 'someConfig'], $this->sourceDirectory . DIRECTORY_SEPARATOR . 'someConfig.yml'];
+        yield [['--level' => 'someConfig'], $this->sourceDirectory . DIRECTORY_SEPARATOR . 'someConfig.yml'];
+        yield [['--level' => 'anotherConfig'], $this->sourceDirectory . DIRECTORY_SEPARATOR . 'anotherConfig.yml'];
     }
 }

--- a/packages/Statie/src/Renderable/ApiGenerator.php
+++ b/packages/Statie/src/Renderable/ApiGenerator.php
@@ -3,6 +3,7 @@
 namespace Symplify\Statie\Renderable;
 
 use Nette\Utils\Json;
+use Symplify\PackageBuilder\Configuration\EolConfiguration;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\Statie\Contract\Api\ApiItemDecoratorInterface;
 use Symplify\Statie\Renderable\File\VirtualFile;
@@ -48,7 +49,7 @@ final class ApiGenerator
             $outputPath = $this->createOutputPath($apiParameter);
             $content = $this->createContent($apiParameter);
 
-            $virtualFiles[] = new VirtualFile($outputPath, $content . PHP_EOL);
+            $virtualFiles[] = new VirtualFile($outputPath, $content . EolConfiguration::getEolChar());
         }
 
         return $virtualFiles;

--- a/packages/Statie/tests/Renderable/Configuration/ConfigurationFileDecoratorTest.php
+++ b/packages/Statie/tests/Renderable/Configuration/ConfigurationFileDecoratorTest.php
@@ -53,7 +53,7 @@ final class ConfigurationFileDecoratorTest extends AbstractKernelTestCase
 
     public function testInvalidYamlSyntax(): void
     {
-        $brokenYamlFilePath = __DIR__ . '/ConfigurationFileDecoratorSource/someFileWithBrokenConfigurationSyntax.latte';
+        $brokenYamlFilePath = __DIR__ . DIRECTORY_SEPARATOR . 'ConfigurationFileDecoratorSource' . DIRECTORY_SEPARATOR . 'someFileWithBrokenConfigurationSyntax.latte';
         $fileInfo = new SmartFileInfo($brokenYamlFilePath);
         $file = $this->fileFactory->createFromFileInfo($fileInfo);
 


### PR DESCRIPTION
Many fixes in Windows tests.

I didn't have to change the regex, when I set the git config to false, the line feed on windows stays to \n. I changed the SPLIT_LINE constant accordingly.

There's 10 tests still failing. Some of them are quite difficult. I'll look at them later.