### PR TITLE
Add missing composer dependency on the new package SetConfigResolver

### DIFF
--- a/packages/ChangelogLinker/composer.json
+++ b/packages/ChangelogLinker/composer.json
@@ -13,6 +13,7 @@
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
         "symplify/package-builder": "^7.1",
+        "symplify/set-config-resolver": "^7.1",
         "symplify/smart-file-system": "^7.1"
     },
     "require-dev": {

--- a/packages/EasyCodingStandard/composer.json
+++ b/packages/EasyCodingStandard/composer.json
@@ -19,6 +19,7 @@
         "symfony/yaml": "^4.4|^5.0",
         "symplify/coding-standard": "^7.1",
         "symplify/package-builder": "^7.1",
+        "symplify/set-config-resolver": "^7.1",
         "symplify/smart-file-system": "^7.1",
         "slevomat/coding-standard": "^5.0",
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
The following commit introduced SetConfigResolver as a separate package:
https://github.com/Symplify/Symplify/commit/30ce8c3d31162eec19ecd31975899c8762f7b88d

Packages EasyCodingStandard and ChangelogLinker use this dependency but their composer.json files were not updated in the commit above to contain the new package in "require" section.

This PR fixes the issue.