### PR TITLE
[CL] Honouring final new line in changelog (for real)

### DIFF
--- a/packages/ChangelogLinker/src/ChangelogLinker.php
+++ b/packages/ChangelogLinker/src/ChangelogLinker.php
@@ -79,10 +79,11 @@ final class ChangelogLinker
     private function appendLinksToContentIfAny(string $content): string
     {
         $eolChar = EolConfiguration::getEolChar();
-        if ($this->linkAppender->getLinksToAppend() !== []) {
+        $linksToAppend = $this->linkAppender->getLinksToAppend();
+        if ($linksToAppend !== []) {
             $content = rtrim($content) . $eolChar;
             $content .= $this->linkAppender->hadExistingLinks() ? '' : $eolChar;
-            $content .= implode($eolChar, $this->linkAppender->getLinksToAppend()) . $eolChar;
+            $content .= implode($eolChar, $linksToAppend) . $eolChar;
         }
 
         return $content;

--- a/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/DumpMergesCommand.php
@@ -172,15 +172,13 @@ final class DumpMergesCommand extends Command
             $sortPriority
         );
 
-        if ($input->getOption(Option::DRY_RUN)) {
-            $content = $this->changelogLinker->processContentWithLinkAppends($content);
+        $content = $this->changelogLinker->processContent($content); // partial content
 
+        if ($input->getOption(Option::DRY_RUN)) {
             $this->symfonyStyle->writeln($content);
 
             return ShellCode::SUCCESS;
         }
-
-        $content = $this->changelogLinker->processContent($content);
 
         $this->changelogFileSystem->addToChangelogOnPlaceholder($content, self::CHANGELOG_PLACEHOLDER_TO_WRITE);
 

--- a/packages/ChangelogLinker/src/Console/Command/LinkCommand.php
+++ b/packages/ChangelogLinker/src/Console/Command/LinkCommand.php
@@ -49,7 +49,7 @@ final class LinkCommand extends Command
     {
         $changelogContent = $this->changelogFileSystem->readChangelog();
 
-        $processedChangelogContent = $this->changelogLinker->processContent($changelogContent);
+        $processedChangelogContent = $this->changelogLinker->processContentWithLinkAppends($changelogContent);
 
         $this->changelogFileSystem->storeChangelog($processedChangelogContent);
 

--- a/packages/ChangelogLinker/src/LinkAppender.php
+++ b/packages/ChangelogLinker/src/LinkAppender.php
@@ -63,6 +63,7 @@ final class LinkAppender
 
     private function removeAlreadyExistingLinks(): void
     {
+        $this->existingLinks = false;
         foreach (array_keys($this->linksToAppend) as $id) {
             if ($this->linksAnalyzer->hasLinkedId((string) $id)) {
                 unset($this->linksToAppend[$id]);


### PR DESCRIPTION
ChangelogLinker do not adds a _new line_ at the end of changelog files. I already tried to fix this with PR #1605, details can be found in issue #1604.

It turns out that the code I wrote is never called in _DumpMergesCommand_ nor in _LinkCommand_.

This PR fix this.