### PR TITLE
add relative path for phar

### DIFF
--- a/packages/SetConfigResolver/src/SetResolver.php
+++ b/packages/SetConfigResolver/src/SetResolver.php
@@ -52,7 +52,7 @@ final class SetResolver
         /** @var SplFileInfo $nearestMatch */
         $nearestMatch = array_shift($nearestMatches);
 
-        return $nearestMatch->getRealPath();
+        return $nearestMatch->getPathname();
     }
 
     /**


### PR DESCRIPTION
Fixes

```
Return value of Symplify\SetConfigResolver\SetResolver::detectFromNameAndDirectory()    
         must be of the type string, boolean returned  
```

for PHAR