### PR TITLE
[EasyCodingStandard] Prefer IncludeFixer over LanguageConstructSpacingSniff

### DIFF
--- a/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/RemoveMutualCheckersCompilerPass.php
+++ b/packages/EasyCodingStandard/src/DependencyInjection/CompilerPass/RemoveMutualCheckersCompilerPass.php
@@ -101,8 +101,8 @@ final class RemoveMutualCheckersCompilerPass implements CompilerPassInterface
             'PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer',
             'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\SuperfluousWhitespaceSniff',
         ],                                               [
-            'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff',
             'PhpCsFixer\Fixer\ControlStructure\IncludeFixer',
+            'PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff',
         ],                                               [
             'PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff',
             'SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff',

--- a/packages/EasyCodingStandard/tests/DependencyInjection/MutualExcludedCheckersSource/config.yml
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/MutualExcludedCheckersSource/config.yml
@@ -1,3 +1,7 @@
 services:
     PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer: ~
     PHP_CodeSniffer\Standards\Generic\Sniffs\WhiteSpace\DisallowTabIndentSniff: ~
+
+    # See https://github.com/Symplify/Symplify/issues/1702
+    PhpCsFixer\Fixer\ControlStructure\IncludeFixer: ~
+    PHP_CodeSniffer\Standards\Squiz\Sniffs\WhiteSpace\LanguageConstructSpacingSniff: ~

--- a/packages/EasyCodingStandard/tests/DependencyInjection/MutualExcludedCheckersTest.php
+++ b/packages/EasyCodingStandard/tests/DependencyInjection/MutualExcludedCheckersTest.php
@@ -17,7 +17,7 @@ final class MutualExcludedCheckersTest extends AbstractKernelTestCase
         );
 
         $fixerFileProcessor = self::$container->get(FixerFileProcessor::class);
-        $this->assertCount(1, $fixerFileProcessor->getCheckers());
+        $this->assertCount(2, $fixerFileProcessor->getCheckers());
 
         $sniffFileProcessor = self::$container->get(SniffFileProcessor::class);
         $this->assertCount(0, $sniffFileProcessor->getCheckers());


### PR DESCRIPTION
Fixes #1702 