### PR TITLE
[ECS] Fix default cache directory documentation

### DIFF
--- a/packages/EasyCodingStandard/README.md
+++ b/packages/EasyCodingStandard/README.md
@@ -220,7 +220,7 @@ vendor/bin/ecs check src --clear-cache
 
 ```yaml
 parameters:
-    cache_directory: .ecs_cache # defaults to sys_get_temp_dir() . '/_easy_coding_standard/_changed_files_detector_tests'
+    cache_directory: .ecs_cache # defaults to sys_get_temp_dir() . '/_changed_files_detector_tests'
 ```
 
 #### How can I change the cache namespace?


### PR DESCRIPTION
The documentation was incorrect about the file path of the default cache folder as per the YAML,
it is supposed to be `'%sys_get_temp_dir%/_changed_files_detector%env(TEST_SUFFIX)%'`.