### PR TITLE
[PHPStanExtensions] Make BoolishClassMethodPrefixRule skip parent interface required methods

### DIFF
--- a/packages/phpstan-extensions/config/config.neon
+++ b/packages/phpstan-extensions/config/config.neon
@@ -1,26 +1,13 @@
 includes:
     - 'php.level.neon'
     - 'symfony.level.neon'
+    - 'rules.neon'
 
 services:
     errorFormatter.symplify:
         class: 'Symplify\PHPStanExtensions\ErrorFormatter\SymplifyErrorFormatter'
 
     - Symfony\Component\Console\Terminal
-
-    # rules
-    -
-        class: Symplify\PHPStanExtensions\Rules\Classes\MatchingTypeConstantRule
-        tags: [phpstan.rules.rule]
-
-    -
-        class: Symplify\PHPStanExtensions\Rules\Include_\ForbidReturnValueOfIncludeOnceRule
-        tags: [phpstan.rules.rule]
-
-    -
-        class: Symplify\PHPStanExtensions\Rules\ClassMethod\BoolishClassMethodPrefixRule
-        tags: [phpstan.rules.rule]
-
     - Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory
     -
         factory: ['@Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory', 'create']

--- a/packages/phpstan-extensions/config/rules.neon
+++ b/packages/phpstan-extensions/config/rules.neon
@@ -1,0 +1,4 @@
+rules:
+    - Symplify\PHPStanExtensions\Rules\Classes\MatchingTypeConstantRule
+    - Symplify\PHPStanExtensions\Rules\Include_\ForbidReturnValueOfIncludeOnceRule
+    - Symplify\PHPStanExtensions\Rules\ClassMethod\BoolishClassMethodPrefixRule

--- a/packages/phpstan-extensions/tests/Rules/ClassMethod/BoolishClassMethodPrefixRuleTest.php
+++ b/packages/phpstan-extensions/tests/Rules/ClassMethod/BoolishClassMethodPrefixRuleTest.php
@@ -4,27 +4,36 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanExtensions\Tests\Rules\ClassMethod;
 
+use Iterator;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Symplify\PHPStanExtensions\Rules\ClassMethod\BoolishClassMethodPrefixRule;
 
 final class BoolishClassMethodPrefixRuleTest extends RuleTestCase
 {
-    public function testRule(): void
+    /**
+     * @dataProvider provideData()
+     */
+    public function testRule(string $analysedFilePath, array $expectedErrorsWithLine): void
     {
-        $this->analyse(
-            [__DIR__ . '/Source/ClassWithBoolishMethods.php'],
+        $this->analyse([$analysedFilePath], $expectedErrorsWithLine);
+    }
+
+    public function provideData(): Iterator
+    {
+        yield [
+            __DIR__ . '/Source/ClassWithBoolishMethods.php',
             [
                 ['Method "honesty()" returns bool type, so the name should start with is/has/was...', 9],
                 ['Method "thatWasGreat()" returns bool type, so the name should start with is/has/was...', 14],
-            ]
-        );
+            ],
+        ];
 
-        $this->analyse([__DIR__ . '/Source/ClassWithEmptyReturn.php'], []);
+        yield [__DIR__ . '/Source/ClassWithEmptyReturn.php', []];
 
-        $this->analyse([__DIR__ . '/Source/ClassThatImplementsInterface.php'], [
-            ['Method "nothing()" returns bool type, so the name should start with is/has/was...', 9],
-        ]);
+        yield [__DIR__ . '/Source/ClassThatImplementsInterface.php', []];
+
+        yield [__DIR__ . '/Source/SkipRequiredByInterface.php', []];
     }
 
     protected function getRule(): Rule

--- a/packages/phpstan-extensions/tests/Rules/ClassMethod/Source/InterfaceWithReturnType.php
+++ b/packages/phpstan-extensions/tests/Rules/ClassMethod/Source/InterfaceWithReturnType.php
@@ -6,5 +6,5 @@ namespace Symplify\PHPStanExtensions\Tests\Rules\ClassMethod\Source;
 
 interface InterfaceWithReturnType
 {
-    public function nothing(): bool;
+    public function vote(): bool;
 }

--- a/packages/phpstan-extensions/tests/Rules/ClassMethod/Source/SkipRequiredByInterface.php
+++ b/packages/phpstan-extensions/tests/Rules/ClassMethod/Source/SkipRequiredByInterface.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanExtensions\Tests\Rules\ClassMethod\Source;
 
-class ClassThatImplementsInterface implements InterfaceWithReturnType
+class SkipRequiredByInterface implements InterfaceWithReturnType
 {
     public function vote(): bool
     {
-        return (bool) 'a';
+        return true;
     }
 }


### PR DESCRIPTION
- Closes #1764
- Closes #1765
