### PR TITLE
[MB] Add SortAutoloadNamespaceCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,15 @@ PRs and issues are linked, so you can find more about it. Thanks to [ChangelogLi
 
 ### Added
 
-#### EasyCodingStandard
+#### CodingStandard
 
-- [#1762] add ecs.phar prefix build to travis
+- [#1776] Add ClassCognitiveComplexitySniff
 
 #### MonorepoBuilder
 
-- [#1760] Add application test
 - [#1755] Add "After split" testing
 - [#1756] Add ComposerJson value object
-
-#### CodingStandard
-
-- [#1776] Add `ClassCognitiveComplexitySniff`
+- [#1760] Add application test
 
 ### Changed
 
@@ -36,6 +32,11 @@ PRs and issues are linked, so you can find more about it. Thanks to [ChangelogLi
 #### EasyCodingStandard
 
 - [#1747] Skip scoping of php cs fixer and code sniffer
+- [#1762] add ecs.phar prefix build to travis
+
+#### FlexLoader
+
+- [#1782] Priority of loaded configs, Thanks to [@vrbata]
 
 #### LatteToTwigConverter
 
@@ -43,25 +44,42 @@ PRs and issues are linked, so you can find more about it. Thanks to [ChangelogLi
 
 #### MonorepoBuilder
 
-- [#1767] Specific branch for split, Thanks to [@natepage]
 - [#1759] Decopule ComposerKeyMerger
+- [#1794] Revert split --branch feature
 - [#1772] SplitCommand default branch option to current branch, Thanks to [@natepage]
+- [#1767] Specific branch for split, Thanks to [@natepage]
+
+#### PHPStanExtensions
+
+- [#1779] Make BoolishClassMethodPrefixRule skip parent interface required methods
+- [#1757] Merge pull request [#1757] from symplify/phsptan-reonce
+
+#### SOLID
+
+- [#1786] Move constant variables/propeties to constants
 
 ### Deprecated
 
 #### CodingStandard
 
-- [#1773] Deprecate `SprintfOverContactSniff`
+- [#1773] Deprecate SprintfOverContactSniff
 
 ### Fixed
 
+- [#1753] Merge pull request [#1753] from symplify/drop-vendor-dir
 - [#1768] fix: replace non exist site link to blog post, Thanks to [@ondraondra81]
+- [#1774] use fixed phpstan rector
+- [#1785] fix static
 
 ### Removed
 
 #### MonorepoBuilder
 
 - [#1771] Remove unused InvalidBranchException, Thanks to [@natepage]
+
+#### Statie
+
+- [#1777] Remove MigratorSculpin, Remove MigratorJekyll, unused
 
 ## [v7.2.2] - 2020-01-20
 
@@ -443,4 +461,15 @@ PRs and issues are linked, so you can find more about it. Thanks to [ChangelogLi
 [@ondraondra81]: https://github.com/ondraondra81
 [@migrify]: https://github.com/migrify
 [#1776]: https://github.com/symplify/symplify/pull/1776
+[#1794]: https://github.com/symplify/symplify/pull/1794
+[#1786]: https://github.com/symplify/symplify/pull/1786
+[#1785]: https://github.com/symplify/symplify/pull/1785
+[#1782]: https://github.com/symplify/symplify/pull/1782
+[#1779]: https://github.com/symplify/symplify/pull/1779
+[#1777]: https://github.com/symplify/symplify/pull/1777
+[@vrbata]: https://github.com/vrbata
 [#1774]: https://github.com/symplify/symplify/pull/1774
+[#1757]: https://github.com/symplify/symplify/pull/1757
+[#1754]: https://github.com/symplify/symplify/pull/1754
+[#1753]: https://github.com/symplify/symplify/pull/1753
+[#1752]: https://github.com/symplify/symplify/pull/1752

--- a/composer.json
+++ b/composer.json
@@ -85,9 +85,6 @@
             "Symplify\\Statie\\GithubContributorsThanker\\": "packages/statie/packages/github-contributors-thanker/src",
             "Symplify\\Statie\\HeadlineAnchorLinker\\": "packages/statie/packages/headline-anchor-linker/src",
             "Symplify\\Statie\\JoindIn\\": "packages/statie/packages/joind-in/src",
-            "Symplify\\Statie\\MigratorJekyll\\": "packages/statie/packages/migrator-jekyll/src",
-            "Symplify\\Statie\\MigratorSculpin\\": "packages/statie/packages/migrator-sculpin/src",
-            "Symplify\\Statie\\Migrator\\": "packages/statie/packages/migrator/src",
             "Symplify\\Statie\\Tweeter\\": "packages/statie/packages/tweeter/src",
             "Symplify\\Statie\\Twig\\": "packages/statie/packages/twig/src"
         }
@@ -119,9 +116,6 @@
             "Symplify\\SmartFileSystem\\Tests\\": "packages/smart-file-system/tests",
             "Symplify\\Statie\\Generator\\Tests\\": "packages/statie/packages/generator/tests",
             "Symplify\\Statie\\HeadlineAnchorLinker\\Tests\\": "packages/statie/packages/headline-anchor-linker/tests",
-            "Symplify\\Statie\\MigratorJekyll\\Tests\\": "packages/statie/packages/migrator-jekyll/tests",
-            "Symplify\\Statie\\MigratorSculpin\\Tests\\": "packages/statie/packages/migrator-sculpin/tests",
-            "Symplify\\Statie\\Migrator\\Tests\\": "packages/statie/packages/migrator/tests",
             "Symplify\\Statie\\Tests\\": "packages/statie/tests",
             "Symplify\\Statie\\Tweeter\\Tests\\": "packages/statie/packages/tweeter/tests",
             "Symplify\\Statie\\Twig\\Tests\\": "packages/statie/packages/twig/tests"

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "doctrine/persistence": "^1.3.3",
         "nikic/php-parser": "^4.3",
         "phpunit/phpunit": "^8.5|^9.0",
-        "rector/rector": "dev-master",
+        "rector/rector": "^0.7.2",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/templating": "^4.4|^5.0",
         "symfony/translation": "^4.4|^5.0",

--- a/packages/monorepo-builder/src/Console/Command/SortAutoloadNamespaceCommand.php
+++ b/packages/monorepo-builder/src/Console/Command/SortAutoloadNamespaceCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Console\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\MonorepoBuilder\ComposerJsonObject\ComposerJsonFactory;
+use Symplify\MonorepoBuilder\ComposerJsonObject\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\FileSystem\JsonFileManager;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+use Symplify\PackageBuilder\Console\ShellCode;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SortAutoloadNamespaceCommand extends Command
+{
+    /**
+     * @var ComposerJsonFactory
+     */
+    private $composerJsonFactory;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $symfonyStyle;
+
+    /**
+     * @var JsonFileManager
+     */
+    private $jsonFileManager;
+
+    public function __construct(
+        ComposerJsonFactory $composerJsonFactory,
+        SymfonyStyle $symfonyStyle,
+        JsonFileManager $jsonFileManager
+    ) {
+        $this->composerJsonFactory = $composerJsonFactory;
+        $this->symfonyStyle = $symfonyStyle;
+        $this->jsonFileManager = $jsonFileManager;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setName(CommandNaming::classToName(self::class));
+        $this->setDescription('Sort autoload/autoload-dev namespaces');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $composerJsonPath = getcwd() . '/composer.json';
+        $composerJsonFileInfo = new SmartFileInfo($composerJsonPath);
+
+        $composerJson = $this->composerJsonFactory->createFromFileInfo($composerJsonFileInfo);
+
+        // should be default?
+        $this->sortAutoloadSections($composerJson);
+
+        $this->jsonFileManager->saveComposerJsonWithFileInfo($composerJson, $composerJsonFileInfo);
+
+        $this->symfonyStyle->success('"autoload"/"autoload-dev" sections were successfully sorted');
+
+        return ShellCode::SUCCESS;
+    }
+
+    private function sortAutoload(array $autoload): array
+    {
+        // 2. sort by namespaces
+        if (isset($autoload['psr-4'])) {
+            ksort($autoload['psr-4']);
+        }
+
+        return $autoload;
+    }
+
+    private function sortAutoloadSections(ComposerJson $composerJson): void
+    {
+        $sortedAutoload = $this->sortAutoload($composerJson->getAutoload());
+        $composerJson->setAutoload($sortedAutoload);
+
+        $sortedAutoloadDev = $this->sortAutoload($composerJson->getAutoloadDev());
+        $composerJson->setAutoloadDev($sortedAutoloadDev);
+    }
+}

--- a/packages/monorepo-builder/src/FileSystem/JsonFileManager.php
+++ b/packages/monorepo-builder/src/FileSystem/JsonFileManager.php
@@ -66,6 +66,11 @@ final class JsonFileManager
         $this->symfonyFilesystem->dumpFile($filePath, $jsonString);
     }
 
+    public function saveComposerJsonWithFileInfo(ComposerJson $composerJson, SmartFileInfo $smartFileInfo): void
+    {
+        $this->saveJsonWithFileInfo($composerJson->getJsonArray(), $smartFileInfo);
+    }
+
     /**
      * @param mixed[] $json
      * @param string[] $inlineSections


### PR DESCRIPTION
This commands sorts namespaces in "autoload"/"autoload-dev" PSR-4 sections:

```bash
vendor/bin/monorepo-builder sort-autoload-namespace
```

Closes #1778