### PR TITLE
[FlexLoader] Priority of loaded configs

### DIFF
--- a/packages/flex-loader/src/Flex/FlexLoader.php
+++ b/packages/flex-loader/src/Flex/FlexLoader.php
@@ -77,7 +77,7 @@ final class FlexLoader
     public function loadRoutes(RouteCollectionBuilder $routeCollectionBuilder, array $extraRoutingPaths = []): void
     {
         $routingPaths = $this->flexPathsFactory->createRoutingPaths($this->projectDir, $this->environment);
-        $routingPaths = array_merge($routingPaths, $extraRoutingPaths);
+        $routingPaths = array_merge($extraRoutingPaths, $routingPaths);
 
         foreach ($routingPaths as $routingPath) {
             $routeCollectionBuilder->import($routingPath . $this->configExtensions, '/', 'glob');

--- a/packages/flex-loader/src/Flex/FlexPathsFactory.php
+++ b/packages/flex-loader/src/Flex/FlexPathsFactory.php
@@ -23,7 +23,7 @@ final class FlexPathsFactory
             $projectDir . '/config/parameters_' . $environment,
         ];
 
-        return $this->filterExistingPaths(array_merge($servicePaths, $extraServicePaths));
+        return $this->filterExistingPaths(array_merge($extraServicePaths, $servicePaths));
     }
 
     /**

--- a/packages/flex-loader/tests/Flex/FlexLoader/MicroKernelTraitTest.php
+++ b/packages/flex-loader/tests/Flex/FlexLoader/MicroKernelTraitTest.php
@@ -24,5 +24,6 @@ final class MicroKernelTraitTest extends TestCase
         $this->assertTrue($container->has(ExtraService::class));
         $this->assertTrue($container->hasParameter('default.parameter'));
         $this->assertTrue($container->hasParameter('dev.environment.parameter'));
+        $this->assertSame('app_level_value', $container->getParameter('package_param_overridable_on_app_level'));
     }
 }

--- a/packages/flex-loader/tests/Flex/FlexLoader/Source/extra-dir/config.yml
+++ b/packages/flex-loader/tests/Flex/FlexLoader/Source/extra-dir/config.yml
@@ -1,3 +1,6 @@
+parameters:
+    package_param_overridable_on_app_level: 'default_value'
+
 services:
     _defaults:
         public: true

--- a/packages/flex-loader/tests/Flex/FlexLoader/Source/project-dir-micro-kernel/config/packages/config.yml
+++ b/packages/flex-loader/tests/Flex/FlexLoader/Source/project-dir-micro-kernel/config/packages/config.yml
@@ -1,3 +1,6 @@
+parameters:
+    package_param_overridable_on_app_level: 'app_level_value'
+
 services:
     _defaults:
         public: true


### PR DESCRIPTION
Hi,
here is promised PR for https://github.com/symplify/symplify/issues/1780
Hope it's more clear now from the test. Before this change
```php
$container->getParameter('package_param_overridable_on_app_level')
```
would return `default_value` instead of `app_level_value`
In my oppition now it has the same behaviour as Symfony. As you are able to override params in same structure like for example doctrine params in `config/packages/doctrine.yaml`

What do you think? :)