### PR TITLE
[Statie] Collect metadata of all files before rendering

### DIFF
--- a/packages/statie/packages/generator/src/Generator.php
+++ b/packages/statie/packages/generator/src/Generator.php
@@ -94,7 +94,14 @@ final class Generator
             }
 
             // run them through decorator and render content to string
-            $generatorFilesByType[$key] = $this->renderableFilesProcessor->processGeneratorElementObjects(
+            $generatorFilesByType[$key] = $this->renderableFilesProcessor->processGeneratorElementObjectMetadata(
+                $generatorElement->getObjects(),
+                $generatorElement
+            );
+        }
+
+        foreach ($this->generatorConfiguration->getGeneratorElements() as $generatorElement) {
+            $this->renderableFilesProcessor->processGeneratorElementObjects(
                 $generatorElement->getObjects(),
                 $generatorElement
             );

--- a/packages/statie/src/Renderable/RenderableFilesProcessor.php
+++ b/packages/statie/src/Renderable/RenderableFilesProcessor.php
@@ -65,13 +65,13 @@ final class RenderableFilesProcessor
      * @param AbstractGeneratorFile[] $objects
      * @return AbstractGeneratorFile[]
      */
-    public function processGeneratorElementObjects(array $objects, GeneratorElement $generatorElement): array
+    public function processGeneratorElementObjectMetadata(array $objects, GeneratorElement $generatorElement): array
     {
         if (count($objects) === 0) {
             return [];
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) {
+        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() >= 1000) {
             $objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
         }
 
@@ -83,6 +83,20 @@ final class RenderableFilesProcessor
         $this->statieConfiguration->addOption($generatorElement->getVariableGlobal(), $objects);
 
         return $objects;
+    }
+
+    /**
+     * @param AbstractGeneratorFile[] $objects
+     */
+    public function processGeneratorElementObjects(array $objects, GeneratorElement $generatorElement): void
+    {
+        if (count($objects) === 0) {
+            return;
+        }
+
+        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() < 1000) {
+            $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+        }
     }
 
     /**

--- a/packages/statie/src/Renderable/RenderableFilesProcessor.php
+++ b/packages/statie/src/Renderable/RenderableFilesProcessor.php
@@ -71,8 +71,10 @@ final class RenderableFilesProcessor
             return [];
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() >= 1000) {
-            $objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+        foreach ($this->getFileDecorators() as $fileDecorator) {
+			if ($fileDecorator->getPriority() >= 1000) {
+				$objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+			}
         }
 
         $objectSorter = $generatorElement->getObjectSorter();
@@ -94,8 +96,10 @@ final class RenderableFilesProcessor
             return;
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() < 1000) {
-            $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+        foreach ($this->getFileDecorators() as $fileDecorator) {
+			if ($fileDecorator->getPriority() < 1000) {
+				$fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+			}
         }
     }
 

--- a/packages/statie/src/Renderable/RenderableFilesProcessor.php
+++ b/packages/statie/src/Renderable/RenderableFilesProcessor.php
@@ -71,10 +71,8 @@ final class RenderableFilesProcessor
             return [];
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) {
-			if ($fileDecorator->getPriority() >= 1000) {
-				$objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
-			}
+        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() >= 1000) {
+            $objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
         }
 
         $objectSorter = $generatorElement->getObjectSorter();
@@ -96,10 +94,8 @@ final class RenderableFilesProcessor
             return;
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) {
-			if ($fileDecorator->getPriority() < 1000) {
-				$fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
-			}
+        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() < 1000) {
+            $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
         }
     }
 

--- a/packages/statie/src/Renderable/RenderableFilesProcessor.php
+++ b/packages/statie/src/Renderable/RenderableFilesProcessor.php
@@ -71,8 +71,10 @@ final class RenderableFilesProcessor
             return [];
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() >= 1000) {
-            $objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+        foreach ($this->getFileDecorators() as $fileDecorator) {
+            if ($fileDecorator->getPriority() >= 1000) {
+                $objects = $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+            }
         }
 
         $objectSorter = $generatorElement->getObjectSorter();
@@ -94,8 +96,10 @@ final class RenderableFilesProcessor
             return;
         }
 
-        foreach ($this->getFileDecorators() as $fileDecorator) if ($fileDecorator->getPriority() < 1000) {
-            $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+        foreach ($this->getFileDecorators() as $fileDecorator) {
+            if ($fileDecorator->getPriority() < 1000) {
+                $fileDecorator->decorateFilesWithGeneratorElement($objects, $generatorElement);
+            }
         }
     }
 


### PR DESCRIPTION
I was running into an issue when having multiple generators as I couldn't render metadata (title, etc) of one generator type while rendering the first generator. This was because the global objects aren't setup in StatieConfiguration yet as the generator elements haven't been run through the ConfigurationFileDecorator yet.

If you run all the objects through that decorator first then render the files with the remaining decorators it works great. So I split the generator element processing so that decorators with a priority of 1000 or greater are run first.

This PR might be too much of a workaround, but I wanted to at least share what I was doing and get some feedback.

Thanks!