### PR TITLE
ISS_1814 Fixing the merge command of the monorepo builder tool

### DIFF
--- a/packages/monorepo-builder/packages/composer-json-object/src/ComposerJsonFactory.php
+++ b/packages/monorepo-builder/packages/composer-json-object/src/ComposerJsonFactory.php
@@ -90,6 +90,10 @@ final class ComposerJsonFactory
             $composerJson->setPreferStable($jsonArray['prefer-stable']);
         }
 
+        if (isset($jsonArray['repositories'])) {
+            $composerJson->setRepositories($jsonArray['repositories']);
+        }
+
         $orderedKeys = array_keys($jsonArray);
         $composerJson->setOrderedKeys($orderedKeys);
 

--- a/packages/monorepo-builder/packages/merge/tests/Package/AbstractMergeTestCase.php
+++ b/packages/monorepo-builder/packages/merge/tests/Package/AbstractMergeTestCase.php
@@ -38,6 +38,8 @@ abstract class AbstractMergeTestCase extends AbstractComposerJsonDecoratorTest
         $fileInfos = $this->getFileInfosFromDirectory($directoryWithJsonFiles);
         $mergedComposerJson = $this->composerJsonMerger->mergeFileInfos($fileInfos);
 
+        $this->assertNotEmpty($mergedComposerJson->getRepositories());
+
         $this->assertComposerJsonEquals($expectedComposerJson, $mergedComposerJson);
     }
 


### PR DESCRIPTION
Previously the 'repositories' section were deleted when using the merge function
This is adding it back and fixing the test to make sure it never happen again