### PR TITLE
[MonorepoBuilder] Add composer exclude folders dynamicly

### DIFF
--- a/packages/monorepo-builder/README.md
+++ b/packages/monorepo-builder/README.md
@@ -58,6 +58,15 @@ parameters:
 
 Sections are sorted for you by saint defaults. Do you want change the order? Just override `section_order` parameter.
 
+To exclude a specific folder for ignoring the composer.json in this folder.
+
+```yaml
+# monorepo-builder.yml
+parameters:
+    package_directories_excludes:
+        - 'ExcludeThis'
+```
+
 #### After Merge Options
 
 Do you need to add or remove some packages only to root `composer.json`?

--- a/packages/monorepo-builder/config/config.yaml
+++ b/packages/monorepo-builder/config/config.yaml
@@ -5,6 +5,7 @@ imports:
 parameters:
     package_directories:
         - 'packages'
+    package_directories_excludes: []
     data_to_append: []
     data_to_remove: []
     package_alias_format: '<major>.<minor>-dev'

--- a/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
+++ b/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
@@ -16,16 +16,23 @@ final class PackageComposerFinder
     private $packageDirectories = [];
 
     /**
+     * @var string[]
+     */
+    private $packageDirectoriesExcludes = [];
+
+    /**
      * @var FinderSanitizer
      */
     private $finderSanitizer;
 
     /**
      * @param string[] $packageDirectories
+     * @param string[] $packageDirectoriesExcludes
      */
-    public function __construct(array $packageDirectories, FinderSanitizer $finderSanitizer)
+    public function __construct(array $packageDirectories, array $packageDirectoriesExcludes, FinderSanitizer $finderSanitizer)
     {
         $this->packageDirectories = $packageDirectories;
+        $this->packageDirectoriesExcludes = $packageDirectoriesExcludes;
         $this->finderSanitizer = $finderSanitizer;
     }
 
@@ -46,6 +53,12 @@ final class PackageComposerFinder
             ->exclude('vendor')
             ->exclude('node_modules')
             ->name('composer.json');
+
+        if ($this->packageDirectoriesExcludes) {
+            foreach ($this->packageDirectoriesExcludes as $excludeFolder) {
+                $finder->exclude($excludeFolder);
+            }
+        }
 
         if (! $this->isPHPUnit()) {
             $finder->notPath('#tests#');

--- a/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
+++ b/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
@@ -57,10 +57,8 @@ final class PackageComposerFinder
             ->exclude('node_modules')
             ->name('composer.json');
 
-        if ($this->packageDirectoriesExcludes !== []) {
-            foreach ($this->packageDirectoriesExcludes as $excludeFolder) {
-                $finder->exclude($excludeFolder);
-            }
+        foreach ($this->packageDirectoriesExcludes as $excludeFolder) {
+            $finder->exclude($excludeFolder);
         }
 
         if (! $this->isPHPUnit()) {

--- a/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
+++ b/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
@@ -29,8 +29,11 @@ final class PackageComposerFinder
      * @param string[] $packageDirectories
      * @param string[] $packageDirectoriesExcludes
      */
-    public function __construct(array $packageDirectories, array $packageDirectoriesExcludes, FinderSanitizer $finderSanitizer)
-    {
+    public function __construct(
+        array $packageDirectories,
+        array $packageDirectoriesExcludes,
+        FinderSanitizer $finderSanitizer
+    ) {
         $this->packageDirectories = $packageDirectories;
         $this->packageDirectoriesExcludes = $packageDirectoriesExcludes;
         $this->finderSanitizer = $finderSanitizer;
@@ -54,7 +57,7 @@ final class PackageComposerFinder
             ->exclude('node_modules')
             ->name('composer.json');
 
-        if ($this->packageDirectoriesExcludes) {
+        if ($this->packageDirectoriesExcludes !== []) {
             foreach ($this->packageDirectoriesExcludes as $excludeFolder) {
                 $finder->exclude($excludeFolder);
             }

--- a/packages/monorepo-builder/tests/Finder/PackageComposerFinder/Source/First/ExcludeThis/composer.json
+++ b/packages/monorepo-builder/tests/Finder/PackageComposerFinder/Source/First/ExcludeThis/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "first/excludePackage"
+}

--- a/packages/monorepo-builder/tests/Finder/PackageComposerFinder/Source/source_config.yaml
+++ b/packages/monorepo-builder/tests/Finder/PackageComposerFinder/Source/source_config.yaml
@@ -1,3 +1,5 @@
 parameters:
     package_directories:
         - '%kernel.project_dir%/tests/Finder/PackageComposerFinder/Source'
+    package_directories_excludes:
+        - 'ExcludeThis'


### PR DESCRIPTION
I've added a new feature to ignoring specific composer.json in specific folders. 

Example for monorepo-builder.yml

```
parameters:
    package_directories_excludes:
        - 'ExcludeThis'
```


I need this for my project.