### PR TITLE
[Static Dumper] [Docs] Add compiler pass in kernel

### DIFF
--- a/packages/symfony-static-dumper/README.md
+++ b/packages/symfony-static-dumper/README.md
@@ -18,6 +18,21 @@ imports:
     - { resource: '../vendor/symplify/symfony-static-dumper/config/config.yaml' }
 ```
 
+Add the `AutowireArrayParameterCompilerPass` in your `Kernel.php`:
+
+```php
+// src/Kernel.php
+<?php
+// ...
+use Symplify\AutowireArrayParameter\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
+// ...
+    protected function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new AutowireArrayParameterCompilerPass());
+    }
+// ...
+```
+
 ## Use
 
 ```bash


### PR DESCRIPTION
On a fresh install of Symfony, after require static dumper, and importing it's config, I get this error : 

```
In DefinitionErrorExceptionPass.php line 54:
                                                                                                                                                                                              
  Cannot autowire service "Symplify\SymfonyStaticDumper\ControllerWithDataProviderMatcher": argument "$controllerWithDataProviders" of method "__construct()" is type-hinted "array", you should configure its value explicitly.   
```

When adding the compilerPass `AutowireArrayParameterCompilerPass`, it's fixed.

I think it should be mentionned :+1: 