### PR TITLE
Fix command in README.md

### DIFF
--- a/packages/symfony-static-dumper/README.md
+++ b/packages/symfony-static-dumper/README.md
@@ -36,7 +36,7 @@ use Symplify\AutowireArrayParameter\DependencyInjection\CompilerPass\AutowireArr
 ## Use
 
 ```bash
-bin/console dump-static-website
+bin/console dump-static-site
 ```
 
 The website will be generated to `/output` directory in your root project.


### PR DESCRIPTION
I've just tried to use the package following the readme but the actual command is `dump-static-site` so just fixing it for everybody else.