### PR TITLE
Move PackageBuilder dependency to require-dev

### DIFF
--- a/packages/auto-bind-parameter/composer.json
+++ b/packages/auto-bind-parameter/composer.json
@@ -6,11 +6,11 @@
         "php": "^7.2",
         "nette/utils": "^3.0",
         "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/dependency-injection": "^4.4|^5.0",
-        "symplify/package-builder": "^7.3"
+        "symfony/dependency-injection": "^4.4|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.0"
+        "phpunit/phpunit": "^8.5|^9.0",
+        "symplify/package-builder": "^7.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
It is required only for tests, so no need to install it for every installation