### PR TITLE
[MB] Add release keyword for ReleaseCommand

### DIFF
--- a/packages/monorepo-builder/README.md
+++ b/packages/monorepo-builder/README.md
@@ -208,6 +208,15 @@ Are you afraid to tag and push? Use `--dry-run` to see only descriptions:
 vendor/bin/monorepo-builder release v7.0 --dry-run
 ```
 
+Do you want ot release next [patch version](https://semver.org/), e.g. current `v0.7.1` → next `v0.7.2`?
+
+```bash
+vendor/bin/monorepo-builder release patch
+```
+
+You can use `minor` and `major` too.
+
+
 ### 7. Set Your Own Release Flow
 
 There is set of few default release workers - classes that implement `Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface`.

--- a/packages/monorepo-builder/packages/release/src/Guard/ReleaseGuard.php
+++ b/packages/monorepo-builder/packages/release/src/Guard/ReleaseGuard.php
@@ -91,7 +91,7 @@ final class ReleaseGuard
 
     public function guardVersion(Version $version, ?string $stage): void
     {
-        // stage is set and it doesn't need a validatoin
+        // stage is set and it doesn't need a validation
         if ($stage && in_array($stage, $this->stagesToAllowExistingTag, true)) {
             return;
         }

--- a/packages/monorepo-builder/packages/release/src/ValueObject/SemVersion.php
+++ b/packages/monorepo-builder/packages/release/src/ValueObject/SemVersion.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Release\ValueObject;
+
+final class SemVersion
+{
+    /**
+     * @var string
+     */
+    public const MAJOR = 'major';
+
+    /**
+     * @var string
+     */
+    public const MINOR = 'minor';
+
+    /**
+     * @var string
+     */
+    public const PATCH = 'patch';
+
+    /**
+     * @var string[]
+     */
+    public static function getAll(): array
+    {
+        return [self::MAJOR, self::MINOR, self::PATCH];
+    }
+}

--- a/packages/monorepo-builder/packages/release/src/Version/VersionFactory.php
+++ b/packages/monorepo-builder/packages/release/src/Version/VersionFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Release\Version;
+
+use PharIo\Version\Version;
+use Symplify\MonorepoBuilder\Release\Guard\ReleaseGuard;
+use Symplify\MonorepoBuilder\Release\ValueObject\SemVersion;
+use Symplify\MonorepoBuilder\Split\Git\GitManager;
+
+final class VersionFactory
+{
+    /**
+     * @var ReleaseGuard
+     */
+    private $releaseGuard;
+
+    /**
+     * @var GitManager
+     */
+    private $gitManager;
+
+    public function __construct(ReleaseGuard $releaseGuard, GitManager $gitManager)
+    {
+        $this->releaseGuard = $releaseGuard;
+        $this->gitManager = $gitManager;
+    }
+
+    public function createValidVersion(string $versionArgument, ?string $stage): Version
+    {
+        if (in_array($versionArgument, SemVersion::getAll(), true)) {
+            return $this->resolveNextVersionByVersionKind($versionArgument);
+        }
+
+        // this object performs validation of version
+        $version = new Version($versionArgument);
+
+        $this->releaseGuard->guardVersion($version, $stage);
+
+        return $version;
+    }
+
+    private function resolveNextVersionByVersionKind(string $versionKind): Version
+    {
+        // get current version
+        $mostRecentVersion = $this->gitManager->getMostRecentTag(getcwd());
+        if ($mostRecentVersion === null) {
+            // the very first tag
+            return new Version('v0.1.0');
+        }
+
+        $mostRecentVersion = new Version($mostRecentVersion);
+
+        $currentMajorVersion = $mostRecentVersion->getMajor()->getValue();
+        $currentMinorVersion = $mostRecentVersion->getMinor()->getValue();
+        $currentPatchVersion = $mostRecentVersion->getPatch()->getValue();
+
+        if ($versionKind === SemVersion::MAJOR) {
+            ++$currentMajorVersion;
+            $currentMinorVersion = 0;
+            $currentPatchVersion = 0;
+        }
+
+        if ($versionKind === SemVersion::MINOR) {
+            ++$currentMinorVersion;
+            $currentPatchVersion = 0;
+        }
+
+        if ($versionKind === SemVersion::PATCH) {
+            ++$currentPatchVersion;
+        }
+
+        return new Version(sprintf('v%d.%d.%d', $currentMajorVersion, $currentMinorVersion, $currentPatchVersion));
+    }
+}


### PR DESCRIPTION
Closes #1838

## Before

```bash
vendor/bin/monorepo-builder release v0.7.x... what was the last patch version?
```

## Now

Let tool solve it for you!

```bash
vendor/bin/monorepo-builder release patch
```

:+1: 

Note: works with `minor` and `major` keywords too.