### PR TITLE
[ECS] Do not install box.phar on ecs require

### DIFF
--- a/packages/easy-coding-standard/.gitattributes
+++ b/packages/easy-coding-standard/.gitattributes
@@ -7,3 +7,4 @@ phpunit.xml export-ignore
 /packages/sniff-runner/tests export-ignore
 *.md export-ignore
 docs/ export-ignore
+compiler/ export-ignore


### PR DESCRIPTION
Prevent box.phar false autocomplete like

![image](https://user-images.githubusercontent.com/924196/80810579-76ba6780-8bc4-11ea-9507-fe247a433f8c.png)
