### PR TITLE
Bugfix when service definition contains multiple '@'

### DIFF
--- a/packages/easy-coding-standard/src/Yaml/CheckerServiceParametersShifter.php
+++ b/packages/easy-coding-standard/src/Yaml/CheckerServiceParametersShifter.php
@@ -220,6 +220,6 @@ final class CheckerServiceParametersShifter
             return $value;
         }
 
-        return Strings::replace($value, '#@#', '@@');
+        return Strings::replace($value, '#^@#', '@@');
     }
 }

--- a/packages/easy-coding-standard/tests/Yaml/FileLoader/CheckerTolerantYamlFileLoader/DefinitionsSource/config-with-at.yaml
+++ b/packages/easy-coding-standard/tests/Yaml/FileLoader/CheckerTolerantYamlFileLoader/DefinitionsSource/config-with-at.yaml
@@ -1,3 +1,3 @@
 services:
     PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
-        absoluteLineLimit: '@author'
+        absoluteLineLimit: '@author, @var'

--- a/packages/easy-coding-standard/tests/Yaml/FileLoader/CheckerTolerantYamlFileLoader/DefinitionsTest.php
+++ b/packages/easy-coding-standard/tests/Yaml/FileLoader/CheckerTolerantYamlFileLoader/DefinitionsTest.php
@@ -59,7 +59,7 @@ final class DefinitionsTest extends TestCase
             __DIR__ . '/DefinitionsSource/config-with-at.yaml',
             LineLengthSniff::class,
             [],
-            ['absoluteLineLimit' => '@author'],
+            ['absoluteLineLimit' => '@author, @var'],
         ];
         # keep original keywords
         yield [


### PR DESCRIPTION
Bugfix when service definition contains multiple '@'. Better Yaml config loader tests. Fix #1921.