### PR TITLE
[ECS] Dislocate bundle locations to prevent symfony/flex autoregistration

### DIFF
--- a/packages/coding-standard/src/Bundle/SymplifyCodingStandardBundle.php
+++ b/packages/coding-standard/src/Bundle/SymplifyCodingStandardBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\CodingStandard;
+namespace Symplify\CodingStandard\Bundle;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -10,6 +10,10 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symplify\AutowireArrayParameter\DependencyInjection\CompilerPass\AutowireArrayParameterCompilerPass;
 use Symplify\CodingStandard\DependencyInjection\Extension\SymplifyCodingStandardExtension;
 
+/**
+ * This class is dislocated in non-standard location, so it's not added by symfony/flex
+ * to bundles.php and cause app to crash. See https://github.com/symplify/symplify/issues/1952#issuecomment-628765364
+ */
 final class SymplifyCodingStandardBundle extends Bundle
 {
     public function build(ContainerBuilder $containerBuilder): void

--- a/packages/coding-standard/tests/HttpKernel/SymplifyCodingStandardKernel.php
+++ b/packages/coding-standard/tests/HttpKernel/SymplifyCodingStandardKernel.php
@@ -7,9 +7,9 @@ namespace Symplify\CodingStandard\Tests\HttpKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
-use Symplify\CodingStandard\SymplifyCodingStandardBundle;
+use Symplify\CodingStandard\Bundle\SymplifyCodingStandardBundle;
 use Symplify\ConsoleColorDiff\ConsoleColorDiffBundle;
-use Symplify\EasyCodingStandard\EasyCodingStandardBundle;
+use Symplify\EasyCodingStandard\Bundle\EasyCodingStandardBundle;
 
 final class SymplifyCodingStandardKernel extends Kernel
 {

--- a/packages/easy-coding-standard/src/Bundle/EasyCodingStandardBundle.php
+++ b/packages/easy-coding-standard/src/Bundle/EasyCodingStandardBundle.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\EasyCodingStandard;
+namespace Symplify\EasyCodingStandard\Bundle;
 
 use Nette\Utils\Strings;
 use PHP_CodeSniffer\Sniffs\Sniff;

--- a/packages/easy-coding-standard/src/HttpKernel/EasyCodingStandardKernel.php
+++ b/packages/easy-coding-standard/src/HttpKernel/EasyCodingStandardKernel.php
@@ -10,10 +10,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel;
-use Symplify\CodingStandard\SymplifyCodingStandardBundle;
+use Symplify\CodingStandard\Bundle\SymplifyCodingStandardBundle;
 use Symplify\ConsoleColorDiff\ConsoleColorDiffBundle;
+use Symplify\EasyCodingStandard\Bundle\EasyCodingStandardBundle;
 use Symplify\EasyCodingStandard\DependencyInjection\DelegatingLoaderFactory;
-use Symplify\EasyCodingStandard\EasyCodingStandardBundle;
 use Symplify\PackageBuilder\Contract\HttpKernel\ExtraConfigAwareKernelInterface;
 use Symplify\ParameterNameGuard\ParameterNameGuardBundle;
 


### PR DESCRIPTION
Might fix https://github.com/symplify/symplify/issues/1952