### PR TITLE
[ChangelogLinker] added failing test with expected result in ChangelogLinkerTest

### DIFF
--- a/packages/changelog-linker/tests/ChangelogLinker/Fixture/link_inside_repository_url.md
+++ b/packages/changelog-linker/tests/ChangelogLinker/Fixture/link_inside_repository_url.md
@@ -1,0 +1,11 @@
+## CodingStandard
+
+- shopsys/microservice-product is part of names_to_urls
+- [#1850]: https://github.com/shopsys/microservice-product/pull/1850
+
+-----
+## CodingStandard
+
+- [shopsys/microservice-product] is part of names_to_urls
+- [#1850]: https://github.com/shopsys/microservice-product/pull/1850
+[shopsys/microservice-product]: https://github.com/shopsys/microservice-product


### PR DESCRIPTION
As in #1963.

Test fails on this error:

```
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
 '## CodingStandard
 
 - [shopsys/microservice-product] is part of names_to_urls
-- [#1850]: https://github.com/shopsys/microservice-product/pull/1850
+- [#1850]: https://github.com/[shopsys/microservice-product]/pull/1850
 [shopsys/microservice-product]: https://github.com/shopsys/microservice-product
 '

/git/symplify/packages/changelog-linker/tests/ChangelogLinker/ChangelogLinkerTest.php:44
```

And I think so use case in test is correct, but I may be wrong.