### PR TITLE
Find only docblocks that are parseable by phpdoc-parser

### DIFF
--- a/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/DocBlockFinder.php
+++ b/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/DocBlockFinder.php
@@ -22,7 +22,7 @@ final class DocBlockFinder
                 return null;
             }
 
-            if ($token->isComment()) {
+            if ($token->isGivenKind(T_DOC_COMMENT)) {
                 return $i;
             }
         }


### PR DESCRIPTION
Fixes #1994