### PR TITLE
[SymfonyStaticDumper] Allow to dump only specific routes or just copy assets without rebuilding everything

### DIFF
--- a/packages/symfony-static-dumper/config/config.yaml
+++ b/packages/symfony-static-dumper/config/config.yaml
@@ -8,6 +8,7 @@ services:
         resource: "../src"
         exclude:
             - "../src/Exception/*"
+            - "../src/Controller/RouteFilter/*"
 
     Symplify\SmartFileSystem\Finder\FinderSanitizer: null
 

--- a/packages/symfony-static-dumper/src/Application/SymfonyStaticDumperApplication.php
+++ b/packages/symfony-static-dumper/src/Application/SymfonyStaticDumperApplication.php
@@ -6,7 +6,10 @@ namespace Symplify\SymfonyStaticDumper\Application;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\SymfonyStaticDumper\Controller\ControllerDumper;
+use Symplify\SymfonyStaticDumper\Controller\RouteFilter\RouteNameFilter;
+use Symplify\SymfonyStaticDumper\Controller\RouteFilter\WildcardFilter;
 use Symplify\SymfonyStaticDumper\FileSystem\AssetsCopier;
+use function count;
 
 final class SymfonyStaticDumperApplication
 {
@@ -35,13 +38,19 @@ final class SymfonyStaticDumperApplication
         $this->assetsCopier = $assetsCopier;
     }
 
-    public function run(string $publicDirectory, string $outputDirectory): void
+    public function dumpControllers(string $outputDirectory, $routeNames = []): void
     {
-        $this->controllerDumper->dump($outputDirectory);
+        $this->controllerDumper->dump(
+            $outputDirectory,
+            count($routeNames) === 0 ? new WildcardFilter() : new RouteNameFilter($routeNames)
+        );
 
         $message = sprintf('Files generated to "%s"', $outputDirectory);
         $this->symfonyStyle->success($message);
+    }
 
+    public function copyAssets(string $publicDirectory, string $outputDirectory): void
+    {
         $this->assetsCopier->copyAssets($publicDirectory, $outputDirectory);
         $this->symfonyStyle->success('Assets copied');
     }

--- a/packages/symfony-static-dumper/src/Command/CopyAssetsCommand.php
+++ b/packages/symfony-static-dumper/src/Command/CopyAssetsCommand.php
@@ -13,7 +13,7 @@ use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\SymfonyStaticDumper\Application\SymfonyStaticDumperApplication;
 
-final class DumpStaticSiteCommand extends Command
+final class CopyAssetsCommand extends Command
 {
     /**
      * @var string
@@ -52,16 +52,13 @@ final class DumpStaticSiteCommand extends Command
     protected function configure(): void
     {
         $this->setName(CommandNaming::classToName(self::class));
-        $this->setDescription('Dump website to static HTML and CSS in the output directory');
+        $this->setDescription('Copy assets from public dir to the output directory');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->symfonyStyle->section('Dumping static website');
-        $this->symfonyStaticDumperApplication->dumpControllers($this->outputDirectory);
+        $this->symfonyStyle->section('Dumping assetss');
         $this->symfonyStaticDumperApplication->copyAssets($this->publicDirectory, $this->outputDirectory);
-
-        $this->symfonyStyle->note('Run local server to see the output: "php -S localhost:8001 -t output"');
 
         return ShellCode::SUCCESS;
     }

--- a/packages/symfony-static-dumper/src/Command/DumpControllersCommand.php
+++ b/packages/symfony-static-dumper/src/Command/DumpControllersCommand.php
@@ -6,20 +6,15 @@ namespace Symplify\SymfonyStaticDumper\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\SymfonyStaticDumper\Application\SymfonyStaticDumperApplication;
 
-final class DumpStaticSiteCommand extends Command
+final class DumpControllersCommand extends Command
 {
-    /**
-     * @var string
-     */
-    private $publicDirectory;
-
     /**
      * @var string
      */
@@ -37,12 +32,10 @@ final class DumpStaticSiteCommand extends Command
 
     public function __construct(
         SymfonyStaticDumperApplication $symfonyStaticDumperApplication,
-        SymfonyStyle $symfonyStyle,
-        ParameterBagInterface $parameterBag
+        SymfonyStyle $symfonyStyle
     ) {
         parent::__construct();
 
-        $this->publicDirectory = $parameterBag->get('kernel.project_dir') . '/public';
         $this->outputDirectory = getcwd() . '/output';
 
         $this->symfonyStyle = $symfonyStyle;
@@ -52,16 +45,19 @@ final class DumpStaticSiteCommand extends Command
     protected function configure(): void
     {
         $this->setName(CommandNaming::classToName(self::class));
-        $this->setDescription('Dump website to static HTML and CSS in the output directory');
+        $this->setDescription('Dump controllers to the output directory');
+        $this->addOption(
+            'route',
+            '',
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'dump only given route names, if not provided all routes are dumped'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->symfonyStyle->section('Dumping static website');
-        $this->symfonyStaticDumperApplication->dumpControllers($this->outputDirectory);
-        $this->symfonyStaticDumperApplication->copyAssets($this->publicDirectory, $this->outputDirectory);
-
-        $this->symfonyStyle->note('Run local server to see the output: "php -S localhost:8001 -t output"');
+        $this->symfonyStyle->section('Dumping Controllers');
+        $this->symfonyStaticDumperApplication->dumpControllers($this->outputDirectory, $input->getOption('route'));
 
         return ShellCode::SUCCESS;
     }

--- a/packages/symfony-static-dumper/src/Controller/ControllerDumper.php
+++ b/packages/symfony-static-dumper/src/Controller/ControllerDumper.php
@@ -55,15 +55,15 @@ final class ControllerDumper
         $this->filePathResolver = $filePathResolver;
     }
 
-    public function dump(string $outputDirectory): void
+    public function dump(string $outputDirectory, RouteFilterInterface $routeFilter): void
     {
-        $this->dumpControllerWithoutParametersContents($outputDirectory);
-        $this->dumpControllerWithParametersContents($outputDirectory);
+        $this->dumpControllerWithoutParametersContents($outputDirectory, $routeFilter);
+        $this->dumpControllerWithParametersContents($outputDirectory, $routeFilter);
     }
 
-    private function dumpControllerWithoutParametersContents($outputDirectory): void
+    private function dumpControllerWithoutParametersContents($outputDirectory, RouteFilterInterface $routeFilter): void
     {
-        $routesWithoutArguments = $this->routesProvider->provideRoutesWithoutArguments();
+        $routesWithoutArguments = $routeFilter->filter($this->routesProvider->provideRoutesWithoutArguments());
 
         $progressBar = $this->createProgressBarIfNeeded($routesWithoutArguments);
 
@@ -81,9 +81,9 @@ final class ControllerDumper
         }
     }
 
-    private function dumpControllerWithParametersContents(string $outputDirectory): void
+    private function dumpControllerWithParametersContents(string $outputDirectory, RouteFilterInterface $routeFilter): void
     {
-        $routesWithParameters = $this->routesProvider->provideRoutesWithParameters();
+        $routesWithParameters = $routeFilter->filter($this->routesProvider->provideRoutesWithParameters());
 
         foreach ($routesWithParameters as $routeName => $route) {
             $controllerWithDataProvider = $this->controllerWithDataProviderMatcher->matchRoute($route);

--- a/packages/symfony-static-dumper/src/Controller/RouteFilter/RouteNameFilter.php
+++ b/packages/symfony-static-dumper/src/Controller/RouteFilter/RouteNameFilter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Symplify\SymfonyStaticDumper\Controller\RouteFilter;
 

--- a/packages/symfony-static-dumper/src/Controller/RouteFilter/RouteNameFilter.php
+++ b/packages/symfony-static-dumper/src/Controller/RouteFilter/RouteNameFilter.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Controller\RouteFilter;
+
+use Symplify\SymfonyStaticDumper\Controller\RouteFilterInterface;
+use function array_filter;
+use function in_array;
+
+final class RouteNameFilter implements RouteFilterInterface
+{
+    /**
+     * @var string[]
+     */
+    private $routeNames;
+
+    public function __construct(array $routeNames)
+    {
+        $this->routeNames = $routeNames;
+    }
+
+    public function filter(array $routes): array
+    {
+        return array_filter(
+            $routes,
+            function (string $name): bool {
+                return in_array($name, $this->routeNames, true);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+}

--- a/packages/symfony-static-dumper/src/Controller/RouteFilter/WildcardFilter.php
+++ b/packages/symfony-static-dumper/src/Controller/RouteFilter/WildcardFilter.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Symplify\SymfonyStaticDumper\Controller\RouteFilter;
 

--- a/packages/symfony-static-dumper/src/Controller/RouteFilter/WildcardFilter.php
+++ b/packages/symfony-static-dumper/src/Controller/RouteFilter/WildcardFilter.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Controller\RouteFilter;
+
+use Symplify\SymfonyStaticDumper\Controller\RouteFilterInterface;
+
+final class WildcardFilter implements RouteFilterInterface
+{
+    public function filter(array $routes): array
+    {
+        return $routes;
+    }
+}

--- a/packages/symfony-static-dumper/src/Controller/RouteFilterInterface.php
+++ b/packages/symfony-static-dumper/src/Controller/RouteFilterInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Controller;
+
+use Symfony\Component\Routing\Route;
+
+interface RouteFilterInterface
+{
+    /**
+     * @param Route[] $routes
+     * @return Route[]
+     */
+    public function filter(array $routes): array;
+}

--- a/packages/symfony-static-dumper/src/Controller/RouteFilterInterface.php
+++ b/packages/symfony-static-dumper/src/Controller/RouteFilterInterface.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Symplify\SymfonyStaticDumper\Controller;
 

--- a/packages/symfony-static-dumper/tests/Application/AbstractSymfonyStaticDumperTestCase.php
+++ b/packages/symfony-static-dumper/tests/Application/AbstractSymfonyStaticDumperTestCase.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Tests\Application;
+
+use Nette\Utils\FileSystem;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
+use Symplify\SymfonyStaticDumper\Application\SymfonyStaticDumperApplication;
+use Symplify\SymfonyStaticDumper\Tests\TestProject\HttpKernel\TestSymfonyStaticDumperKernel;
+
+abstract class AbstractSymfonyStaticDumperTestCase extends AbstractKernelTestCase
+{
+    /**
+     * @var string
+     */
+    protected const EXPECTED_DIRECTORY = __DIR__ . '/../Fixture/expected';
+
+    /**
+     * @var string
+     */
+    protected const OUTPUT_DIRECTORY = __DIR__ . '/../temp/output';
+
+    /**
+     * @var SymfonyStaticDumperApplication
+     */
+    private $symfonyStaticDumperApplication;
+
+    protected function setUp(): void
+    {
+        FileSystem::delete(self::OUTPUT_DIRECTORY);
+    }
+
+    protected function tearDown(): void
+    {
+        FileSystem::delete(self::OUTPUT_DIRECTORY);
+    }
+
+    public function application(): SymfonyStaticDumperApplication
+    {
+        if ($this->symfonyStaticDumperApplication === null) {
+            $this->bootApplication();
+        }
+
+        return $this->symfonyStaticDumperApplication;
+    }
+
+    private function bootApplication(): void
+    {
+        $this->bootKernel(TestSymfonyStaticDumperKernel::class);
+
+        $this->symfonyStaticDumperApplication = self::$container->get(SymfonyStaticDumperApplication::class);
+
+        // disable output in tests
+        $symfonyStyle = self::$container->get(SymfonyStyle::class);
+        $symfonyStyle->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+    }
+}

--- a/packages/symfony-static-dumper/tests/Application/AbstractSymfonyStaticDumperTestCase.php
+++ b/packages/symfony-static-dumper/tests/Application/AbstractSymfonyStaticDumperTestCase.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Symplify\SymfonyStaticDumper\Tests\Application;
 

--- a/packages/symfony-static-dumper/tests/Controller/RouteFilter/RouteNameFilterTest.php
+++ b/packages/symfony-static-dumper/tests/Controller/RouteFilter/RouteNameFilterTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Tests\Controller\RouteFilter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Route;
+use Symplify\SymfonyStaticDumper\Controller\RouteFilter\RouteNameFilter;
+use function array_keys;
+
+final class RouteNameFilterTest extends TestCase
+{
+    public function testFilterOutRoutesWithoutMatchingNames(): void
+    {
+        $filter = new RouteNameFilter($routeNames = ['expected_name', 'expected_name_2']);
+
+        $filteredRouteNames = array_keys($filter->filter([
+            'not_expected_name' => new Route('/not/expected/name'),
+            'expected_name' => new Route('/expected/name'),
+            'expected_name_2' => new Route('/expected/name/2'),
+        ]));
+
+        $this->assertSame($routeNames, $filteredRouteNames);
+    }
+}

--- a/packages/symfony-static-dumper/tests/Controller/RouteFilter/RouteNameFilterTest.php
+++ b/packages/symfony-static-dumper/tests/Controller/RouteFilter/RouteNameFilterTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Symplify\SymfonyStaticDumper\Tests\Controller\RouteFilter;
 

--- a/packages/symfony-static-dumper/tests/Controller/RouteFilter/WildcardFilterTest.php
+++ b/packages/symfony-static-dumper/tests/Controller/RouteFilter/WildcardFilterTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Tests\Controller\RouteFilter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\Route;
+use Symplify\SymfonyStaticDumper\Controller\RouteFilter\WildcardFilter;
+use function array_keys;
+
+final class WildcardFilterTest extends TestCase
+{
+    public function testFilterOutRoutesWithoutMatchingNames(): void
+    {
+        $filter = new WildcardFilter();
+
+        $filteredRouteNames = array_keys(
+            $filter->filter([
+                'not_expected_name' => new Route('/not/expected/name'),
+                'expected_name' => new Route('/expected/name'),
+                'expected_name_2' => new Route('/expected/name/2'),
+            ])
+        );
+
+        $this->assertSame(['not_expected_name', 'expected_name', 'expected_name_2'], $filteredRouteNames);
+    }
+}

--- a/packages/symfony-static-dumper/tests/Controller/RouteFilter/WildcardFilterTest.php
+++ b/packages/symfony-static-dumper/tests/Controller/RouteFilter/WildcardFilterTest.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Symplify\SymfonyStaticDumper\Tests\Controller\RouteFilter;
 


### PR DESCRIPTION
Hey, 
first of all, thanks for the symfony static dumper! I hope this contribution will make it even better. 

### Context
Let me maybe start from explaining my use case to bring some context here. So I'm using symfony static dumper to generate documentation for the [set of libraries](https://aeon-php.org/) I'm working on, it's almost whole auto generated. 

I have this [folder](https://github.com/aeon-php/website/tree/1.x/sources) which holds code for the the libraries in different versions (I'm planning to keep documentation for all supported versions live)
![image](https://user-images.githubusercontent.com/1921950/87222444-f9556500-c373-11ea-8c6e-85ee7b2480da.png)

This code is loaded through [BetterReflection](https://github.com/Roave/BetterReflection) which is using [PHPParser](https://github.com/nikic/PHP-Parser) so it's even not autoloaded. 
As you can see I have here 6 different libraries (few more are still missing), the biggest one generates around 600 static pages (each class and method has it own standalone page) and it's still before first stable release. Each new minor version of each library will duplicate number of static pages. 

### Problem 
That's a lot static pages to generate and the generation takes a while even now, when new versions of each library is released I need to basically regenerate everything, including libraries that didn't change. 

### Solution 

It would be really nice for me to be able to generate only specific routes or only static assets which I might want to regenerate in case of some minor style changes. 
Possibility to generate only specific routes would let me maybe also to generate most heavy parts in parallel.

This PR is adding 2 new CLI commands that are also backward compatible with the one that already exists:

* `bin/console dump-static-site` - not affected by changes
* `bin/console dump-controllers` - new
* `bin/console copy-assets` - new

**dump-controllers** by default will dump all controllers but when option `--route` (which is optional array) is provided it will filter out all routes that does not match given names. 

**copy-assets** dumps all assets 

**bin/console dump-static-site** dumps all assets and all controllers

### Changes

In order to achieve that I had to split `SymfonyStaticDumperApplication::run` method into `SymfonyStaticDumperApplication::dumpControllers(string $outputDirectory, $routeNames = []): void` and `SymfonyStaticDumperApplication::copyAssets(string $publicDirectory, string $outputDirectory): void`. This class is marked as final but if anyone used it that change is a BC break (I can restore old method and use new methods internally to keep BC). 

`ControllerDumper::dump` method received something called `RouteFilterInterface` which has 2 implementations: 

* `WildardFilter` - accepts everything 
* `RouteNameFilter` - accepts only routes with matching names 

### Tests 

I allowed myself to introduce `AbstractSymfonyStaticDumperTestCase` which is basically bootstraping the `SymfonyStaticDumperApplication` and exposing it through `AbstractSymfonyStaticDumperTestCase::application()` method.
 
In my opinion this makes SymfonyStaticDumpeerTest class cleaner, each test intentions are more readable, but it's all a cosmetic change which I can easily revert and follow any other already taken approach 

```php
<?php 

    public function testCssIsDumped(): void
    {
        $this->application()->copyAssets(__DIR__ . '/../test_project/public', self::OUTPUT_DIRECTORY);

        // css
        $this->assertFileExists(self::OUTPUT_DIRECTORY . '/some.css');
        $this->assertFileEquals(self::EXPECTED_DIRECTORY . '/some.css', self::OUTPUT_DIRECTORY . '/some.css');
    }

    public function testRenderHtml(): void
    {
        $this->application()->dumpControllers(self::OUTPUT_DIRECTORY);

        $this->assertFileExists(self::OUTPUT_DIRECTORY . '/kedlubna/index.html');
        $this->assertFileEquals(
            self::EXPECTED_DIRECTORY . '/kedlubna/index.html',
            self::OUTPUT_DIRECTORY . '/kedlubna/index.html'
        );
    }

    public function testRenderOnlySpecificRoute(): void
    {
        $this->application()->dumpControllers(self::OUTPUT_DIRECTORY, ['kedlubna']);

        $this->assertFileExists(self::OUTPUT_DIRECTORY . '/kedlubna/index.html');
        $this->assertFileEquals(
            self::EXPECTED_DIRECTORY . '/kedlubna/index.html',
            self::OUTPUT_DIRECTORY . '/kedlubna/index.html'
        );
        $this->assertFileDoesNotExist(self::OUTPUT_DIRECTORY . '/api.json');
        $this->assertFileDoesNotExist(self::OUTPUT_DIRECTORY . '/static/index.html');
        $this->assertFileDoesNotExist(self::OUTPUT_DIRECTORY . '/index.html');
    }
```

### Summary 

It's my first contribution here, I might break some rules I wasn't ware of or my use case might not be generic enough to be merged, in that case just let me know what and how needs to be changed and I'll do my best to adjust this PR. 

Once again, thanks for Symfony Static Dumper. 

