### PR TITLE
Add a new conflict resolution

### DIFF
--- a/packages/easy-coding-standard/src/DependencyInjection/CompilerPass/ConflictingCheckersCompilerPass.php
+++ b/packages/easy-coding-standard/src/DependencyInjection/CompilerPass/ConflictingCheckersCompilerPass.php
@@ -37,6 +37,9 @@ final class ConflictingCheckersCompilerPass implements CompilerPassInterface
         ], [
             'SlevomatCodingStandard\Sniffs\TypeHints\DeclareStrictTypesSniff',
             'PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer',
+        ], [
+            'PHP_CodeSniffer\Standards\PSR12\Sniffs\Files\FileHeaderSniff',
+            'PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer',
         ],
     ];
 


### PR DESCRIPTION
- Create a conflict resolution between a PSR-12 sniff requiring a newline and a PHP-CS-Fixer rule that removes newlines