### PR TITLE
[ComposerJsonManipulator] Removing empty keys from json content before dumping to file

### DIFF
--- a/packages/composer-json-manipulator/src/FileSystem/JsonFileManager.php
+++ b/packages/composer-json-manipulator/src/FileSystem/JsonFileManager.php
@@ -76,6 +76,8 @@ final class JsonFileManager
      */
     public function encodeJsonToFileContent(array $json, array $inlineSections = []): string
     {
+        // Empty arrays may lead to bad encoding since we can't be sure whether they need to be arrays or objects.
+        $json = $this->removeEmptyKeysFromJsonArray($json);
         $jsonContent = Json::encode($json, Json::PRETTY) . StaticEolConfiguration::getEolChar();
 
         foreach ($inlineSections as $inlineSection) {
@@ -91,5 +93,22 @@ final class JsonFileManager
         }
 
         return $jsonContent;
+    }
+
+    private function removeEmptyKeysFromJsonArray(array $json): array
+    {
+        foreach ($json as $key => $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if (count($value) === 0) {
+                unset($json[$key]);
+            } else {
+                $json[$key] = $this->removeEmptyKeysFromJsonArray($value);
+            }
+        }
+
+        return $json;
     }
 }

--- a/packages/composer-json-manipulator/tests/ComposerJsonSchemaValidation/ComposerJsonSchemaValidationTest.php
+++ b/packages/composer-json-manipulator/tests/ComposerJsonSchemaValidation/ComposerJsonSchemaValidationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\ComposerJsonManipulator\Tests\ComposerJsonSchemaValidation;
+
+use Composer\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Filesystem\Filesystem;
+use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
+use Symplify\ComposerJsonManipulator\Tests\HttpKernel\ComposerJsonManipulatorKernel;
+use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
+
+class ComposerJsonSchemaValidationTest extends AbstractKernelTestCase
+{
+    /**
+     * @var JsonFileManager
+     */
+    private $jsonFileManager;
+
+    /**
+     * @var Filesystem
+     */
+    private $fileSystem;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(ComposerJsonManipulatorKernel::class);
+
+        $this->jsonFileManager = self::$container->get(JsonFileManager::class);
+        $this->fileSystem = new Filesystem();
+    }
+
+    public function testCheckEmptyKeysAreRemoved(): void
+    {
+        $sourceJsonPath = __DIR__ . '/Source/symfony-website_skeleton-composer.json';
+        $targetJsonPath = sys_get_temp_dir() . '/composer_json_manipulator_test_schema_validation.json';
+
+        $sourceJson = $this->jsonFileManager->loadFromFilePath($sourceJsonPath);
+        $this->fileSystem->dumpFile($targetJsonPath, $this->jsonFileManager->encodeJsonToFileContent($sourceJson));
+
+        $sourceJson = $this->jsonFileManager->loadFromFilePath($sourceJsonPath);
+        $targetJson = $this->jsonFileManager->loadFromFilePath($targetJsonPath);
+
+        /*
+         * Check empty keys are present in "source" but not in "target"
+         */
+        $this->assertArrayHasKey('require-dev', $sourceJson);
+        $this->assertArrayHasKey('auto-scripts', $sourceJson['scripts']);
+        $this->assertArrayNotHasKey('require-dev', $targetJson);
+        $this->assertArrayNotHasKey('auto-scripts', $targetJson['scripts']);
+
+        /*
+         * Validate composer.json schema using `composer validate`
+         */
+        $input = new ArrayInput([
+            'command' => 'validate',
+            'file' => $targetJsonPath,
+            // https://getcomposer.org/doc/03-cli.md#validate
+            '--no-check-publish' => true,
+            '--no-interaction' => true,
+            '--quiet' => true,
+        ]);
+        $application = new Application();
+        // prevent `$application->run` method from exiting the script
+        $application->setAutoExit(false);
+        $this->assertSame(
+            0,
+            $application->run($input),
+            'Dumped composer.json did not pass validation ("composer validate --no-check-publish" exited with non-zero status)'
+        );
+    }
+}

--- a/packages/composer-json-manipulator/tests/ComposerJsonSchemaValidation/Source/symfony-website_skeleton-composer.json
+++ b/packages/composer-json-manipulator/tests/ComposerJsonSchemaValidation/Source/symfony-website_skeleton-composer.json
@@ -1,0 +1,90 @@
+{
+    "name": "symfony/website-skeleton",
+    "type": "project",
+    "license": "MIT",
+    "description": "A skeleton to start a new Symfony website",
+    "require": {
+        "php": "^7.2.5",
+        "ext-ctype": "*",
+        "ext-iconv": "*",
+        "symfony/flex": "^1.3.1"
+    },
+    "flex-require": {
+        "sensio/framework-extra-bundle": "^5.1",
+        "symfony/asset": "*",
+        "symfony/console": "*",
+        "symfony/dotenv": "*",
+        "symfony/expression-language": "*",
+        "symfony/form": "*",
+        "symfony/framework-bundle": "*",
+        "symfony/http-client": "*",
+        "symfony/intl": "*",
+        "symfony/mailer": "*",
+        "symfony/mime": "*",
+        "symfony/monolog-bundle": "^3.1",
+        "symfony/notifier": "*",
+        "symfony/orm-pack": "*",
+        "symfony/process": "*",
+        "symfony/security-bundle": "*",
+        "symfony/serializer-pack": "*",
+        "symfony/string": "*",
+        "symfony/translation": "*",
+        "symfony/twig-pack": "*",
+        "symfony/validator": "*",
+        "symfony/web-link": "*",
+        "symfony/yaml": "*"
+    },
+    "require-dev": {
+    },
+    "flex-require-dev": {
+        "symfony/debug-pack": "*",
+        "symfony/maker-bundle": "^1.0",
+        "symfony/profiler-pack": "*",
+        "symfony/test-pack": "*"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
+        },
+        "sort-packages": true
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\": "tests/"
+        }
+    },
+    "replace": {
+        "paragonie/random_compat": "2.*",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php56": "*"
+    },
+    "scripts": {
+        "auto-scripts": [
+        ],
+        "post-install-cmd": [
+            "@auto-scripts"
+        ],
+        "post-update-cmd": [
+            "@auto-scripts"
+        ]
+    },
+    "conflict": {
+        "symfony/symfony": "*"
+    },
+    "extra": {
+        "symfony": {
+            "allow-contrib": false,
+            "require": "5.1.*"
+        }
+    }
+}

--- a/packages/easy-hydrator/src/ValueResolver.php
+++ b/packages/easy-hydrator/src/ValueResolver.php
@@ -41,17 +41,17 @@ final class ValueResolver
             return DateTime::from($value);
         }
 
-        $parameterType = (string) $reflectionParameter->getType();
-        if ($parameterType === 'string') {
-            return (string) $value;
-        }
+        $parameterType = $reflectionParameter->getType();
 
-        if ($parameterType === 'bool') {
-            return (bool) $value;
-        }
-
-        if ($parameterType === 'int') {
-            return (int) $value;
+        if ($parameterType !== null) {
+            switch ($parameterType->getName()) {
+                case 'string':
+                    return (string) $value;
+                case 'bool':
+                    return (bool) $value;
+                case 'int':
+                    return (int) $value;
+            }
         }
 
         return $value;


### PR DESCRIPTION
This PR fixes #2000.

I think that removing empty keys in `JsonFileManager::encodeJsonToFileContent()` should solve the problem ensuring that any dumped file gets cleaned up properly.

I also tried to create a test case but I don't know much about this topic, so I have some questions:

- I don't know if using a custom `composer.json` template would be a good idea so I used a real one from https://github.com/symfony/website-skeleton (it shows many interesting cases: empty keys, empty nested keys, custom keys, etc.), is it ok?
- I decided to validate the resulting json file using `composer validate`, but I don't know if there's a better way to run a composer command programmatically
- I used some classes from external dependecies that might not be included in the **Composer Json Manipulator** package do I need to add them? (`Composer\Console\Application`, `Symfony\Component\Filesystem\Filesystem`, etc.)

Thank you