### PR TITLE
Correct the type of the configuration.

### DIFF
--- a/packages/easy-coding-standard/config/set/symfony.php
+++ b/packages/easy-coding-standard/config/set/symfony.php
@@ -110,7 +110,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FunctionTypehintSpaceFixer::class);
 
     $services->set(SingleLineCommentStyleFixer::class)
-        ->call('configure', [['comment_types' => 'hash']]);
+        ->call('configure', [['comment_types' => ['hash']]]);
 
     $services->set(IncludeFixer::class);
 


### PR DESCRIPTION
Fixes:
```
PHP Fatal error:  Uncaught Symfony\Component\OptionsResolver\Exception\InvalidOptionsException:
 The option "comment_types" with value "hash" is expected to be of type "array", but is of type "string".
 in /path/to/project/vendor/symfony/options-resolver/OptionsResolver.php:1017
```