### PR TITLE
[ECS] Deprecate "find" command

### DIFF
--- a/packages/easy-coding-standard/src/Console/Command/FindCommand.php
+++ b/packages/easy-coding-standard/src/Console/Command/FindCommand.php
@@ -15,6 +15,9 @@ use Symplify\PackageBuilder\Composer\StaticVendorDirProvider;
 use Symplify\PackageBuilder\Console\Command\CommandNaming;
 use Symplify\PackageBuilder\Console\ShellCode;
 
+/**
+ * @deprecated Use ecs.php config instead
+ */
 final class FindCommand extends Command
 {
     /**
@@ -55,6 +58,13 @@ final class FindCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $message = sprintf(
+            'The "find" command is deprecated and will be soon removed.%sSwitch to "ecs.php" and use PHP autocomplete there.',
+            PHP_EOL
+        );
+        $this->easyCodingStandardStyle->warning($message);
+        sleep(5);
+
         $checkers = $this->checkerClassFinder->findInDirectories([
             getcwd() . '/src',
             getcwd() . '/packages',
@@ -62,7 +72,7 @@ final class FindCommand extends Command
         ]);
 
         /** @var string $name */
-        $name = $input->getArgument(self::ARGUMENT_NAME);
+        $name = (string) $input->getArgument(self::ARGUMENT_NAME);
 
         if ($name !== '') {
             $checkers = $this->filterCheckersByName($checkers, $name);


### PR DESCRIPTION
Command will removed, because the number of rule is growing very quickly and "googling" in CLI sucks.
Also we're moving to PHP configuration based on constant autocomplete: 

* https://twitter.com/rectorphp/status/1288874586084433925
* https://twitter.com/rectorphp/status/1289288283655036930

In CLI class rename change can cause head ache, e.g.

```bash
vendor/bin/ecs find array sniff

// how was it?
vendor/bin/ecs find arraySniff
```

With PHP, the PHPStorm IDE is here for you much advanced with fuzzy search

```php
<?php

declare(strict_types=1);

use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
use Symplify\EasyCodingStandard\Configuration\Option;

return static function (ContainerConfigurator $containerConfigurator): void {
    $services = $containerConfigurator->services();
    $services->set(Array<IDE autocompelte any class instantly>);
};
```
