### PR TITLE
[ECS] Warn about deprecated YAML syntax

### DIFF
--- a/packages/easy-coding-standard/bin/ecs
+++ b/packages/easy-coding-standard/bin/ecs
@@ -28,6 +28,9 @@ $autoloadIncluder->autoloadProjectAutoloaderFile('/../../autoload.php');
 $autoloadIncluder->includeDependencyOrRepositoryVendorAutoloadIfExists();
 $autoloadIncluder->includePhpCodeSnifferAutoloadIfNotInPharAndInitliazeTokens();
 
+$symfonyStyleFactory = new SymfonyStyleFactory();
+$symfonyStyle = $symfonyStyleFactory->create();
+
 # 2. create container
 try {
     $configFileInfos = [];
@@ -58,6 +61,24 @@ try {
 
     $environment = 'prod' . md5(computeConfigHash($configFileInfos) . random_int(1, 100000));
     $configFileInfos = shiftInputConfigAsLast($configFileInfos, $inputConfigFileInfo);
+
+    // report YAML deprecated configs
+    foreach ($configFileInfos as $configFileInfo) {
+        if (! in_array($configFileInfo->getSuffix(), ['yml', 'yaml'], true)) {
+            continue;
+        }
+
+        $warning = sprintf(
+            'You are using YAML format in "%s" config.%sIt is deprecated and will be removed in next ECS 9. Switch to PHP format as soon as possible with "%s"',
+            $configFileInfo->getRelativeFilePathFromCwd(),
+            PHP_EOL,
+            'https://github.com/migrify/config-transformer'
+        );
+
+        $symfonyStyle->warning($warning);
+
+        sleep(3);
+    }
 
     $easyCodingStandardKernel = new EasyCodingStandardKernel($environment, InputDetector::isDebug());
     if ($configFileInfos !== []) {


### PR DESCRIPTION
The ECS is moving from YAML to PHP syntax. This should prepare whole community in time, 
before YAML is dropped and make use of upcoming PHP features.

![warning](https://user-images.githubusercontent.com/924196/89576286-605d2100-d82f-11ea-9ec8-892df181f6ec.png)

## How to Migrate in 1 minute?

```bash
composer require migrify/config-transformer --dev
vendor/bin/config-transformer switch-format -i yaml -o php ecs.yaml
composer remove migrify/config-transformer
```

If any problem appears, create an issue in
https://github.com/migrify/config-transformer

<br>

We'll do what we can to resolve it promptly so you can migrate safely

<br>

Thank you for patience and cooperation with this big step :+1:  
We belieive it will bring solid ground for more lazy features like `SetList::PSR_12` name autocompletes