### PR TITLE
[MonorepoBuilder] Add asterisk split support

### DIFF
--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -13,17 +13,6 @@ use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateBranchAliasReleaseWorke
 use Symplify\MonorepoBuilder\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $services = $containerConfigurator->services();
-
-    # release workers - in order to execute
-    $services->set(SetCurrentMutualDependenciesReleaseWorker::class);
-    $services->set(AddTagToChangelogReleaseWorker::class);
-    $services->set(TagVersionReleaseWorker::class);
-    $services->set(PushTagReleaseWorker::class);
-    $services->set(SetNextMutualDependenciesReleaseWorker::class);
-    $services->set(UpdateBranchAliasReleaseWorker::class);
-    $services->set(PushNextDevReleaseWorker::class);
-
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::DATA_TO_REMOVE, [
         'require' => [
@@ -36,24 +25,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     ]);
 
     $parameters->set(Option::DIRECTORIES_TO_REPOSITORIES, [
-        # @todo add patern matching 'packages/*' => 'git@github.com:symplify/*.git',
-        'packages/autowire-array-parameter' => 'git@github.com:symplify/autowire-array-parameter.git',
-        'packages/auto-bind-parameter' => 'git@github.com:symplify/auto-bind-parameter.git',
-        'packages/smart-file-system' => 'git@github.com:symplify/smart-file-system.git',
-        'packages/package-builder' => 'git@github.com:symplify/package-builder.git',
-        'packages/easy-coding-standard' => 'git@github.com:symplify/easy-coding-standard.git',
-        'packages/easy-coding-standard-tester' => 'git@github.com:symplify/easy-coding-standard-tester.git',
-        'packages/coding-standard' => 'git@github.com:symplify/coding-standard.git',
-        'packages/changelog-linker' => 'git@github.com:symplify/changelog-linker.git',
-        'packages/monorepo-builder' => 'git@github.com:symplify/monorepo-builder.git',
-        'packages/phpstan-extensions' => 'git@github.com:symplify/phpstan-extensions.git',
-        'packages/flex-loader' => 'git@github.com:symplify/flex-loader.git',
-        'packages/autodiscovery' => 'git@github.com:symplify/autodiscovery.git',
-        'packages/set-config-resolver' => 'git@github.com:symplify/set-config-resolver.git',
-        'packages/symfony-static-dumper' => 'git@github.com:symplify/symfony-static-dumper.git',
-        'packages/composer-json-manipulator' => 'git@github.com:symplify/composer-json-manipulator.git',
-        'packages/easy-hydrator' => 'git@github.com:symplify/easy-hydrator.git',
-        'packages/console-color-diff' => 'git@github.com:symplify/console-color-diff.git',
-        'packages/easy-testing' => 'git@github.com:symplify/easy-testing.git',
+        'packages/*' => 'git@github.com:symplify/*.git',
     ]);
+
+    $services = $containerConfigurator->services();
+
+    # release workers - in order to execute
+    $services->set(SetCurrentMutualDependenciesReleaseWorker::class);
+    $services->set(AddTagToChangelogReleaseWorker::class);
+    $services->set(TagVersionReleaseWorker::class);
+    $services->set(PushTagReleaseWorker::class);
+    $services->set(SetNextMutualDependenciesReleaseWorker::class);
+    $services->set(UpdateBranchAliasReleaseWorker::class);
+    $services->set(PushNextDevReleaseWorker::class);
 };

--- a/packages/monorepo-builder/README.md
+++ b/packages/monorepo-builder/README.md
@@ -171,8 +171,29 @@ use Symplify\MonorepoBuilder\ValueObject\Option;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::DIRECTORIES_TO_REPOSITORIES, [
-        __DIR__ . '/packages/PackageBuilder' => 'git@github.com:Symplify/PackageBuilder.git',
-        __DIR__ . '/packagages/MonorepoBuilder' => 'git@github.com:Symplify/MonorepoBuilder.git',
+        __DIR__ . '/packages/package-builder' => 'git@github.com:symplify/package-builder.git',
+        __DIR__ . '/packagages/monorepo-builder' => 'git@github.com:symplify/monorepo-builder.git',
+        __DIR__ . '/packagages/coding-standard' => 'git@github.com:symplify/coding-standard.git',
+    ]);
+};
+```
+
+Or even simpler:
+
+```php
+<?php
+
+// monorepo-builder.php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::DIRECTORIES_TO_REPOSITORIES, [
+        __DIR__ . '/packages/*' => 'git@github.com:symplify/*.git',
     ]);
 };
 ```
@@ -211,8 +232,8 @@ use Symplify\MonorepoBuilder\ValueObject\Option;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::DIRECTORIES_TO_REPOSITORIES, [
-        __DIR__ . '/packages/PackageBuilder' => 'file:///home/developer/git/PackageBuilder.git',
-        __DIR__ . '/packagages/MonorepoBuilder' => 'file:///home/developer/git/MonorepoBuilder.git',
+        __DIR__ . '/packages/package-builder' => 'file:///home/developer/git/package-builder.git',
+        __DIR__ . '/packagages/monorepo-builder' => 'file:///home/developer/git/monorepo-builder.git',
     ]);
 };
 ```
@@ -222,8 +243,8 @@ After that you can test the result:
 ```bash
 vendor/bin/monorepo-builder split
 cd /tmp
-git clone /home/developer/git/PackageBuilder.git
-cd PackageBuilder
+git clone /home/developer/git/package-builder.git
+cd package-builder
 git log
 ```
 

--- a/packages/monorepo-builder/packages/split/src/PackageToRepositorySplitter.php
+++ b/packages/monorepo-builder/packages/split/src/PackageToRepositorySplitter.php
@@ -59,7 +59,7 @@ final class PackageToRepositorySplitter
     }
 
     /**
-     * @param mixed[] $splitConfig
+     * @param array<string, string> $splitConfig
      * @throws PackageToRepositorySplitException
      * @throws DirectoryNotFoundException
      */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -180,3 +180,6 @@ parameters:
         - '#Cannot call method getRealPath\(\) on Symplify\\SmartFileSystem\\SmartFileInfo\|null#'
         - '#Parameter \#1 \$endPath of method Symfony\\Component\\Filesystem\\Filesystem\:\:makePathRelative\(\) expects string, string\|false given#'
 
+        -
+            message: '#Parameter \#1 \$haystack of static method Nette\\Utils\\Strings\:\:after\(\) expects string, string\|false given#'
+            path: 'packages/monorepo-builder/packages/split/src/Command/SplitCommand.php'


### PR DESCRIPTION
# Before

```php
    $parameters->set(Option::DIRECTORIES_TO_REPOSITORIES, [
        'packages/autowire-array-parameter' => 'git@github.com:symplify/autowire-array-parameter.git',
        'packages/auto-bind-parameter' => 'git@github.com:symplify/auto-bind-parameter.git',
        'packages/smart-file-system' => 'git@github.com:symplify/smart-file-system.git',
        'packages/package-builder' => 'git@github.com:symplify/package-builder.git',
        'packages/easy-coding-standard' => 'git@github.com:symplify/easy-coding-standard.git',
        'packages/easy-coding-standard-tester' => 'git@github.com:symplify/easy-coding-standard-tester.git',
        'packages/coding-standard' => 'git@github.com:symplify/coding-standard.git',
        'packages/changelog-linker' => 'git@github.com:symplify/changelog-linker.git',
        'packages/monorepo-builder' => 'git@github.com:symplify/monorepo-builder.git',
        'packages/phpstan-extensions' => 'git@github.com:symplify/phpstan-extensions.git',
        'packages/flex-loader' => 'git@github.com:symplify/flex-loader.git',
        'packages/autodiscovery' => 'git@github.com:symplify/autodiscovery.git',
        'packages/set-config-resolver' => 'git@github.com:symplify/set-config-resolver.git',
        'packages/symfony-static-dumper' => 'git@github.com:symplify/symfony-static-dumper.git',
        'packages/composer-json-manipulator' => 'git@github.com:symplify/composer-json-manipulator.git',
        'packages/easy-hydrator' => 'git@github.com:symplify/easy-hydrator.git',
        'packages/console-color-diff' => 'git@github.com:symplify/console-color-diff.git',
        'packages/easy-testing' => 'git@github.com:symplify/easy-testing.git',
    ]);
```

---

# After

```php
    $parameters->set(Option::DIRECTORIES_TO_REPOSITORIES, [
        'packages/*' => 'git@github.com:symplify/*.git',
    ]);
```