### PR TITLE
do not show output if not needed

### DIFF
--- a/packages/monorepo-builder/packages/release/src/Process/ProcessRunner.php
+++ b/packages/monorepo-builder/packages/release/src/Process/ProcessRunner.php
@@ -71,9 +71,6 @@ final class ProcessRunner
     private function reportResult(Process $process): void
     {
         if ($process->isSuccessful()) {
-            $trimmedOutput = trim($process->getOutput());
-            $this->symfonyStyle->writeln($trimmedOutput);
-
             return;
         }
 


### PR DESCRIPTION
This actually respects previous behavior

Fix after  #2080