### PR TITLE
Move dependencies to require-dev

### DIFF
--- a/packages/coding-standard/composer.json
+++ b/packages/coding-standard/composer.json
@@ -10,16 +10,16 @@
         "squizlabs/php_codesniffer": "^3.5",
         "friendsofphp/php-cs-fixer": "^2.16",
         "phpstan/phpstan": "^0.12.36",
-        "symplify/smart-file-system": "^8.3",
         "symplify/package-builder": "^8.3",
-        "symplify/autowire-array-parameter": "^8.3",
-        "symplify/phpstan-extensions": "^8.3"
+        "symplify/autowire-array-parameter": "^8.3"
     },
     "require-dev": {
         "nette/application": "^3.0",
         "nette/bootstrap": "^3.0",
         "symplify/easy-coding-standard-tester": "^8.3",
         "symplify/package-builder": "^8.3",
+        "symplify/phpstan-extensions": "^8.3",
+        "symplify/smart-file-system": "^8.3",
         "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {


### PR DESCRIPTION
As far as I can tell `symplify/smart-file-system` and `symplify/phpstan-extensions` are only used in tests.

I found out by wondering why is `symplify/phpstan-extensions` installed to my project even though don't want it. (The rules there seem incorrect to me.) `composer why` revealed that it was a dependency of `coding-standard`.