### PR TITLE
Fix heredoc/nowdoc formatter regex for multiple code snippet in single php file

### DIFF
--- a/packages/easy-coding-standard/src/Formatter/AbstractPHPFormatter.php
+++ b/packages/easy-coding-standard/src/Formatter/AbstractPHPFormatter.php
@@ -63,17 +63,15 @@ abstract class AbstractPHPFormatter
             $fileInfo->getContents(),
             static::PHP_CODE_SNIPPET,
             function ($match) use ($noStrictTypesDeclaration): string {
-                $fixedContent = rtrim(
-                    $this->fixContent($match['content'], $noStrictTypesDeclaration),
-                    PHP_EOL
-                ) . PHP_EOL;
-                return rtrim($match['opening'], PHP_EOL) . PHP_EOL . $fixedContent . $match['closing'];
+                $fixedContent = trim($this->fixContent($match['content'], $noStrictTypesDeclaration));
+                return trim($match['opening']) . PHP_EOL . $fixedContent . PHP_EOL . trim($match['closing']);
             }
         );
     }
 
     protected function fixContent(string $content, bool $noStrictTypesDeclaration): string
     {
+        $content = trim($content);
         $key = md5($content);
 
         /** @var string $file */

--- a/packages/easy-coding-standard/src/Formatter/AbstractPHPFormatter.php
+++ b/packages/easy-coding-standard/src/Formatter/AbstractPHPFormatter.php
@@ -63,13 +63,15 @@ abstract class AbstractPHPFormatter
             $fileInfo->getContents(),
             static::PHP_CODE_SNIPPET,
             function ($match) use ($noStrictTypesDeclaration): string {
-                $fixedContent = trim($this->fixContent($match['content'], $noStrictTypesDeclaration));
-                return trim($match['opening']) . PHP_EOL . $fixedContent . PHP_EOL . trim($match['closing']);
+                $fixedContent = $this->fixContent($match['content'], $noStrictTypesDeclaration);
+                return rtrim($match['opening'], PHP_EOL) . PHP_EOL
+                    . $fixedContent
+                    . ltrim($match['closing'], PHP_EOL);
             }
         );
     }
 
-    protected function fixContent(string $content, bool $noStrictTypesDeclaration): string
+    private function fixContent(string $content, bool $noStrictTypesDeclaration): string
     {
         $content = trim($content);
         $key = md5($content);
@@ -111,7 +113,7 @@ abstract class AbstractPHPFormatter
             $fileContent = substr($fileContent, 6);
         }
 
-        return $fileContent;
+        return rtrim($fileContent, PHP_EOL) . PHP_EOL;
     }
 
     private function skipStrictTypesDeclaration(bool $noStrictTypesDeclaration): void

--- a/packages/easy-coding-standard/src/HeredocNowdoc/HeredocNowdocPHPCodeFormatter.php
+++ b/packages/easy-coding-standard/src/HeredocNowdoc/HeredocNowdocPHPCodeFormatter.php
@@ -15,5 +15,5 @@ final class HeredocNowdocPHPCodeFormatter extends AbstractPHPFormatter
      * @see https://regex101.com/r/SZr0X5/4
      * @var string
      */
-    protected const PHP_CODE_SNIPPET = '#(?<opening><<<(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+|(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+)(?<content>[^\3|\4]+\n)(?<closing>(\s+)?\3|\4)#ms';
+    protected const PHP_CODE_SNIPPET = '#(?<opening><<<(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+|(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+)(?<content>[^\3|\4]+\n)(?<closing>(\s+)?\3|\4)#msU';
 }

--- a/packages/easy-coding-standard/src/HeredocNowdoc/HeredocNowdocPHPCodeFormatter.php
+++ b/packages/easy-coding-standard/src/HeredocNowdoc/HeredocNowdocPHPCodeFormatter.php
@@ -12,7 +12,7 @@ use Symplify\EasyCodingStandard\Formatter\AbstractPHPFormatter;
 final class HeredocNowdocPHPCodeFormatter extends AbstractPHPFormatter
 {
     /**
-     * @see https://regex101.com/r/SZr0X5/4
+     * @see https://regex101.com/r/SZr0X5/12
      * @var string
      */
     protected const PHP_CODE_SNIPPET = '#(?<opening><<<(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+)(?<content>[^\3|\4]+)(?<closing>(\s+)?\3|\4)#msU';

--- a/packages/easy-coding-standard/src/HeredocNowdoc/HeredocNowdocPHPCodeFormatter.php
+++ b/packages/easy-coding-standard/src/HeredocNowdoc/HeredocNowdocPHPCodeFormatter.php
@@ -15,5 +15,5 @@ final class HeredocNowdocPHPCodeFormatter extends AbstractPHPFormatter
      * @see https://regex101.com/r/SZr0X5/4
      * @var string
      */
-    protected const PHP_CODE_SNIPPET = '#(?<opening><<<(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+|(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+)(?<content>[^\3|\4]+\n)(?<closing>(\s+)?\3|\4)#msU';
+    protected const PHP_CODE_SNIPPET = '#(?<opening><<<(\'?([A-Z]+)\'?|\"?([A-Z]+)\"?)\s+)(?<content>[^\3|\4]+)(?<closing>(\s+)?\3|\4)#msU';
 }


### PR DESCRIPTION
using `msU` fix the multiple snippet, but seems cause a bug on trimming code:

```php
There was 1 failure:

1) Symplify\EasyCodingStandard\Tests\HeredocNowdoc\HeredocNowdocPHPCodeFormatterTest::test with data set #5 (Symplify\SmartFileSystem\SmartFileInfo Object (...))
packages/easy-coding-standard/tests/HeredocNowdoc/Fixture/trim.php.inc
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
     public function getDefinition(): string
     {
         return <<<'PHP'
+
 <?php
 class Definition
 {
     public function getResult(): array
     {
-        return ['test' => 'data'];
+        return array('test' => 'data');
     }
 }
+
 PHP;
     }
 }
 '

/Users/samsonasik/www/symplify/packages/easy-coding-standard/tests/HeredocNowdoc/HeredocNowdocPHPCodeFormatterTest.php:51
```