### PR TITLE
[ChangelogLinker] Fix url resolving for repos in SSH format

### DIFF
--- a/packages/changelog-linker/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/changelog-linker/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -8,7 +8,6 @@ use Nette\Utils\Strings;
 use Symplify\ChangelogLinker\Exception\Git\InvalidGitRemoteException;
 use function parse_url;
 use function pathinfo;
-use function rtrim;
 use function sprintf;
 use function str_replace;
 use const PATHINFO_DIRNAME;
@@ -47,7 +46,7 @@ final class GithubRepositoryFromRemoteResolver
 
         // turn SSH format to "https"
         if (Strings::startsWith($url, 'git@')) {
-            $url = rtrim($url, '.git');
+            $url = Strings::substring($url, 0, -4);
             $url = str_replace(':', '/', $url);
             $url = Strings::substring($url, Strings::length('git@'));
 

--- a/packages/changelog-linker/tests/Github/GithubRepositoryFromRemoteResolverTest.php
+++ b/packages/changelog-linker/tests/Github/GithubRepositoryFromRemoteResolverTest.php
@@ -41,6 +41,7 @@ final class GithubRepositoryFromRemoteResolverTest extends TestCase
         yield ['https://www.my-company.com/symplify/symplify.git', 'https://www.my-company.com/symplify/symplify'];
         yield ['https://gitlab.com/my-group/my-user/my-repo.git', 'https://gitlab.com/my-group/my-user/my-repo'];
         yield ['https://git/user/project.git', 'https://git/user/project'];
+        yield ['git@github.com:space/low-orbit.git', 'https://github.com/space/low-orbit'];
     }
 
     public function testInvalid(): void


### PR DESCRIPTION
`rtrim` second parameter is a list, the order of characters doesn't matter.

Example: 

```php 
$url = 'git@github.com:space/low-orbit.git';
rtrim($url, '.git'); // "git@github.com:space/low-orb"
```

The correct output should be `git@github.com:space/low-orbit`. I fixed that.