### PR TITLE
Correct when to pluralise word

### DIFF
--- a/packages/easy-coding-standard/src/Console/Output/ConsoleOutputFormatter.php
+++ b/packages/easy-coding-standard/src/Console/Output/ConsoleOutputFormatter.php
@@ -179,7 +179,7 @@ final class ConsoleOutputFormatter implements OutputFormatterInterface
                 'Found %d error%s that need%s to be fixed manually.',
                 $errorCount,
                 $errorCount === 1 ? '' : 's',
-                $errorCount === 1 ? '' : 's'
+                $errorCount === 1 ? 's' : ''
             );
             $this->easyCodingStandardStyle->error($errorMessage);
         }


### PR DESCRIPTION
```diff
- Found 1 error that need to be fixed manually.
- Found 2 errors that needs to be fixed manually.
+ Found 1 error that needs to be fixed manually.
+ Found 2 errors that need to be fixed manually.
```