### PR TITLE
Bug fix: NoProtectedElementInFinalClassRule::isPropertyExistInTraits() should check namespaced class name

### DIFF
--- a/packages/coding-standard/src/Rules/NoProtectedElementInFinalClassRule.php
+++ b/packages/coding-standard/src/Rules/NoProtectedElementInFinalClassRule.php
@@ -71,7 +71,7 @@ final class NoProtectedElementInFinalClassRule extends AbstractManyNodeTypeRule
     private function isPropertyExistInTraits(Class_ $class, string $propertyName): bool
     {
         /** @var Identifier $name */
-        $name = $class->name;
+        $name = $class->namespacedName;
         $usedTraits = class_uses($name->toString());
         foreach ($usedTraits as $trait) {
             $r = new ReflectionClass($trait);

--- a/packages/coding-standard/tests/Rules/NoProtectedElementInFinalClassRule/NoProtectedElementInFinalClassRuleTest.php
+++ b/packages/coding-standard/tests/Rules/NoProtectedElementInFinalClassRule/NoProtectedElementInFinalClassRuleTest.php
@@ -28,6 +28,7 @@ final class NoProtectedElementInFinalClassRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SomeFinalClassWithNoPropertyAndNoMethod.php', []];
         yield [__DIR__ . '/Fixture/SomeFinalClassWithNoProtectedProperty.php', []];
         yield [__DIR__ . '/Fixture/SomeFinalClassWithNoProtectedMethod.php', []];
+        yield [__DIR__ . '/Fixture/SomeFinalClassUsesTrait.php', []];
 
         yield [
             __DIR__ . '/Fixture/SomeFinalClassWithProtectedProperty.php',
@@ -42,11 +43,6 @@ final class NoProtectedElementInFinalClassRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/SomeFinalClassWithProtectedPropertyAndProtectedMethod.php',
             [[NoProtectedElementInFinalClassRule::ERROR_MESSAGE, 9],
                 [NoProtectedElementInFinalClassRule::ERROR_MESSAGE, 11], ],
-        ];
-
-        yield [
-            __DIR__ . '/Fixture/SomeFinalClassUsesTrait.php',
-            [[NoProtectedElementInFinalClassRule::ERROR_MESSAGE, 11]],
         ];
     }
 


### PR DESCRIPTION
Like in the `isMethodExistInTraits()`, the `isPropertyExistInTraits()` should check namespaced class name as well.