### PR TITLE
Typo fix: NoAbstactMethodRule should be NoAbstractMethodRule

### DIFF
--- a/packages/coding-standard/config/symplify-rules.neon
+++ b/packages/coding-standard/config/symplify-rules.neon
@@ -66,7 +66,7 @@ services:
         tags: [phpstan.rules.rule]
 
     -
-        class: Symplify\CodingStandard\Rules\NoAbstactMethodRule
+        class: Symplify\CodingStandard\Rules\NoAbstractMethodRule
         tags: [phpstan.rules.rule]
 
     -

--- a/packages/coding-standard/docs/phpstan_rules.md
+++ b/packages/coding-standard/docs/phpstan_rules.md
@@ -312,7 +312,7 @@ final class SomeFinalClassWithProtectedPropertyAndProtectedMethod
 
 ## Use Contract or Service over Abstract Method
 
-- class: [`NoAbstactMethodRule`](../src/Rules/NoAbstactMethodRule.php)
+- class: [`NoAbstractMethodRule`](../src/Rules/NoAbstractMethodRule.php)
 
 ```php
 abstract class SomeClass

--- a/packages/coding-standard/src/Rules/NoAbstractMethodRule.php
+++ b/packages/coding-standard/src/Rules/NoAbstractMethodRule.php
@@ -12,7 +12,7 @@ use PHPStan\Rules\Rule;
 /**
  * @see \Symplify\CodingStandard\Tests\Rules\NoAbstractMethodRule\NoAbstractMethodRuleTest
  */
-final class NoAbstactMethodRule implements Rule
+final class NoAbstractMethodRule implements Rule
 {
     /**
      * @var string

--- a/packages/coding-standard/tests/Rules/NoAbstractMethodRule/NoAbstractMethodRuleTest.php
+++ b/packages/coding-standard/tests/Rules/NoAbstractMethodRule/NoAbstractMethodRuleTest.php
@@ -7,7 +7,7 @@ namespace Symplify\CodingStandard\Tests\Rules\NoAbstractMethodRule;
 use Iterator;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
-use Symplify\CodingStandard\Rules\NoAbstactMethodRule;
+use Symplify\CodingStandard\Rules\NoAbstractMethodRule;
 
 final class NoAbstractMethodRuleTest extends RuleTestCase
 {
@@ -21,12 +21,12 @@ final class NoAbstractMethodRuleTest extends RuleTestCase
 
     public function provideData(): Iterator
     {
-        yield [__DIR__ . '/Fixture/SomeAbstractMethod.php', [[NoAbstactMethodRule::ERROR_MESSAGE, 9]]];
+        yield [__DIR__ . '/Fixture/SomeAbstractMethod.php', [[NoAbstractMethodRule::ERROR_MESSAGE, 9]]];
         yield [__DIR__ . '/Fixture/SkipNonAbstractMethod.php', []];
     }
 
     protected function getRule(): Rule
     {
-        return new NoAbstactMethodRule();
+        return new NoAbstractMethodRule();
     }
 }


### PR DESCRIPTION
Missing `r` in 'Abstract'.