### PR TITLE
[MB] Fix absolute to relative paths

### DIFF
--- a/packages/monorepo-builder/packages/split/src/FileSystem/DirectoryToRepositoryProvider.php
+++ b/packages/monorepo-builder/packages/split/src/FileSystem/DirectoryToRepositoryProvider.php
@@ -8,6 +8,7 @@ use Nette\Utils\Strings;
 use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\SmartFileSystem\FileSystemGuard;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
  * @see \Symplify\MonorepoBuilder\Split\Tests\FileSystem\DirectoryToRepositoryProvider\DirectoryToRepositoryProviderTest
@@ -62,7 +63,7 @@ final class DirectoryToRepositoryProvider
             );
         }
 
-        return $resolvedDirectoriesToRepository;
+        return $this->relativizeDirectories($resolvedDirectoriesToRepository);
     }
 
     private function ensureDirectoryExists(string $directory): void
@@ -94,5 +95,23 @@ final class DirectoryToRepositoryProvider
         }
 
         return $resolvedDirectoriesToRepository;
+    }
+
+    /**
+     * @param array<string, string> $directoriesToRepositories
+     * @return array<string, string>
+     */
+    private function relativizeDirectories(array $directoriesToRepositories): array
+    {
+        $relativeDirectoriesToRepositories = [];
+
+        foreach ($directoriesToRepositories as $directory => $repository) {
+            $directoryFileInfo = new SmartFileInfo($directory);
+            $relativeDirectory = $directoryFileInfo->getRelativeFilePathFromCwd();
+
+            $relativeDirectoriesToRepositories[$relativeDirectory] = $repository;
+        }
+
+        return $relativeDirectoriesToRepositories;
     }
 }

--- a/packages/monorepo-builder/packages/split/tests/FileSystem/DirectoryToRepositoryProvider/DirectoryToRepositoryProviderTest.php
+++ b/packages/monorepo-builder/packages/split/tests/FileSystem/DirectoryToRepositoryProvider/DirectoryToRepositoryProviderTest.php
@@ -10,6 +10,7 @@ use Symplify\MonorepoBuilder\Split\FileSystem\DirectoryToRepositoryProvider;
 use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DirectoryToRepositoryProviderTest extends AbstractKernelTestCase
 {
@@ -47,15 +48,20 @@ final class DirectoryToRepositoryProviderTest extends AbstractKernelTestCase
     public function provideData(): Iterator
     {
         yield [[], []];
+
+        $smartFileInfo = new SmartFileInfo(__DIR__ . '/Fixture/existing-package');
+        $relativeFilePathFromCwd = $smartFileInfo->getRelativeFilePathFromCwd();
+
         yield [[
             __DIR__ . '/Fixture/existing-package' => 'some.git',
         ], [
-            __DIR__ . '/Fixture/existing-package' => 'some.git',
+            $relativeFilePathFromCwd => 'some.git',
         ]];
+
         yield [[
             __DIR__ . '/Fixture/existing-*' => 'some/*.git',
         ], [
-            __DIR__ . '/Fixture/existing-package' => 'some/package.git',
+            $relativeFilePathFromCwd => 'some/package.git',
         ]];
     }
 }


### PR DESCRIPTION
Absolute paths cannot be used on git split, see https://travis-ci.com/github/rectorphp/rector/jobs/397778613

This will make them relative