### PR TITLE
improve CheckUsedNamespacedNameOnClassNodeRule

### DIFF
--- a/packages/coding-standard/config/symplify-rules.neon
+++ b/packages/coding-standard/config/symplify-rules.neon
@@ -207,14 +207,6 @@ services:
     -
         class: Symplify\CodingStandard\Rules\CheckUsedNamespacedNameOnClassNodeRule
         tags: [phpstan.rules.rule]
-        arguments:
-            excludedClasses:
-                - 'Symplify\CodingStandard\Rules\CheckRequiredAbstractKeywordForClassNameStartWithAbstractRule'
-                - 'Symplify\CodingStandard\Rules\ClassNameRespectsParentSuffixRule'
-                - 'Symplify\CodingStandard\Rules\ForbiddenParentClassRule'
-                - 'Symplify\CodingStandard\Rules\NoClassWithStaticMethodWithoutStaticNameRule'
-                - 'Symplify\CodingStandard\Rules\PreferredClassRule'
-                - 'Symplify\CodingStandard\Rules\SeeAnnotationToTestRule'
 
     -
         class: Symplify\CodingStandard\Rules\ForbiddenAssignInifRule

--- a/packages/coding-standard/config/symplify-rules.neon
+++ b/packages/coding-standard/config/symplify-rules.neon
@@ -214,9 +214,7 @@ services:
                 - 'Symplify\CodingStandard\Rules\ForbiddenParentClassRule'
                 - 'Symplify\CodingStandard\Rules\NoClassWithStaticMethodWithoutStaticNameRule'
                 - 'Symplify\CodingStandard\Rules\PreferredClassRule'
-                - 'Symplify\CodingStandard\Rules\PrefixAbstractClassRule'
                 - 'Symplify\CodingStandard\Rules\SeeAnnotationToTestRule'
-                - 'Symplify\CodingStandard\Rules\NoSuffixValueObjectClassRule'
 
     -
         class: Symplify\CodingStandard\Rules\ForbiddenAssignInifRule

--- a/packages/coding-standard/src/Rules/AbstractSymplifyRule.php
+++ b/packages/coding-standard/src/Rules/AbstractSymplifyRule.php
@@ -93,7 +93,7 @@ abstract class AbstractSymplifyRule implements Rule, ManyNodeRuleInterface
     {
         $node = $node->getAttribute(PHPStanAttributeKey::PARENT);
         while ($node) {
-            if (is_a($node, $nodeClass, true)) {
+            if (is_a($node, $nodeClass, true) && $node instanceof Node) {
                 return $node;
             }
 

--- a/packages/coding-standard/src/Rules/AbstractSymplifyRule.php
+++ b/packages/coding-standard/src/Rules/AbstractSymplifyRule.php
@@ -89,6 +89,20 @@ abstract class AbstractSymplifyRule implements Rule, ManyNodeRuleInterface
         return null;
     }
 
+    public function getFirstParentByType(Node $node, string $nodeClass): ?Node
+    {
+        $node = $node->getAttribute(PHPStanAttributeKey::PARENT);
+        while ($node) {
+            if (is_a($node, $nodeClass, true)) {
+                return $node;
+            }
+
+            $node = $node->getAttribute(PHPStanAttributeKey::PARENT);
+        }
+
+        return null;
+    }
+
     private function shouldSkipNode(Node $node): bool
     {
         foreach ($this->getNodeTypes() as $nodeType) {

--- a/packages/coding-standard/src/Rules/CheckRequiredAbstractKeywordForClassNameStartWithAbstractRule.php
+++ b/packages/coding-standard/src/Rules/CheckRequiredAbstractKeywordForClassNameStartWithAbstractRule.php
@@ -34,9 +34,9 @@ final class CheckRequiredAbstractKeywordForClassNameStartWithAbstractRule extend
      */
     public function process(Node $node, Scope $scope): array
     {
-        /** @var Identifier $name */
-        $name = $node->name;
-        $className = ucfirst($name->toString());
+        /** @var Identifier $shortClassName */
+        $shortClassName = $node->name;
+        $className = ucfirst($shortClassName->toString());
 
         if ($node->isAbstract() || ! Strings::startsWith($className, 'Abstract')) {
             return [];

--- a/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
+++ b/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
@@ -86,7 +86,7 @@ final class CheckUsedNamespacedNameOnClassNodeRule extends AbstractSymplifyRule
     private function isVariableNamedShortClassName(Variable $variable): bool
     {
         $assign = $variable->getAttribute(PHPStanAttributeKey::PARENT)
-                           ->getAttribute(PHPStanAttributeKey::PARENT);
+            ->getAttribute(PHPStanAttributeKey::PARENT);
 
         if (! $assign instanceof Assign) {
             return false;

--- a/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
+++ b/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
@@ -71,7 +71,8 @@ final class CheckUsedNamespacedNameOnClassNodeRule extends AbstractSymplifyRule
             return [];
         }
 
-        $class = $this->getClassOfVariable($node);
+        /** @var Class_|null $class */
+        $class = $this->getFirstParentByType($node, Class_::class);
         if ($class === null) {
             return [];
         }
@@ -85,15 +86,8 @@ final class CheckUsedNamespacedNameOnClassNodeRule extends AbstractSymplifyRule
 
     private function isVariableNamedShortClassName(Variable $variable): bool
     {
-        $assign = $variable->getAttribute(PHPStanAttributeKey::PARENT);
-        while ($assign) {
-            if ($assign instanceof Assign) {
-                break;
-            }
-
-            $assign = $assign->getAttribute(PHPStanAttributeKey::PARENT);
-        }
-
+        /** @var Assign|null $assign */
+        $assign = $this->getFirstParentByType($variable, Assign::class);
         if (! $assign instanceof Assign) {
             return false;
         }
@@ -109,19 +103,5 @@ final class CheckUsedNamespacedNameOnClassNodeRule extends AbstractSymplifyRule
         }
 
         return true;
-    }
-
-    private function getClassOfVariable(Variable $variable): ?Class_
-    {
-        $class = $variable->getAttribute(PHPStanAttributeKey::PARENT);
-        while ($class) {
-            if ($class instanceof Class_) {
-                return $class;
-            }
-
-            $class = $class->getAttribute(PHPStanAttributeKey::PARENT);
-        }
-
-        return null;
     }
 }

--- a/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
+++ b/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
@@ -98,11 +98,13 @@ final class CheckUsedNamespacedNameOnClassNodeRule extends AbstractSymplifyRule
             return false;
         }
 
-        /** @var Identifier $identifierClassName */
-        $identifierClassName = $assign->var->name;
-        $variableClassName = (string) $identifierClassName;
+        /** @var Variable $classNameVariable */
+        $classNameVariable = $assign->var;
+        /** @var Identifier $classNameIdentifier */
+        $classNameIdentifier = $classNameVariable->name;
+        $classNameVariableName = (string) $classNameIdentifier;
 
-        if ($variableClassName !== 'shortClassName') {
+        if ($classNameVariableName !== 'shortClassName') {
             return false;
         }
 

--- a/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
+++ b/packages/coding-standard/src/Rules/CheckUsedNamespacedNameOnClassNodeRule.php
@@ -85,8 +85,14 @@ final class CheckUsedNamespacedNameOnClassNodeRule extends AbstractSymplifyRule
 
     private function isVariableNamedShortClassName(Variable $variable): bool
     {
-        $assign = $variable->getAttribute(PHPStanAttributeKey::PARENT)
-            ->getAttribute(PHPStanAttributeKey::PARENT);
+        $assign = $variable->getAttribute(PHPStanAttributeKey::PARENT);
+        while ($assign) {
+            if ($assign instanceof Assign) {
+                break;
+            }
+
+            $assign = $assign->getAttribute(PHPStanAttributeKey::PARENT);
+        }
 
         if (! $assign instanceof Assign) {
             return false;

--- a/packages/coding-standard/src/Rules/ClassNameRespectsParentSuffixRule.php
+++ b/packages/coding-standard/src/Rules/ClassNameRespectsParentSuffixRule.php
@@ -67,7 +67,8 @@ final class ClassNameRespectsParentSuffixRule extends AbstractSymplifyRule
      */
     public function process(Node $node, Scope $scope): array
     {
-        if ($node->name === null) {
+        $shortClassName = $node->name;
+        if ($shortClassName === null) {
             return [];
         }
 
@@ -79,7 +80,7 @@ final class ClassNameRespectsParentSuffixRule extends AbstractSymplifyRule
             return $this->processParent($node, $node->extends);
         }
 
-        $class = (string) $node->name;
+        $class = (string) $shortClassName;
         foreach ($node->implements as $implement) {
             $errorMessages = $this->processClassNameAndShort($class, $implement->getLast());
             if ($errorMessages !== []) {
@@ -117,12 +118,12 @@ final class ClassNameRespectsParentSuffixRule extends AbstractSymplifyRule
      */
     private function processParent(Class_ $class, Name $parentClassName): array
     {
-        $className = (string) $class->name;
+        $shortClassName = (string) $class->name;
 
         $parentShortClassName = $parentClassName->getLast();
         $parentShortClassName = $this->resolveExpectedSuffix($parentShortClassName);
 
-        return $this->processClassNameAndShort($className, $parentShortClassName);
+        return $this->processClassNameAndShort($shortClassName, $parentShortClassName);
     }
 
     /**

--- a/packages/coding-standard/src/Rules/ForbiddenParentClassRule.php
+++ b/packages/coding-standard/src/Rules/ForbiddenParentClassRule.php
@@ -66,7 +66,8 @@ final class ForbiddenParentClassRule extends AbstractSymplifyRule
      */
     public function process(Node $node, Scope $scope): array
     {
-        if ($node->name === null) {
+        $shortClassName = $node->name;
+        if ($shortClassName === null) {
             return [];
         }
 

--- a/packages/coding-standard/src/Rules/NoClassWithStaticMethodWithoutStaticNameRule.php
+++ b/packages/coding-standard/src/Rules/NoClassWithStaticMethodWithoutStaticNameRule.php
@@ -64,7 +64,8 @@ final class NoClassWithStaticMethodWithoutStaticNameRule extends AbstractSymplif
     public function process(Node $node, Scope $scope): array
     {
         // skip anonymous class
-        if ($node->name === null) {
+        $shortClassName = $node->name;
+        if ($shortClassName === null) {
             return [];
         }
 
@@ -72,7 +73,7 @@ final class NoClassWithStaticMethodWithoutStaticNameRule extends AbstractSymplif
             return [];
         }
 
-        $classShortName = (string) $node->name;
+        $classShortName = (string) $shortClassName;
         if ($this->shouldSkipClassName($classShortName)) {
             return [];
         }

--- a/packages/coding-standard/src/Rules/PreferredClassRule.php
+++ b/packages/coding-standard/src/Rules/PreferredClassRule.php
@@ -78,11 +78,11 @@ final class PreferredClassRule extends AbstractSymplifyRule
         }
 
         if ($newClass instanceof Class_) {
-            $className = $newClass->name;
-            if ($className === null) {
+            $shortClassName = $newClass->name;
+            if ($shortClassName === null) {
                 return [];
             }
-            $className = $className->toString();
+            $className = $shortClassName->toString();
         } else {
             $className = (string) $newClass;
         }

--- a/packages/coding-standard/src/Rules/SeeAnnotationToTestRule.php
+++ b/packages/coding-standard/src/Rules/SeeAnnotationToTestRule.php
@@ -118,7 +118,8 @@ final class SeeAnnotationToTestRule extends AbstractSymplifyRule
 
     private function matchClassReflection(Class_ $class): ?ClassReflection
     {
-        if ($class->name === null) {
+        $shortClassName = $class->name;
+        if ($shortClassName === null) {
             return null;
         }
 

--- a/packages/coding-standard/tests/Rules/CheckUsedNamespacedNameOnClassNodeRule/CheckUsedNamespacedNameOnClassNodeRuleTest.php
+++ b/packages/coding-standard/tests/Rules/CheckUsedNamespacedNameOnClassNodeRule/CheckUsedNamespacedNameOnClassNodeRuleTest.php
@@ -25,6 +25,7 @@ final class CheckUsedNamespacedNameOnClassNodeRuleTest extends AbstractServiceAw
         yield [__DIR__ . '/Fixture/UsedNamespacedClass.php', []];
         yield [__DIR__ . '/Fixture/NotClassVariable.php', []];
         yield [__DIR__ . '/Fixture/SkippedClass.php', []];
+        yield [__DIR__ . '/Fixture/SkippedVariableNamedShortClassName.php', []];
         yield [__DIR__ . '/Fixture/UsedNameOfClass.php', [[CheckUsedNamespacedNameOnClassNodeRule::ERROR_MESSAGE, 14]]];
     }
 

--- a/packages/coding-standard/tests/Rules/CheckUsedNamespacedNameOnClassNodeRule/Fixture/SkippedVariableNamedShortClassName.php
+++ b/packages/coding-standard/tests/Rules/CheckUsedNamespacedNameOnClassNodeRule/Fixture/SkippedVariableNamedShortClassName.php
@@ -11,7 +11,7 @@ final class SkippedVariableNamedShortClassName
 {
     public function process(Class_ $class, Scope $scope): array
     {
-        $shortClassName = $class->name;
+        $shortClassName = (string) $class->name;
 
         return [];
     }

--- a/packages/coding-standard/tests/Rules/CheckUsedNamespacedNameOnClassNodeRule/Fixture/SkippedVariableNamedShortClassName.php
+++ b/packages/coding-standard/tests/Rules/CheckUsedNamespacedNameOnClassNodeRule/Fixture/SkippedVariableNamedShortClassName.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Rules\CheckUsedNamespacedNameOnClassNodeRule\Fixture;
+
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+
+final class SkippedVariableNamedShortClassName
+{
+    public function process(Class_ $class, Scope $scope): array
+    {
+        $shortClassName = $class->name;
+
+        return [];
+    }
+}


### PR DESCRIPTION
- [x] Added check to skip if variable is named `shortClassName`