### PR TITLE
Use DIRECTORY_SEPARATOR constant instead of `/`

### DIFF
--- a/packages/coding-standard/src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php
+++ b/packages/coding-standard/src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php
@@ -84,6 +84,6 @@ final class CheckNotTestsNamespaceOutsideTestsDirectoryRule extends AbstractSymp
 
     private function isInTestsDirectory(Scope $scope): bool
     {
-        return Strings::contains($scope->getFile(), '/tests/');
+        return Strings::contains($scope->getFile(), DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR);
     }
 }


### PR DESCRIPTION
On Windows `CheckNotTestsNamespaceOutsideTestsDirectoryRule` wouldn't have worked as inteded.