### PR TITLE
[EasyHydrator] fix missing ParameterTypeRecognizer dependencies

### DIFF
--- a/packages/easy-hydrator/composer.json
+++ b/packages/easy-hydrator/composer.json
@@ -5,6 +5,8 @@
     "type": "symfony-bundle",
     "require": {
         "php": ">=7.2",
+        "phpstan/phpdoc-parser": "^0.4.9",
+        "rector/simple-php-doc-parser": "^0.8.21",
         "symfony/cache": "^4.4|^5.1",
         "symfony/config": "^4.4|^5.1",
         "symfony/dependency-injection": "^4.4|^5.1",


### PR DESCRIPTION
Fix missing dependencies for [ParameterTypeRecognizer](https://github.com/symplify/symplify/blob/master/packages/easy-hydrator/src/ParameterTypeRecognizer.php)