### PR TITLE
[EasyHydrator] ObjectTypeCaster fix indexed array of objects

### DIFF
--- a/packages/easy-hydrator/src/TypeCaster/ObjectTypeCaster.php
+++ b/packages/easy-hydrator/src/TypeCaster/ObjectTypeCaster.php
@@ -54,12 +54,9 @@ final class ObjectTypeCaster implements TypeCasterInterface
             return $this->createObject($className, $value, $classConstructorValuesResolver);
         }
 
-        $objects = [];
-        foreach ($value as $objectData) {
-            $objects[] = $this->createObject($className, $objectData, $classConstructorValuesResolver);
-        }
-
-        return $objects;
+        return array_map(function ($objectData) use ($className, $classConstructorValuesResolver) {
+            return $this->createObject($className, $objectData, $classConstructorValuesResolver);
+        }, $value);
     }
 
     public function getPriority(): int

--- a/packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php
+++ b/packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php
@@ -197,6 +197,11 @@ final class ArrayToValueObjectHydratorTest extends AbstractKernelTestCase
                         'name' => 'Jane Doe 1',
                     ],
                 ],
+                'indexedPersons' => [
+                    'HOMER' => [
+                        'name' => 'Homer',
+                    ],
+                ],
             ],
             [
                 'persons' => [
@@ -205,6 +210,11 @@ final class ArrayToValueObjectHydratorTest extends AbstractKernelTestCase
                     ],
                     [
                         'name' => 'Jane Doe 2',
+                    ],
+                ],
+                'indexedPersons' => [
+                    'HOMER' => [
+                        'name' => 'Homer',
                     ],
                 ],
             ],
@@ -220,6 +230,11 @@ final class ArrayToValueObjectHydratorTest extends AbstractKernelTestCase
 
             $this->assertCount(2, $persons);
             $this->assertContainsOnlyInstancesOf(Person::class, $persons);
+
+            $indexedPersons = $personsCollection->getIndexedPersons();
+            $this->assertCount(1, $indexedPersons);
+            $this->assertArrayHasKey('HOMER', $indexedPersons);
+            $this->assertContainsOnlyInstancesOf(Person::class, $indexedPersons);
         }
     }
 

--- a/packages/easy-hydrator/tests/Fixture/PersonsCollection.php
+++ b/packages/easy-hydrator/tests/Fixture/PersonsCollection.php
@@ -10,11 +10,18 @@ final class PersonsCollection
     private $persons;
 
     /**
-     * @param Person[] $persons
+     * @var array<string, Person>
      */
-    public function __construct(array $persons)
+    private $indexedPersons;
+
+    /**
+     * @param Person[] $persons
+     * @param array<string, Person> $indexedPersons
+     */
+    public function __construct(array $persons, array $indexedPersons)
     {
         $this->persons = $persons;
+        $this->indexedPersons = $indexedPersons;
     }
 
     /**
@@ -23,5 +30,13 @@ final class PersonsCollection
     public function getPersons(): array
     {
         return $this->persons;
+    }
+
+    /**
+     * @return array<string, Person>
+     */
+    public function getIndexedPersons(): array
+    {
+        return $this->indexedPersons;
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -337,6 +337,11 @@ parameters:
                 - packages/easy-testing/src/PHPUnit/Behavior/DirectoryAssertableTrait.php # 32
                 - packages/easy-testing/src/PHPUnit/Behavior/DirectoryAssertableTrait.php # 85
                 - packages/easy-testing/src/PHPUnit/Behavior/DirectoryAssertableTrait.php # 91
+                - packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php # 234
+                - packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php # 234
+                - packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php # 235
+                - packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php # 236
+                - packages/easy-hydrator/tests/ArrayToValueObjectHydratorTest.php # 237
 
         -
             message: '#SymfonyStyle usage is unneeded for only newline, write, and/or writeln, use PHP_EOL and concatenation instead#'


### PR DESCRIPTION
Allow use indexed arrays, eg.:

```json
{
	"permissions": {
		"article" : {
			"create": false,
			"read": true,
			"update": false,
			"delete": false
		},
		"category" : {
			"create": false,
			"read": true,
			"update": false,
			"delete": false
		}
	}
}
```