### PR TITLE
[PHPStanRules] Improve CheckTypehintCallerTypeRule : skip non private and multiple usages

### DIFF
--- a/packages/phpstan-rules/src/Rules/CheckTypehintCallerTypeRule.php
+++ b/packages/phpstan-rules/src/Rules/CheckTypehintCallerTypeRule.php
@@ -170,23 +170,24 @@ CODE_SAMPLE
             return [];
         }
 
+        /** @var ClassMethod|null $classMethod */
+        $classMethod = $currentClass->getMethod($methodCallName);
+        if (! $classMethod instanceof ClassMethod) {
+            return [];
+        }
+
+        if (! $classMethod->isPrivate()) {
+            return [];
+        }
+
+        /** @var Param[] $params */
+        $params = $classMethod->getParams();
+
         foreach ($args as $position => $arg) {
             if (! $this->areNodesEqual($instanceof->expr, $arg->value)) {
                 continue;
             }
 
-            /** @var ClassMethod|null $classMethod */
-            $classMethod = $currentClass->getMethod($methodCallName);
-            if (! $classMethod instanceof ClassMethod) {
-                return [];
-            }
-
-            if (! $classMethod->isPrivate()) {
-                return [];
-            }
-
-            /** @var Param[] $params */
-            $params = $classMethod->getParams();
             $validateParam = $this->validateParam($params, $position, $class);
             if ($validateParam === []) {
                 continue;

--- a/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/CheckTypehintCallerTypeRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/CheckTypehintCallerTypeRuleTest.php
@@ -27,6 +27,8 @@ final class CheckTypehintCallerTypeRuleTest extends AbstractServiceAwareRuleTest
         yield [__DIR__ . '/Fixture/SkipNoArgs.php', []];
         yield [__DIR__ . '/Fixture/SkipAlreadyCorrectType.php', []];
         yield [__DIR__ . '/Fixture/SkipMayOverrideArg.php', []];
+        yield [__DIR__ . '/Fixture/SkipMultipleUsed.php', []];
+        yield [__DIR__ . '/Fixture/SkipNotPrivate.php', []];
         yield [__DIR__ . '/Fixture/Fixture.php', [
             [sprintf(CheckTypehintCallerTypeRule::ERROR_MESSAGE, 1, MethodCall::class), 15],
         ]];

--- a/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/Fixture/SkipMultipleUsed.php
+++ b/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/Fixture/SkipMultipleUsed.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\CheckTypehintCallerTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+
+class SkipMultipleUsed
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+            $this->isCheck($node);
+        }
+
+        if ($node instanceof PropertyFetch) {
+            $this->isCheck($node);
+        }
+    }
+
+    private function isCheck(Node $node)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/Fixture/SkipNotPrivate.php
+++ b/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/Fixture/SkipNotPrivate.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\CheckTypehintCallerTypeRule\Fixture;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+
+class SkipNotPrivate
+{
+    public function run(Node $node)
+    {
+        if ($node instanceof MethodCall) {
+            $this->isCheckNotPrivate($node);
+        }
+    }
+
+    public function isCheckNotPrivate(Node $node)
+    {
+    }
+}


### PR DESCRIPTION
Non private can be used outside/derived class, while multiple usecase can make the following case:

```php
if ($var instanceof PropertyFetch) {
      $this->call($var);
}

if ($var instanceof MethodCall) {
      $this->call($var);
}
```

as noted at https://github.com/rectorphp/rector/pull/4727/files#r532124867