### PR TITLE
Drop support for ref() and inline()

### DIFF
--- a/packages/autodiscovery/config/config.php
+++ b/packages/autodiscovery/config/config.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
 use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 use Symplify\SmartFileSystem\SmartFileSystem;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -33,5 +33,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SymfonyStyleFactory::class);
 
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 };

--- a/packages/changelog-linker/config/config.php
+++ b/packages/changelog-linker/config/config.php
@@ -11,7 +11,7 @@ use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
 use Symplify\PackageBuilder\Yaml\ParametersMerger;
 use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\SmartFileSystem;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
@@ -44,7 +44,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SymfonyStyleFactory::class);
 
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 
     $services->set(Client::class);
 

--- a/packages/composer-json-manipulator/config/config.php
+++ b/packages/composer-json-manipulator/config/config.php
@@ -8,7 +8,7 @@ use Symplify\ComposerJsonManipulator\ValueObject\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\PackageBuilder\Reflection\PrivatesCaller;
 use Symplify\SmartFileSystem\SmartFileSystem;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
@@ -28,5 +28,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(PrivatesCaller::class);
 
     $services->set(ParameterProvider::class)
-        ->args([ref(ContainerInterface::class)]);
+        ->args([service(ContainerInterface::class)]);
 };

--- a/packages/console-color-diff/config/config.php
+++ b/packages/console-color-diff/config/config.php
@@ -6,7 +6,7 @@ use SebastianBergmann\Diff\Differ;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\PackageBuilder\Console\Style\SymfonyStyleFactory;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -22,5 +22,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(SymfonyStyleFactory::class);
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 };

--- a/packages/console-package-builder/tests/DependencyInjection/CompilerPass/config/command_config.php
+++ b/packages/console-package-builder/tests/DependencyInjection/CompilerPass/config/command_config.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\ConsolePackageBuilder\Tests\DependencyInjection\CompilerPass\Source\SomeCommand;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -18,5 +18,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(SomeCommand::class);
 
     $services->set(Application::class)
-        ->call('add', [ref(SomeCommand::class)]);
+        ->call('add', [service(SomeCommand::class)]);
 };

--- a/packages/easy-coding-standard/config/services.php
+++ b/packages/easy-coding-standard/config/services.php
@@ -16,7 +16,7 @@ use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 use Symplify\SmartFileSystem\Finder\SmartFinder;
 use Symplify\SmartFileSystem\SmartFileSystem;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/services/services_cache.php');
@@ -48,13 +48,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(SymfonyStyleFactory::class);
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 
     $services->set(EasyCodingStandardStyle::class)
-        ->factory([ref(EasyCodingStandardStyleFactory::class), 'create']);
+        ->factory([service(EasyCodingStandardStyleFactory::class), 'create']);
 
     $services->set(WhitespacesFixerConfig::class)
-        ->factory([ref(WhitespacesFixerConfigFactory::class), 'create']);
+        ->factory([service(WhitespacesFixerConfigFactory::class), 'create']);
 
     $services->set(NoCheckersLoaderReporter::class);
 };

--- a/packages/easy-coding-standard/packages/changed-files-detector/config/services.php
+++ b/packages/easy-coding-standard/packages/changed-files-detector/config/services.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Symfony\Component\Cache\Adapter\Psr16Adapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(TagAwareAdapter::class)
         ->args([
-            '$itemsPool' => ref(Psr16Adapter::class),
-            '$tagsPool' => ref(Psr16Adapter::class),
+            '$itemsPool' => service(Psr16Adapter::class),
+            '$tagsPool' => service(Psr16Adapter::class),
         ]);
 };

--- a/packages/markdown-diff/config/config.php
+++ b/packages/markdown-diff/config/config.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symplify\MarkdownDiff\Diff\Output\CompleteUnifiedDiffOutputBuilderFactory;
 use Symplify\MarkdownDiff\Differ\MarkdownDiffer;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -24,13 +24,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     // markdown
     $services->set('markdownDiffOutputBuilder', UnifiedDiffOutputBuilder::class)
-        ->factory([ref(CompleteUnifiedDiffOutputBuilderFactory::class), 'create']);
+        ->factory([service(CompleteUnifiedDiffOutputBuilderFactory::class), 'create']);
 
     $services->set('markdownDiffer', Differ::class)
-        ->arg('$outputBuilder', ref('markdownDiffOutputBuilder'));
+        ->arg('$outputBuilder', service('markdownDiffOutputBuilder'));
 
     $services->set(MarkdownDiffer::class)
-        ->arg('$markdownDiffer', ref('markdownDiffer'));
+        ->arg('$markdownDiffer', service('markdownDiffer'));
 
     $services->set(PrivatesAccessor::class);
 };

--- a/packages/phpstan-rules/composer.json
+++ b/packages/phpstan-rules/composer.json
@@ -26,6 +26,7 @@
         }
     },
     "autoload-dev": {
+        "files": ["packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Source/Namespaced.php"],
         "psr-4": {
             "Symplify\\PHPStanRules\\Tests\\": "tests",
             "Symplify\\PHPStanRules\\ObjectCalisthenics\\Tests\\": "packages/object-calisthenics/tests",

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/Functions/Namespaced.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/Functions/Namespaced.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture\Functions;
+
+function namespaced(): string {
+    return 'something';
+}

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/Functions/Namespaced.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/Functions/Namespaced.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture\Functions;
-
-function namespaced(): string {
-    return 'something';
-}

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipNamespacedFunction.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipNamespacedFunction.php
@@ -4,16 +4,27 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture;
 
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 final class SkipNamespacedFunction
 {
     public function something()
     {
-        $this->process(ref('reference'));
+        $this->process($this->getReferenceConfigurator());
     }
 
     private function process(\Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator $ref)
     {
+    }
+
+    private function getReferenceConfigurator(): ReferenceConfigurator
+    {
+        if (function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service')) {
+            return service('reference');
+        }
+
+        return ref('reference');
     }
 }

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipNamespacedFunction.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipNamespacedFunction.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture;
 
-use function \Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture\Functions\namespaced;
+use function Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Source\some_function;
 
 final class SkipNamespacedFunction
 {
     public function something(): void
     {
-        $this->process(namespaced());
+        $this->process(some_function());
     }
 
     private function process(string $ref)

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipNamespacedFunction.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipNamespacedFunction.php
@@ -4,27 +4,16 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture;
 
-use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function \Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture\Functions\namespaced;
 
 final class SkipNamespacedFunction
 {
-    public function something()
+    public function something(): void
     {
-        $this->process($this->getReferenceConfigurator());
+        $this->process(namespaced());
     }
 
-    private function process(\Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator $ref)
+    private function process(string $ref)
     {
-    }
-
-    private function getReferenceConfigurator(): ReferenceConfigurator
-    {
-        if (function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\service')) {
-            return service('reference');
-        }
-
-        return ref('reference');
     }
 }

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Source/Namespaced.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Source/Namespaced.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Source;
+
+function some_function(): string {
+    return 'something';
+}

--- a/packages/static-detector/config/config.php
+++ b/packages/static-detector/config/config.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\StaticDetector\NodeTraverser\StaticCollectNodeTraverser;
 use Symplify\StaticDetector\NodeTraverser\StaticCollectNodeTraverserFactory;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -22,11 +22,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->exclude([__DIR__ . '/../src/ValueObject', __DIR__ . '/../src/HttpKernel/StaticDetectorKernel.php']);
 
     $services->set(StaticCollectNodeTraverser::class)
-        ->factory([ref(StaticCollectNodeTraverserFactory::class), 'create']);
+        ->factory([service(StaticCollectNodeTraverserFactory::class), 'create']);
 
     $services->set(ParserFactory::class);
     $services->set(Parser::class)
-        ->factory([ref(ParserFactory::class), 'create'])
+        ->factory([service(ParserFactory::class), 'create'])
         ->arg('$kind', ParserFactory::PREFER_PHP7);
 
     $services->set(ParameterProvider::class);

--- a/packages/symfony-php-config/src/ValueObjectInliner.php
+++ b/packages/symfony-php-config/src/ValueObjectInliner.php
@@ -9,9 +9,8 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\InlineServiceConfi
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator;
 use Symplify\SymfonyPhpConfig\Reflection\ArgumentAndParameterFactory;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\inline;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 final class ValueObjectInliner
 {
@@ -30,10 +29,10 @@ final class ValueObjectInliner
         $argumentValues = self::resolveArgumentValues($reflectionClass, $object);
 
         $servicesConfigurator->set($className)
-            ->factory([ref(ArgumentAndParameterFactory::class), 'create'])
+            ->factory([service(ArgumentAndParameterFactory::class), 'create'])
             ->args([$className, $argumentValues, $propertyValues]);
 
-        return ref($className);
+        return service($className);
     }
 
     /**
@@ -114,13 +113,7 @@ final class ValueObjectInliner
         $className = $reflectionClass->getName();
         $argumentValues = self::resolveArgumentValues($reflectionClass, $object);
 
-        if (function_exists('Symfony\Component\DependencyInjection\Loader\Configurator\inline_service')) {
-            // Symfony 5.1+
-            $inlineServiceConfigurator = inline_service($className);
-        } else {
-            // Symfony 5.0-
-            $inlineServiceConfigurator = inline($className);
-        }
+        $inlineServiceConfigurator = inline_service($className);
 
         if ($argumentValues !== []) {
             $inlineServiceConfigurator->args($argumentValues);

--- a/packages/symfony-route-usage/config/config.php
+++ b/packages/symfony-route-usage/config/config.php
@@ -11,7 +11,7 @@ use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 use Symplify\SmartFileSystem\Finder\SmartFinder;
 use Symplify\SmartFileSystem\SmartFileSystem;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
@@ -30,7 +30,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(SymfonyStyleFactory::class);
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 
     $services->set(SchemaTool::class);
 

--- a/packages/symfony-route-usage/tests/config/config_test.php
+++ b/packages/symfony-route-usage/tests/config/config_test.php
@@ -9,7 +9,7 @@ use Symfony\Component\Routing\Router;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Security;
 use Symplify\SymfonyRouteUsage\Tests\Routing\RouterFactory;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/packages/*');
@@ -22,10 +22,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->alias(CacheInterface::class, Psr16Cache::class);
 
     $services->set(Security::class)
-        ->args([ref('service_container')]);
+        ->args([service('service_container')]);
 
     $services->set(RouterFactory::class);
     $services->set(Router::class)
-        ->factory([ref(RouterFactory::class), 'create']);
+        ->factory([service(RouterFactory::class), 'create']);
     $services->alias(RouterInterface::class, Router::class);
 };

--- a/packages/symfony-static-dumper/config/config.php
+++ b/packages/symfony-static-dumper/config/config.php
@@ -10,7 +10,7 @@ use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 use Symplify\SmartFileSystem\Finder\SmartFinder;
 use Symplify\SmartFileSystem\SmartFileSystem;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -27,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(SymfonyStyleFactory::class);
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 
     $services->set(SmartFileSystem::class);
     $services->set(SmartFinder::class);

--- a/packages/symplify-kernel/config/common-config.php
+++ b/packages/symplify-kernel/config/common-config.php
@@ -18,7 +18,7 @@ use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 use Symplify\SmartFileSystem\Finder\SmartFinder;
 use Symplify\SmartFileSystem\SmartFileSystem;
 use Symplify\SymplifyKernel\Console\ConsoleApplicationFactory;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -31,7 +31,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // symfony style
     $services->set(SymfonyStyleFactory::class);
     $services->set(SymfonyStyle::class)
-        ->factory([ref(SymfonyStyleFactory::class), 'create']);
+        ->factory([service(SymfonyStyleFactory::class), 'create']);
 
     // filesystem
     $services->set(FinderSanitizer::class);
@@ -41,7 +41,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FileSystemFilter::class);
 
     $services->set(ParameterProvider::class)
-        ->args([ref(ContainerInterface::class)]);
+        ->args([service(ContainerInterface::class)]);
 
     $services->set(PrivatesAccessor::class);
 

--- a/packages/template-checker/config/config.php
+++ b/packages/template-checker/config/config.php
@@ -7,7 +7,7 @@ use PhpParser\Parser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -23,7 +23,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // php-parser
     $services->set(ParserFactory::class);
     $services->set(Parser::class)
-        ->factory([ref(ParserFactory::class), 'create'])
+        ->factory([service(ParserFactory::class), 'create'])
         ->args([ParserFactory::PREFER_PHP7]);
 
     $services->set(Standard::class);

--- a/packages/vendor-patches/config/config.php
+++ b/packages/vendor-patches/config/config.php
@@ -6,7 +6,7 @@ use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\PackageBuilder\Composer\VendorDirProvider;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -26,7 +26,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(Differ::class)
         ->args([
-            '$outputBuilder' => ref(UnifiedDiffOutputBuilder::class),
+            '$outputBuilder' => service(UnifiedDiffOutputBuilder::class),
         ]);
 
     $services->set(VendorDirProvider::class);


### PR DESCRIPTION
[Symfony deprecated](https://github.com/symfony/dependency-injection/blob/5.x/CHANGELOG.md#510) `ref()` and `inline()` dependency injection functions were deprecated since symfony/dependency-injection 5.1. 

Because Symplify requires symfony/dependency-injection as ^5.1, there is no reason to not drop legacy functions.