### PR TITLE
[MonorepoBuilder] Allow passing base json data to packages-json

### DIFF
--- a/packages/monorepo-builder/src/Command/PackagesJsonCommand.php
+++ b/packages/monorepo-builder/src/Command/PackagesJsonCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Command;
 
 use Nette\Utils\Json;
+use Nette\Utils\JsonException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -18,6 +19,11 @@ final class PackagesJsonCommand extends AbstractSymplifyCommand
      * @var string
      */
     private const NAMES = 'names';
+
+    /**
+     * @var string
+     */
+    private const BASE_DATA = 'base-data';
 
     /**
      * @var PackageJsonProvider
@@ -35,15 +41,24 @@ final class PackagesJsonCommand extends AbstractSymplifyCommand
     {
         $this->setDescription('Provides packages in json format. Useful for GitHub Actions Workflow');
         $this->addOption(self::NAMES, null, InputOption::VALUE_NONE, 'Return package names');
+        $this->addOption(self::BASE_DATA, null, InputOption::VALUE_REQUIRED, 'Base json data to append to. Example: {"php-version":["7.4","8.0"]}');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $names = (bool) $input->getOption(self::NAMES);
+        $baseData = (string) $input->getOption(self::BASE_DATA);
+        try {
+            $base = Json::decode($baseData ?: "[]", Json::FORCE_ARRAY);
+        } catch (JsonException $jsonException) {
+            $this->symfonyStyle->error('Could not decode base json data. Please make you provided valid json.');
+
+            return ShellCode::ERROR;
+        }
 
         $data = $names ? $this->packageJsonProvider->createPackageNames() : $this->packageJsonProvider->createPackagePaths();
 
-        $json = Json::encode($data);
+        $json = Json::encode($base + $data);
         $this->symfonyStyle->writeln($json);
 
         return ShellCode::SUCCESS;


### PR DESCRIPTION
This allows for running something like this:
```
./bin/monorepo-builder packages-json --base-data='{"php-version": ["7.4", "8.0"]}'
```

It will then create a matrix with php-version and package-path.

Fixes #2578