### PR TITLE
[EasyCI] Add php-json command to provide currently support PHP versions

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -56,6 +56,6 @@ jobs:
             -
                 uses: "ramsey/composer-install@v1"
                 with:
-                    composer-options: "--ignore-platform-reqs"
+                    composer-options: "--ignore-platform-req php"
 
             -   run: ${{ matrix.actions.run }}

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -29,6 +29,10 @@ jobs:
                         run: composer validate --strict
 
                     -
+                        name: Easy CI php-json
+                        run: packages/easy-ci/bin/easy-ci php-json
+
+                    -
                         name: Binary File Run
                         run: |
                             # test run bin files

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -29,10 +29,6 @@ jobs:
                         run: composer validate --strict
 
                     -
-                        name: Easy CI php-json
-                        run: packages/easy-ci/bin/easy-ci php-json
-
-                    -
                         name: Binary File Run
                         run: |
                             # test run bin files

--- a/.github/workflows/cron_generate_changenlog.yaml
+++ b/.github/workflows/cron_generate_changenlog.yaml
@@ -29,7 +29,7 @@ jobs:
             -
                 uses: "ramsey/composer-install@v1"
                 with:
-                    composer-options: "--ignore-platform-reqs"
+                    composer-options: "--ignore-platform-req php"
 
             -
                 name: Generate Changelog

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -33,9 +33,7 @@ jobs:
             # composer install cache - https://github.com/ramsey/composer-install
             -
                 if: "matrix.php == 7.3"
-                uses: "ramsey/composer-install@v1"
-                with:
-                    dependency-versions: "lowest"
+                run: composer update  --no-progress --ansi --prefer-lowest
 
             -
                 if: "matrix.php < 8"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -45,6 +45,6 @@ jobs:
                 if: "matrix.php >= 8"
                 uses: "ramsey/composer-install@v1"
                 with:
-                    composer-options: "--ignore-platform-reqs"
+                    composer-options: "--ignore-platform-req php"
 
             -   run: vendor/bin/phpunit

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -8,13 +8,41 @@ env:
     COMPOSER_ROOT_VERSION: "dev-master"
 
 jobs:
+    provide_php_versions_json:
+        runs-on: ubuntu-latest
+
+        steps:
+            # git clone + use PHP + composer install
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.4
+
+            -   run: composer install --no-progress --ansi
+
+            -
+                # to see the output
+                run: packages/easy-ci/bin/easy-ci php-versions-json
+
+            # here we create the json, we need the "id:" so we can use it in "outputs" bellow
+
+            -
+                id: php-versions-json
+                run: echo "::set-output name=matrix::$(packages/easy-ci/bin/easy-ci php-versions-json)"
+
+        # here, we save the result of this 1st phase to the "outputs"
+        outputs:
+            matrix: ${{ steps.php-versions-json.outputs.matrix }}
+
     unit_tests:
+        needs: provide_php_versions_json
+
         runs-on: ubuntu-latest
 
         strategy:
             fail-fast: false
             matrix:
-                php: ['7.3', '7.4', '8.0']
+                php: ${{ fromJson(needs.provide_php_versions_json.outputs.matrix) }}
 
         name: PHP ${{ matrix.php }} tests
 
@@ -36,7 +64,7 @@ jobs:
                 run: composer update  --no-progress --ansi --prefer-lowest
 
             -
-                if: "matrix.php < 8"
+                if: "matrix.php == 7.4"
                 uses: "ramsey/composer-install@v1"
 
             -
@@ -45,4 +73,5 @@ jobs:
                 with:
                     composer-options: "--ignore-platform-req php"
 
-            -   run: vendor/bin/phpunit
+            -
+                run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "ext-dom": "*",
         "ext-pdo": "*",
         "ext-simplexml": "*",
+        "composer/semver": "^3.2",
         "composer/xdebug-handler": "^1.4",
         "cweagans/composer-patches": "^1.6",
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "symfony/templating": "^4.4|^5.1",
         "symfony/translation": "^4.4|^5.1",
         "symfony/twig-bundle": "^4.4|^5.1",
-        "tracy/tracy": "^2.7"
+        "tracy/tracy": "^2.7.6"
     },
     "autoload": {
         "files": [

--- a/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
+++ b/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
@@ -153,6 +153,11 @@ final class ComposerJson
         return $this->require;
     }
 
+    public function getRequirePhpVersion(): ?string
+    {
+        return $this->require['php'] ?? null;
+    }
+
     /**
      * @return array<string, string>
      */

--- a/packages/easy-ci/composer.json
+++ b/packages/easy-ci/composer.json
@@ -7,6 +7,7 @@
     ],
     "require": {
         "php": ">=7.3",
+        "composer/semver": "^3.2",
         "symfony/dependency-injection": "^5.1",
         "symfony/console": "^4.4|^5.1",
         "symfony/http-kernel": "^4.4|^5.1",

--- a/packages/easy-ci/config/config.php
+++ b/packages/easy-ci/config/config.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Composer\Semver\Semver;
+use Composer\Semver\VersionParser;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCI\ValueObject\Option;
 
@@ -23,4 +25,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->load('Symplify\EasyCI\\', __DIR__ . '/../src')
         ->exclude([__DIR__ . '/../src/HttpKernel', __DIR__ . '/../src/ValueObject']);
+
+    $services->set(VersionParser::class);
+    $services->set(Semver::class);
 };

--- a/packages/easy-ci/src/Command/PhpJsonCommand.php
+++ b/packages/easy-ci/src/Command/PhpJsonCommand.php
@@ -60,11 +60,7 @@ final class PhpJsonCommand extends AbstractSymplifyCommand
             throw new ShouldNotHappenException($message);
         }
 
-        $json = [
-            'php' => $supportePhpVersions,
-        ];
-        $jsonContent = Json::encode($json, Json::PRETTY);
-
+        $jsonContent = Json::encode($supportePhpVersions, Json::PRETTY);
         $this->symfonyStyle->writeln($jsonContent);
 
         return ShellCode::SUCCESS;

--- a/packages/easy-ci/src/Command/PhpVersionsJsonCommand.php
+++ b/packages/easy-ci/src/Command/PhpVersionsJsonCommand.php
@@ -13,7 +13,7 @@ use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\PHPStanRules\Exception\ShouldNotHappenException;
 
-final class PhpJsonCommand extends AbstractSymplifyCommand
+final class PhpVersionsJsonCommand extends AbstractSymplifyCommand
 {
     /**
      * @var string
@@ -60,7 +60,8 @@ final class PhpJsonCommand extends AbstractSymplifyCommand
             throw new ShouldNotHappenException($message);
         }
 
-        $jsonContent = Json::encode($supportePhpVersions, Json::PRETTY);
+        // output must be without spaces, otherwise it breaks the GitHub Actions json
+        $jsonContent = Json::encode($supportePhpVersions);
         $this->symfonyStyle->writeln($jsonContent);
 
         return ShellCode::SUCCESS;

--- a/packages/easy-ci/src/Composer/SupportedPhpVersionResolver.php
+++ b/packages/easy-ci/src/Composer/SupportedPhpVersionResolver.php
@@ -6,6 +6,7 @@ namespace Symplify\EasyCI\Composer;
 
 use Composer\Semver\Semver;
 use Composer\Semver\VersionParser;
+use DateTimeInterface;
 use Nette\Utils\DateTime;
 use Symplify\ComposerJsonManipulator\ComposerJsonFactory;
 use Symplify\EasyCI\ValueObject\PhpVersionList;
@@ -53,20 +54,18 @@ final class SupportedPhpVersionResolver
             throw new ShouldNotHappenException($message);
         }
 
-        return $this->resolveFromConstraints($requirePhpVersion);
+        return $this->resolveFromConstraints($requirePhpVersion, DateTime::from('now'));
     }
 
     /**
      * @return string[]
      */
-    public function resolveFromConstraints(string $phpVersionConstraints): array
+    public function resolveFromConstraints(string $phpVersionConstraints, DateTimeInterface $todayDateTime): array
     {
         // to validate version
         $this->versionParser->parseConstraints($phpVersionConstraints);
 
         $supportedPhpVersion = [];
-
-        $todayDateTime = DateTime::from('now');
 
         foreach (PhpVersionList::VERSIONS_BY_RELEASE_DATE as $releaseDate => $phpVersion) {
             if (! $this->semver->satisfies($phpVersion, $phpVersionConstraints)) {

--- a/packages/easy-ci/src/Composer/SupportedPhpVersionResolver.php
+++ b/packages/easy-ci/src/Composer/SupportedPhpVersionResolver.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCI\Composer;
+
+use Composer\Semver\Semver;
+use Composer\Semver\VersionParser;
+use Nette\Utils\DateTime;
+use Symplify\ComposerJsonManipulator\ComposerJsonFactory;
+use Symplify\EasyCI\ValueObject\PhpVersionList;
+use Symplify\PHPStanRules\Exception\ShouldNotHappenException;
+
+/**
+ * @see \Symplify\EasyCI\Tests\Composer\SupportedPhpVersionResolverTest
+ */
+final class SupportedPhpVersionResolver
+{
+    /**
+     * @var VersionParser
+     */
+    private $versionParser;
+
+    /**
+     * @var Semver
+     */
+    private $semver;
+    /**
+     * @var ComposerJsonFactory
+     */
+    private $composerJsonFactory;
+
+    public function __construct(
+        VersionParser $versionParser,
+        Semver $semver,
+        ComposerJsonFactory $composerJsonFactory
+    ) {
+        $this->versionParser = $versionParser;
+        $this->semver = $semver;
+        $this->composerJsonFactory = $composerJsonFactory;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function resolveFromComposerJsonFilePath(string $composerJsonFilePath): array
+    {
+        $composerJson = $this->composerJsonFactory->createFromFilePath($composerJsonFilePath);
+
+        $requirePhpVersion = $composerJson->getRequirePhpVersion();
+        if ($requirePhpVersion === null) {
+            $message = sprintf('PHP version was not found in "%s"', $composerJsonFilePath);
+            throw new ShouldNotHappenException($message);
+        }
+
+        return $this->resolveFromConstraints($requirePhpVersion);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function resolveFromConstraints(string $phpVersionConstraints): array
+    {
+        // to validate version
+        $this->versionParser->parseConstraints($phpVersionConstraints);
+
+        $supportedPhpVersion = [];
+
+        $todayDateTime = DateTime::from('now');
+
+        foreach (PhpVersionList::VERSIONS_BY_RELEASE_DATE as $releaseDate => $phpVersion) {
+            if (! $this->semver->satisfies($phpVersion, $phpVersionConstraints)) {
+                continue;
+            }
+
+            // is in the future?
+            $relaseDateTime = DateTime::from($releaseDate);
+            if ($relaseDateTime > $todayDateTime) {
+                continue;
+            }
+
+            $supportedPhpVersion[] = $phpVersion;
+        }
+
+        return $supportedPhpVersion;
+    }
+}

--- a/packages/easy-ci/src/ValueObject/PhpVersionList.php
+++ b/packages/easy-ci/src/ValueObject/PhpVersionList.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCI\ValueObject;
+
+final class PhpVersionList
+{
+    /**
+     * @see https://en.wikipedia.org/wiki/PHP#Release_history
+     * @var string[]
+     */
+    public const VERSIONS_BY_RELEASE_DATE = [
+        '2009-06-30' => '5.3',
+        '2012-03-01' => '5.4',
+        '2013-06-20' => '5.5',
+        '2014-08-28' => '5.6',
+        '2015-12-03' => '7.0',
+        '2016-12-01' => '7.1',
+        '2017-11-30' => '7.2',
+        '2018-12-06' => '7.3',
+        '2019-11-28' => '7.4',
+        '2020-11-26' => '8.0',
+        // ETAs ↓
+        '2021-12-01' => '8.1',
+        '2022-12-01' => '8.2',
+    ];
+}

--- a/packages/easy-ci/tests/Composer/SupportedPhpVersionResolverTest.php
+++ b/packages/easy-ci/tests/Composer/SupportedPhpVersionResolverTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCI\Tests\Composer;
+
+use Iterator;
+use Symplify\EasyCI\Composer\SupportedPhpVersionResolver;
+use Symplify\EasyCI\HttpKernel\EasyCIKernel;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+
+final class SupportedPhpVersionResolverTest extends AbstractKernelTestCase
+{
+    /**
+     * @var SupportedPhpVersionResolver
+     */
+    private $supportedPhpVersionResolver;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(EasyCIKernel::class);
+        $this->supportedPhpVersionResolver = $this->getService(SupportedPhpVersionResolver::class);
+    }
+
+    /**
+     * @dataProvider provideData()
+     * @param string[] $expectedPhpVersions
+     */
+    public function test(string $constraints, array $expectedPhpVersions): void
+    {
+        $supportedVersions = $this->supportedPhpVersionResolver->resolveFromConstraints($constraints);
+        $this->assertSame($expectedPhpVersions, $supportedVersions);
+    }
+
+    public function provideData(): Iterator
+    {
+        yield ['>= 8.0', ['8.0']];
+    }
+}

--- a/packages/easy-ci/tests/Composer/SupportedPhpVersionResolverTest.php
+++ b/packages/easy-ci/tests/Composer/SupportedPhpVersionResolverTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCI\Tests\Composer;
 
+use DateTimeInterface;
 use Iterator;
+use Nette\Utils\DateTime;
 use Symplify\EasyCI\Composer\SupportedPhpVersionResolver;
 use Symplify\EasyCI\HttpKernel\EasyCIKernel;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
@@ -26,14 +28,14 @@ final class SupportedPhpVersionResolverTest extends AbstractKernelTestCase
      * @dataProvider provideData()
      * @param string[] $expectedPhpVersions
      */
-    public function test(string $constraints, array $expectedPhpVersions): void
+    public function test(string $constraints, array $expectedPhpVersions, DateTimeInterface $targetDateTime): void
     {
-        $supportedVersions = $this->supportedPhpVersionResolver->resolveFromConstraints($constraints);
+        $supportedVersions = $this->supportedPhpVersionResolver->resolveFromConstraints($constraints, $targetDateTime);
         $this->assertSame($expectedPhpVersions, $supportedVersions);
     }
 
     public function provideData(): Iterator
     {
-        yield ['>= 8.0', ['8.0']];
+        yield ['>= 8.0', ['8.0'], DateTime::from('2020-12-05')];
     }
 }

--- a/packages/package-builder/src/Testing/AbstractKernelTestCase.php
+++ b/packages/package-builder/src/Testing/AbstractKernelTestCase.php
@@ -59,6 +59,18 @@ abstract class AbstractKernelTestCase extends TestCase
         return static::$kernel;
     }
 
+    /**
+     * Syntax sugger to remove static from the test cases vission
+     */
+    protected function getService(string $type): object
+    {
+        if (self::$container === null) {
+            throw new ShouldNotHappenException('First, crewate container with booKernel(KernelClass::class)');
+        }
+
+        return self::$container->get($type);
+    }
+
     protected function bootKernel(string $kernelClass): void
     {
         $this->ensureKernelShutdown();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -404,3 +404,5 @@ parameters:
                 - packages/symfony-route-usage/src/EntityRepository/RouteVisitRepository.php #12
 
         - '#Parameter (.*?) class ReflectionClass constructor expects class\-string<T of object\>\|T of object, string given#'
+
+        - '#Property (.*?)Test\:\:\$(.*?) does not accept object#'


### PR DESCRIPTION
Closes https://github.com/symplify/symplify/issues/2584

Closes https://github.com/symplify/symplify/pull/2579



The output of `php-json` here: https://github.com/symplify/symplify/pull/2592/checks?check_run_id=1503614394

![image](https://user-images.githubusercontent.com/924196/101245078-aad1aa00-370a-11eb-8ca4-712ba5a1ac5d.png)
