### PR TITLE
Add AuthorComposerKeyMerger

### DIFF
--- a/packages/composer-json-manipulator/src/ComposerJsonFactory.php
+++ b/packages/composer-json-manipulator/src/ComposerJsonFactory.php
@@ -65,6 +65,10 @@ final class ComposerJsonFactory
             $composerJson->setType($jsonArray[ComposerJsonSection::TYPE]);
         }
 
+        if (isset($jsonArray[ComposerJsonSection::AUTHORS])) {
+            $composerJson->setAuthors($jsonArray[ComposerJsonSection::AUTHORS]);
+        }
+
         if (isset($jsonArray[ComposerJsonSection::DESCRIPTION])) {
             $composerJson->setDescription($jsonArray[ComposerJsonSection::DESCRIPTION]);
         }

--- a/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
+++ b/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
@@ -117,6 +117,11 @@ final class ComposerJson
      */
     private $type;
 
+    /**
+     * @var mixed[]
+     */
+    private $authors = [];
+
     public function __construct()
     {
         $this->composerPackageSorter = new ComposerPackageSorter();
@@ -495,6 +500,22 @@ final class ComposerJson
     public function getLicense(): ?string
     {
         return $this->license;
+    }
+
+    /**
+     * @param mixed[] $authors
+     */
+    public function setAuthors(array $authors): void
+    {
+        $this->authors = $authors;
+    }
+
+    /**
+     * @return mixed[] $authors
+     */
+    public function getAuthors(): array
+    {
+        return $this->authors;
     }
 
     /**

--- a/packages/composer-json-manipulator/src/ValueObject/ComposerJsonSection.php
+++ b/packages/composer-json-manipulator/src/ValueObject/ComposerJsonSection.php
@@ -107,4 +107,10 @@ final class ComposerJsonSection
      * @var string
      */
     public const TYPE = 'type';
+
+    /**
+     * @api
+     * @var string
+     */
+    public const AUTHORS = 'authors';
 }

--- a/packages/monorepo-builder/packages/merge/src/ComposerKeyMerger/AuthorComposerKeyMerger.php
+++ b/packages/monorepo-builder/packages/merge/src/ComposerKeyMerger/AuthorComposerKeyMerger.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Merge\ComposerKeyMerger;
+
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Merge\Contract\ComposerKeyMergerInterface;
+
+final class AuthorComposerKeyMerger extends AbstractComposerKeyMerger implements ComposerKeyMergerInterface
+{
+    public function merge(ComposerJson $mainComposerJson, ComposerJson $newComposerJson) : void
+    {
+        if ($newComposerJson->getAuthors() === []) {
+            return;
+        }
+
+        $mainAuthors = array_column($mainComposerJson->getAuthors(), null, 'name');
+        $newAuthors = array_column($newComposerJson->getAuthors(), null, 'name');
+
+        $authors = array_merge($mainAuthors, $newAuthors);
+        $authors = array_values($authors);
+
+        $mainComposerJson->setAuthors($authors);
+    }
+}

--- a/packages/monorepo-builder/packages/merge/tests/ComposerJsonDecorator/AbstractComposerJsonDecoratorTest.php
+++ b/packages/monorepo-builder/packages/merge/tests/ComposerJsonDecorator/AbstractComposerJsonDecoratorTest.php
@@ -63,5 +63,6 @@ abstract class AbstractComposerJsonDecoratorTest extends AbstractKernelTestCase
         $this->assertSame($firstComposerJson->getName(), $secondComposerJson->getName());
         $this->assertSame($firstComposerJson->getLicense(), $secondComposerJson->getLicense());
         $this->assertSame($firstComposerJson->getDescription(), $secondComposerJson->getDescription());
+        $this->assertSame($firstComposerJson->getAuthors(), $secondComposerJson->getAuthors());
     }
 }

--- a/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/ComposerJsonMergerTest.php
+++ b/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/ComposerJsonMergerTest.php
@@ -24,9 +24,11 @@ final class ComposerJsonMergerTest extends AbstractComposerJsonDecoratorTest
     public function test(): void
     {
         $mainComposerJson = $this->createComposerJson(__DIR__ . '/Source/main-composer.json');
-        $mergedComposerJson = $this->createComposerJson(__DIR__ . '/Source/merged-composer.json');
+        $package1Json = $this->createComposerJson(__DIR__ . '/Source/package1-composer.json');
+        $package2Json = $this->createComposerJson(__DIR__ . '/Source/package2-composer.json');
 
-        $this->composerJsonMerger->mergeJsonToRoot($mainComposerJson, $mergedComposerJson);
+        $this->composerJsonMerger->mergeJsonToRoot($mainComposerJson, $package1Json);
+        $this->composerJsonMerger->mergeJsonToRoot($mainComposerJson, $package2Json);
 
         $this->assertComposerJsonEquals(__DIR__ . '/Source/expected-root.json', $mainComposerJson);
     }

--- a/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/expected-root.json
+++ b/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/expected-root.json
@@ -8,6 +8,20 @@
             "Some\\": "some"
         }
     },
+    "authors": [
+        {
+            "name": "Original Author",
+            "email": "original@example.com"
+        },
+        {
+            "name": "New Author",
+            "email": "new@example.com"
+        },
+        {
+            "name": "Package 2 Author",
+            "email": "package2@example.com"
+        }
+    ],
     "repositories": [
         {
             "type": "vcs",

--- a/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/main-composer.json
+++ b/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/main-composer.json
@@ -3,6 +3,12 @@
         "php": "^7.1",
         "symfony/dependency-injection": "^4.1"
     },
+    "authors": [
+        {
+            "name": "Original Author",
+            "email": "original@example.com"
+        }
+    ],
     "repositories": [
         {
             "type": "vcs",

--- a/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/package1-composer.json
+++ b/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/package1-composer.json
@@ -2,6 +2,12 @@
     "require": {
         "php": "^7.1"
     },
+    "authors": [
+        {
+            "name": "New Author",
+            "email": "new@example.com"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Some\\": "some"

--- a/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/package2-composer.json
+++ b/packages/monorepo-builder/packages/merge/tests/ComposerJsonMerger/Source/package2-composer.json
@@ -1,0 +1,20 @@
+{
+    "require": {
+        "php": "^7.1"
+    },
+    "authors": [
+        {
+            "name": "Package 2 Author",
+            "email": "package2@example.com"
+        },
+        {
+            "name": "New Author",
+            "email": "new@example.com"
+        }
+    ],
+    "autoload": {
+        "psr-4": {
+            "Some\\": "some"
+        }
+    }
+}


### PR DESCRIPTION
I noticed that `vendor/bin/monorepo-builder merge` would remove the `authors` section from the root `composer.json`.

To fix this, I added a new AuthorComposerKeyMerger that combines all the `authors` and merges them to the root `composer.json`. It uses the `name` key to produce a unique list.

Fixes #2599