### PR TITLE
[ComposerJsonManipulator] Export `authors`, `type` and `conflicting`

### DIFF
--- a/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
+++ b/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
@@ -397,12 +397,24 @@ final class ComposerJson
             $array[ComposerJsonSection::LICENSE] = $this->license;
         }
 
+        if ($this->authors !== null) {
+            $array[ComposerJsonSection::AUTHORS] = $this->authors;
+        }
+
+        if ($this->type !== null) {
+            $array[ComposerJsonSection::TYPE] = $this->type;
+        }
+
         if ($this->require !== []) {
             $array[ComposerJsonSection::REQUIRE] = $this->require;
         }
 
         if ($this->requireDev !== []) {
             $array[ComposerJsonSection::REQUIRE_DEV] = $this->requireDev;
+        }
+
+        if ($this->conflicting !== []) {
+            $array[ComposerJsonSection::CONFLICTING] = $this->conflicting;
         }
 
         if ($this->autoload !== []) {

--- a/packages/composer-json-manipulator/tests/ComposerJsonFactory/Source/full_composer.json
+++ b/packages/composer-json-manipulator/tests/ComposerJsonFactory/Source/full_composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "test-package",
+    "description": "Package to load, merge and save composer.json file(s)",
+    "license": "MIT",
+    "type": "symfony-bundle",
+    "require": {
+        "php": ">=7.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^8.5|^9.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "Symplify\\ComposerJsonManipulator\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Symplify\\ComposerJsonManipulator\\Tests\\": "tests"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "9.1-dev"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "replace": {
+        "symplify/autodiscovery": "self.version"
+    },
+    "scripts": {
+        "check-cs": "packages/easy-coding-standard/bin/ecs check --ansi"
+    },
+    "config": {
+        "sort-packages": true
+    }
+}

--- a/packages/package-scoper/tests/ComposerJson/ScopedComposerJsonFactory/Fixture/Expected/expected_scoped_composer.json
+++ b/packages/package-scoper/tests/ComposerJson/ScopedComposerJsonFactory/Fixture/Expected/expected_scoped_composer.json
@@ -4,6 +4,9 @@
     "require": {
         "php": "^7.2"
     },
+    "conflicting": [
+        "some/package"
+    ],
     "replace": {
         "some/package": "self.version"
     }


### PR DESCRIPTION
Followup of https://github.com/symplify/symplify/pull/2604

The test was not using the `getJsonData`.