### PR TITLE
Enable PHPUnit colors on CI

### DIFF
--- a/.github/workflows/split_tests.yaml
+++ b/.github/workflows/split_tests.yaml
@@ -57,4 +57,4 @@ jobs:
 
             -
                 working-directory: packages/${{ matrix.package }}
-                run: vendor/bin/phpunit
+                run: vendor/bin/phpunit --colors=always

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -74,4 +74,4 @@ jobs:
                     composer-options: "--ignore-platform-req php"
 
             -
-                run: vendor/bin/phpunit
+                run: vendor/bin/phpunit --colors=always


### PR DESCRIPTION
Somehow colors are not working even though `colors=true` in `phpunit.xml`.