### PR TITLE
[PHPStanRules] Fixes CheckClassNamespaceFollowPsr4Rule check is in named directory in Windows Operating System

### DIFF
--- a/packages/phpstan-rules/src/ComposerAutoloadResolver.php
+++ b/packages/phpstan-rules/src/ComposerAutoloadResolver.php
@@ -24,7 +24,7 @@ class ComposerAutoloadResolver
      */
     public function getPsr4Autoload(): array
     {
-        $composerJsonFile = './composer.json';
+        $composerJsonFile = getcwd() . DIRECTORY_SEPARATOR . 'composer.json';
         if (! file_exists($composerJsonFile)) {
             return [];
         }

--- a/packages/phpstan-rules/src/ComposerAutoloadResolver.php
+++ b/packages/phpstan-rules/src/ComposerAutoloadResolver.php
@@ -24,7 +24,7 @@ class ComposerAutoloadResolver
      */
     public function getPsr4Autoload(): array
     {
-        $composerJsonFile = getcwd() . DIRECTORY_SEPARATOR . 'composer.json';
+        $composerJsonFile = './composer.json';
         if (! file_exists($composerJsonFile)) {
             return [];
         }

--- a/packages/phpstan-rules/src/Rules/AbstractSymplifyRule.php
+++ b/packages/phpstan-rules/src/Rules/AbstractSymplifyRule.php
@@ -111,6 +111,7 @@ abstract class AbstractSymplifyRule implements Rule, ManyNodeRuleInterface, Docu
 
     protected function isInDirectoryNamed(Scope $scope, string $directoryName): bool
     {
+        $directoryName = str_replace('/', DIRECTORY_SEPARATOR, $directoryName);
         return Strings::contains($scope->getFile(), DIRECTORY_SEPARATOR . $directoryName . DIRECTORY_SEPARATOR);
     }
 


### PR DESCRIPTION
Fixes #2658