### PR TITLE
[PHPStanRules]  ensure no superflous / or \ in check isInDirectoryNamed()

### DIFF
--- a/packages/phpstan-rules/src/Rules/AbstractSymplifyRule.php
+++ b/packages/phpstan-rules/src/Rules/AbstractSymplifyRule.php
@@ -111,7 +111,7 @@ abstract class AbstractSymplifyRule implements Rule, ManyNodeRuleInterface, Docu
 
     protected function isInDirectoryNamed(Scope $scope, string $directoryName): bool
     {
-        $directoryName = str_replace('/', DIRECTORY_SEPARATOR, $directoryName);
+        $directoryName = rtrim(str_replace('/', DIRECTORY_SEPARATOR, $directoryName), '\/');
         return Strings::contains($scope->getFile(), DIRECTORY_SEPARATOR . $directoryName . DIRECTORY_SEPARATOR);
     }
 


### PR DESCRIPTION
Fixes #2662  

ref https://3v4l.org/OCsD5