### PR TITLE
Improved documentation (to avoid error)

### DIFF
--- a/packages/monorepo-builder/README.md
+++ b/packages/monorepo-builder/README.md
@@ -49,6 +49,8 @@ vendor/bin/monorepo-builder merge
 Typical location for packages is `/packages`. But what if you have different naming or extra `/projects` directory?
 
 ```php
+// File: monorepo-builder.php
+
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\MonorepoBuilder\ValueObject\Option;
 
@@ -162,6 +164,36 @@ The `release` command will make you safe:
 
 ```bash
 vendor/bin/monorepo-builder release v7.0
+```
+
+And add the following release workers to your `monorepo-builder.php`:
+
+```php
+// File: monorepo-builder.php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushNextDevReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetCurrentMutualDependenciesReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\SetNextMutualDependenciesReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateBranchAliasReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateReplaceReleaseWorker;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    # release workers - in order to execute
+    $services->set(UpdateReplaceReleaseWorker::class);
+    $services->set(SetCurrentMutualDependenciesReleaseWorker::class);
+    $services->set(AddTagToChangelogReleaseWorker::class);
+    $services->set(TagVersionReleaseWorker::class);
+    $services->set(PushTagReleaseWorker::class);
+    $services->set(SetNextMutualDependenciesReleaseWorker::class);
+    $services->set(UpdateBranchAliasReleaseWorker::class);
+    $services->set(PushNextDevReleaseWorker::class);
+};
 ```
 
 Are you afraid to tag and push? Use `--dry-run` to see only descriptions:


### PR DESCRIPTION
Following the instructions to install the monorepo builder, I executed:

```bash
vendor/bin/monorepo-builder release v7.0 --dry-run
```

And I got an error:

```
 [ERROR] There are no release workers registered. Be sure to add them to "monorepo-builder.php" 
```

So I added the release workers in that same step