### PR TITLE
Added 2 commands, to 1. add and 2. remove symlinks to local packages, in all composer.json files

### DIFF
--- a/packages/monorepo-builder/packages/testing/src/AbstractComposerJsonRepositoriesUpdater.php
+++ b/packages/monorepo-builder/packages/testing/src/AbstractComposerJsonRepositoriesUpdater.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Testing;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
+use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\ConsoleColorDiff\Console\Output\ConsoleDiffer;
+use Symplify\MonorepoBuilder\Package\PackageNamesProvider;
+use Symplify\MonorepoBuilder\Testing\PackageDependency\UsedPackagesResolver;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
+
+abstract class AbstractComposerJsonRepositoriesUpdater
+{
+    /**
+     * @var PackageNamesProvider
+     */
+    private $packageNamesProvider;
+
+    /**
+     * @var JsonFileManager
+     */
+    private $jsonFileManager;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $symfonyStyle;
+
+    /**
+     * @var UsedPackagesResolver
+     */
+    private $usedPackagesResolver;
+
+    /**
+     * @var ConsoleDiffer
+     */
+    private $consoleDiffer;
+
+    public function __construct(
+        PackageNamesProvider $packageNamesProvider,
+        JsonFileManager $jsonFileManager,
+        SymfonyStyle $symfonyStyle,
+        UsedPackagesResolver $usedPackagesResolver,
+        ConsoleDiffer $consoleDiffer
+    ) {
+        $this->packageNamesProvider = $packageNamesProvider;
+        $this->jsonFileManager = $jsonFileManager;
+        $this->symfonyStyle = $symfonyStyle;
+        $this->usedPackagesResolver = $usedPackagesResolver;
+        $this->consoleDiffer = $consoleDiffer;
+    }
+
+    public function processPackage(SmartFileInfo $packageFileInfo, ComposerJson $rootComposerJson, ?bool $symlink): void
+    {
+        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
+
+        $usedPackageNames = $this->usedPackagesResolver->resolveForPackage($packageComposerJson);
+        if ($usedPackageNames === []) {
+            $message = sprintf(
+                'Package "%s" does not use any mutual dependencies, so we skip it',
+                $packageFileInfo->getRelativeFilePathFromCwd()
+            );
+            $this->symfonyStyle->note($message);
+            return;
+        }
+
+        // possibly replace them all to cover recursive secondary dependencies
+        $packageNames = $this->packageNamesProvider->provide();
+
+        $oldComposerJsonContents = $packageFileInfo->getContents();
+
+        $rootComposerJsonFileInfo = $rootComposerJson->getFileInfo();
+        if ($rootComposerJsonFileInfo === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        $packageComposerJson = $this->decoratePackageComposerJson(
+            $packageComposerJson,
+            $packageNames,
+            $rootComposerJsonFileInfo,
+            $symlink
+        );
+
+        $newComposerJsonContents = $this->jsonFileManager->printJsonToFileInfo($packageComposerJson, $packageFileInfo);
+
+        $message = sprintf('File "%s" was updated', $packageFileInfo->getRelativeFilePathFromCwd());
+        $this->symfonyStyle->title($message);
+
+        $this->consoleDiffer->diffAndPrint($oldComposerJsonContents, $newComposerJsonContents);
+        $this->symfonyStyle->newLine(2);
+    }
+
+    /**
+     * @param mixed[] $packageComposerJson
+     * @param string[] $packageNames
+     * @return mixed[]
+     */
+    abstract protected function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array;
+}

--- a/packages/monorepo-builder/packages/testing/src/AbstractComposerJsonRepositoriesUpdater.php
+++ b/packages/monorepo-builder/packages/testing/src/AbstractComposerJsonRepositoriesUpdater.php
@@ -13,7 +13,7 @@ use Symplify\MonorepoBuilder\Testing\PackageDependency\UsedPackagesResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
-abstract class AbstractComposerJsonRepositoriesUpdater
+abstract class AbstractComposerJsonRepositoriesUpdater implements ComposerJsonRepositoriesUpdaterInterface
 {
     /**
      * @var PackageNamesProvider
@@ -93,11 +93,4 @@ abstract class AbstractComposerJsonRepositoriesUpdater
         $this->consoleDiffer->diffAndPrint($oldComposerJsonContents, $newComposerJsonContents);
         $this->symfonyStyle->newLine(2);
     }
-
-    /**
-     * @param mixed[] $packageComposerJson
-     * @param string[] $packageNames
-     * @return mixed[]
-     */
-    abstract protected function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array;
 }

--- a/packages/monorepo-builder/packages/testing/src/AbstractComposerJsonRepositoriesUpdater.php
+++ b/packages/monorepo-builder/packages/testing/src/AbstractComposerJsonRepositoriesUpdater.php
@@ -9,6 +9,7 @@ use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\ConsoleColorDiff\Console\Output\ConsoleDiffer;
 use Symplify\MonorepoBuilder\Package\PackageNamesProvider;
+use Symplify\MonorepoBuilder\Testing\Contract\ComposerJsonRepositoriesUpdaterInterface;
 use Symplify\MonorepoBuilder\Testing\PackageDependency\UsedPackagesResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;

--- a/packages/monorepo-builder/packages/testing/src/Command/LocalizeComposerPathsCommand.php
+++ b/packages/monorepo-builder/packages/testing/src/Command/LocalizeComposerPathsCommand.php
@@ -65,7 +65,13 @@ final class LocalizeComposerPathsCommand extends AbstractSymplifyCommand
         }
 
         // 2. update "repository" to "*" for current composer.json
-        $this->composerJsonRepositoriesUpdater->processPackage($packageComposerJsonFileInfo, $rootComposerJson);
+        // $symlink => `false`: we need hard copy of files,
+        // as in normal composer install of standalone package
+        $this->composerJsonRepositoriesUpdater->processPackage(
+            $packageComposerJsonFileInfo,
+            $rootComposerJson,
+            false
+        );
 
         $message = sprintf(
             'Package paths in "%s" have been updated',

--- a/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
@@ -38,7 +38,8 @@ final class ComposerJsonSymlinker
     public function decoratePackageComposerJsonWithPackageSymlinks(
         array $packageComposerJson,
         array $packageNames,
-        SmartFileInfo $mainComposerJsonFileInfo
+        SmartFileInfo $mainComposerJsonFileInfo,
+        ?bool $symlink
     ): array {
         // @see https://getcomposer.org/doc/05-repositories.md#path
         foreach ($packageNames as $packageName) {
@@ -52,11 +53,12 @@ final class ComposerJsonSymlinker
             $repositoriesContent = [
                 'type' => 'path',
                 'url' => $relativePathToLocalPackage,
-                // we need hard copy of files, as in normal composer install of standalone package
-                'options' => [
-                    'symlink' => false,
-                ],
             ];
+            if ($symlink !== null) {
+                $repositoriesContent['options'] = [
+                    'symlink' => $symlink,
+                ];
+            }
 
             if (array_key_exists(ComposerJsonSection::REPOSITORIES, $packageComposerJson)) {
                 array_unshift($packageComposerJson[ComposerJsonSection::REPOSITORIES], $repositoriesContent);

--- a/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
@@ -96,7 +96,10 @@ final class ComposerJsonSymlinker
             $packageComposerJson[ComposerJsonSection::REPOSITORIES] = array_values(array_filter(
                 $packageComposerJson[ComposerJsonSection::REPOSITORIES],
                 function (array $repository) use ($relativePathToLocalPackage): bool {
-                    return ! ($repository['type'] === 'path' && $repository['url'] === $relativePathToLocalPackage);
+                    return ! (
+                        isset($repository['type']) && $repository['type'] === 'path'
+                        && isset($repository['url']) && $repository['url'] === $relativePathToLocalPackage
+                    );
                 }
             ));
         }

--- a/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
@@ -69,4 +69,38 @@ final class ComposerJsonSymlinker
 
         return $packageComposerJson;
     }
+
+    /**
+     * @param mixed[] $packageComposerJson
+     * @param string[] $packageNames
+     * @return mixed[]
+     */
+    public function removePackageSymlinksFromPackageComposerJson(
+        array $packageComposerJson,
+        array $packageNames,
+        SmartFileInfo $mainComposerJsonFileInfo
+    ): array {
+        // If there are no repositories, then nothing to do
+        if (! array_key_exists(ComposerJsonSection::REPOSITORIES, $packageComposerJson)) {
+            return $packageComposerJson;
+        }
+        foreach ($packageNames as $packageName) {
+            $usedPackageFileInfo = $this->composerJsonProvider->getPackageFileInfoByName($packageName);
+
+            $relativePathToLocalPackage = $this->packagePathResolver->resolveRelativePathToLocalPackage(
+                $mainComposerJsonFileInfo,
+                $usedPackageFileInfo
+            );
+
+            // Filter out the repositories of type "path" with this URL
+            $packageComposerJson[ComposerJsonSection::REPOSITORIES] = array_values(array_filter(
+                $packageComposerJson[ComposerJsonSection::REPOSITORIES],
+                function (array $repository) use ($relativePathToLocalPackage): bool {
+                    return ! ($repository['type'] === 'path' && $repository['url'] === $relativePathToLocalPackage);
+                }
+            ));
+        }
+
+        return $packageComposerJson;
+    }
 }

--- a/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesRemover.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesRemover.php
@@ -43,7 +43,7 @@ final class ComposerJsonRepositoriesRemover extends AbstractComposerJsonReposito
      * @param string[] $packageNames
      * @return mixed[]
      */
-    protected function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array
+    public function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array
     {
         return $this->composerJsonSymlinker->removePackageSymlinksFromPackageComposerJson(
             $packageComposerJson,

--- a/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesRemover.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesRemover.php
@@ -12,7 +12,7 @@ use Symplify\MonorepoBuilder\Testing\ComposerJson\ComposerJsonSymlinker;
 use Symplify\MonorepoBuilder\Testing\PackageDependency\UsedPackagesResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-final class ComposerJsonRepositoriesUpdater extends AbstractComposerJsonRepositoriesUpdater
+final class ComposerJsonRepositoriesRemover extends AbstractComposerJsonRepositoriesUpdater
 {
     /**
      * @var ComposerJsonSymlinker
@@ -45,11 +45,10 @@ final class ComposerJsonRepositoriesUpdater extends AbstractComposerJsonReposito
      */
     protected function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array
     {
-        return $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
+        return $this->composerJsonSymlinker->removePackageSymlinksFromPackageComposerJson(
             $packageComposerJson,
             $packageNames,
-            $rootComposerJsonFileInfo,
-            $symlink
+            $rootComposerJsonFileInfo
         );
     }
 }

--- a/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdater.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdater.php
@@ -62,7 +62,7 @@ final class ComposerJsonRepositoriesUpdater
         $this->consoleDiffer = $consoleDiffer;
     }
 
-    public function processPackage(SmartFileInfo $packageFileInfo, ComposerJson $rootComposerJson): void
+    public function processPackage(SmartFileInfo $packageFileInfo, ComposerJson $rootComposerJson, ?bool $symlink): void
     {
         $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
 
@@ -89,7 +89,8 @@ final class ComposerJsonRepositoriesUpdater
         $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
             $packageComposerJson,
             $packageNames,
-            $rootComposerJsonFileInfo
+            $rootComposerJsonFileInfo,
+            $symlink
         );
 
         $newComposerJsonContents = $this->jsonFileManager->printJsonToFileInfo($packageComposerJson, $packageFileInfo);

--- a/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdater.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdater.php
@@ -43,7 +43,7 @@ final class ComposerJsonRepositoriesUpdater extends AbstractComposerJsonReposito
      * @param string[] $packageNames
      * @return mixed[]
      */
-    protected function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array
+    public function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array
     {
         return $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
             $packageComposerJson,

--- a/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdater.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdater.php
@@ -4,101 +4,32 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Testing;
 
-use Symfony\Component\Console\Style\SymfonyStyle;
-use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
-use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
-use Symplify\ConsoleColorDiff\Console\Output\ConsoleDiffer;
-use Symplify\MonorepoBuilder\Package\PackageNamesProvider;
 use Symplify\MonorepoBuilder\Testing\ComposerJson\ComposerJsonSymlinker;
-use Symplify\MonorepoBuilder\Testing\PackageDependency\UsedPackagesResolver;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class ComposerJsonRepositoriesUpdater
 {
-    /**
-     * @var PackageNamesProvider
-     */
-    private $packageNamesProvider;
-
-    /**
-     * @var JsonFileManager
-     */
-    private $jsonFileManager;
-
-    /**
-     * @var SymfonyStyle
-     */
-    private $symfonyStyle;
-
     /**
      * @var ComposerJsonSymlinker
      */
     private $composerJsonSymlinker;
 
-    /**
-     * @var UsedPackagesResolver
-     */
-    private $usedPackagesResolver;
-
-    /**
-     * @var ConsoleDiffer
-     */
-    private $consoleDiffer;
-
-    public function __construct(
-        PackageNamesProvider $packageNamesProvider,
-        JsonFileManager $jsonFileManager,
-        SymfonyStyle $symfonyStyle,
-        ComposerJsonSymlinker $composerJsonSymlinker,
-        UsedPackagesResolver $usedPackagesResolver,
-        ConsoleDiffer $consoleDiffer
-    ) {
-        $this->packageNamesProvider = $packageNamesProvider;
-        $this->jsonFileManager = $jsonFileManager;
-        $this->symfonyStyle = $symfonyStyle;
+    public function __construct(ComposerJsonSymlinker $composerJsonSymlinker) {
         $this->composerJsonSymlinker = $composerJsonSymlinker;
-        $this->usedPackagesResolver = $usedPackagesResolver;
-        $this->consoleDiffer = $consoleDiffer;
     }
 
-    public function processPackage(SmartFileInfo $packageFileInfo, ComposerJson $rootComposerJson, ?bool $symlink): void
+    /**
+     * @param mixed[] $packageComposerJson
+     * @param string[] $packageNames
+     * @return mixed[]
+     */
+    protected function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array
     {
-        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
-
-        $usedPackageNames = $this->usedPackagesResolver->resolveForPackage($packageComposerJson);
-        if ($usedPackageNames === []) {
-            $message = sprintf(
-                'Package "%s" does not use any mutual dependencies, so we skip it',
-                $packageFileInfo->getRelativeFilePathFromCwd()
-            );
-            $this->symfonyStyle->note($message);
-            return;
-        }
-
-        // possibly replace them all to cover recursive secondary dependencies
-        $packageNames = $this->packageNamesProvider->provide();
-
-        $oldComposerJsonContents = $packageFileInfo->getContents();
-
-        $rootComposerJsonFileInfo = $rootComposerJson->getFileInfo();
-        if ($rootComposerJsonFileInfo === null) {
-            throw new ShouldNotHappenException();
-        }
-
-        $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
+        return $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
             $packageComposerJson,
             $packageNames,
             $rootComposerJsonFileInfo,
             $symlink
         );
-
-        $newComposerJsonContents = $this->jsonFileManager->printJsonToFileInfo($packageComposerJson, $packageFileInfo);
-
-        $message = sprintf('File "%s" was updated', $packageFileInfo->getRelativeFilePathFromCwd());
-        $this->symfonyStyle->title($message);
-
-        $this->consoleDiffer->diffAndPrint($oldComposerJsonContents, $newComposerJsonContents);
-        $this->symfonyStyle->newLine(2);
     }
 }

--- a/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdaterInterface.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJsonRepositoriesUpdaterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Testing;
+
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+interface ComposerJsonRepositoriesUpdaterInterface
+{
+    /**
+     * @param mixed[] $packageComposerJson
+     * @param string[] $packageNames
+     * @return mixed[]
+     */
+    public function decoratePackageComposerJson(array $packageComposerJson, array $packageNames, SmartFileInfo $rootComposerJsonFileInfo, ?bool $symlink): array;
+}

--- a/packages/monorepo-builder/packages/testing/src/Contract/ComposerJsonRepositoriesUpdaterInterface.php
+++ b/packages/monorepo-builder/packages/testing/src/Contract/ComposerJsonRepositoriesUpdaterInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\MonorepoBuilder\Testing;
+namespace Symplify\MonorepoBuilder\Testing\Contract;
 
 use Symplify\SmartFileSystem\SmartFileInfo;
 

--- a/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
+++ b/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
@@ -40,7 +40,8 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
         $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
             $packageComposerJson,
             ['example/package-two'],
-            $mainComposerJson
+            $mainComposerJson,
+            false
         );
 
         $this->assertSame([
@@ -74,7 +75,8 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
         $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
             $packageComposerJson,
             ['example/package-one'],
-            $mainComposerJson
+            $mainComposerJson,
+            false
         );
 
         $this->assertSame([

--- a/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
+++ b/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
@@ -145,4 +145,31 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
             ],
         ], $packageComposerJson);
     }
+
+    public function testRemovePackageSymlinksFromRepository(): void
+    {
+        $mainComposerJson = new SmartFileInfo(__DIR__ . '/composer.json');
+        $packageFileInfo = new SmartFileInfo(__DIR__ . '/packages/package-three/composer.json');
+
+        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
+
+        $packageComposerJson = $this->composerJsonSymlinker->removePackageSymlinksFromPackageComposerJson(
+            $packageComposerJson,
+            ['example/package-one'],
+            $mainComposerJson
+        );
+
+        $this->assertSame([
+            'name' => 'example/package-three',
+            'repositories' => [
+                [
+                    'type' => 'composer',
+                    'url' => 'https://repo.packagist.com/acme-companies/',
+                ],
+                [
+                    'packagist.org' => false,
+                ],
+            ],
+        ], $packageComposerJson);
+    }
 }

--- a/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
+++ b/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
@@ -92,4 +92,57 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
             ],
         ], $packageComposerJson);
     }
+
+    public function testSymlinkTrue(): void
+    {
+        $mainComposerJson = new SmartFileInfo(__DIR__ . '/composer.json');
+        $packageFileInfo = new SmartFileInfo(__DIR__ . '/packages/package-two/composer.json');
+
+        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
+
+        $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
+            $packageComposerJson,
+            ['example/package-one'],
+            $mainComposerJson,
+            true
+        );
+
+        $this->assertSame([
+            'name' => 'example/package-two',
+            'repositories' => [
+                [
+                    'type' => 'path',
+                    'url' => '../../packages/package-one',
+                    'options' => [
+                        'symlink' => true,
+                    ],
+                ],
+            ],
+        ], $packageComposerJson);
+    }
+
+    public function testNoOptions(): void
+    {
+        $mainComposerJson = new SmartFileInfo(__DIR__ . '/composer.json');
+        $packageFileInfo = new SmartFileInfo(__DIR__ . '/packages/package-two/composer.json');
+
+        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
+
+        $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
+            $packageComposerJson,
+            ['example/package-one'],
+            $mainComposerJson,
+            null
+        );
+
+        $this->assertSame([
+            'name' => 'example/package-two',
+            'repositories' => [
+                [
+                    'type' => 'path',
+                    'url' => '../../packages/package-one',
+                ],
+            ],
+        ], $packageComposerJson);
+    }
 }

--- a/packages/monorepo-builder/packages/testing/tests/ComposerJson/packages/package-three/composer.json
+++ b/packages/monorepo-builder/packages/testing/tests/ComposerJson/packages/package-three/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "example/package-three",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/package-one",
+            "options": {
+                "symlink": false
+            }
+        },
+        {
+            "type": "composer",
+            "url": "https://repo.packagist.com/acme-companies/"
+        },
+        {
+            "packagist.org": false
+        }
+    ]
+}

--- a/packages/monorepo-builder/src/Command/RemoveSymlinkToLocalPackagesCommand.php
+++ b/packages/monorepo-builder/src/Command/RemoveSymlinkToLocalPackagesCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
+use Symplify\MonorepoBuilder\Testing\ComposerJsonRepositoriesUpdater;
+use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
+use Symplify\PackageBuilder\Console\ShellCode;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class RemoveSymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
+{
+    /**
+     * @var ComposerJsonProvider
+     */
+    private $composerJsonProvider;
+
+    /**
+     * @var ComposerJsonRepositoriesUpdater
+     */
+    private $composerJsonRepositoriesUpdater;
+
+    public function __construct(
+        ComposerJsonProvider $composerJsonProvider,
+        ComposerJsonRepositoriesUpdater $composerJsonRepositoriesUpdater
+    ) {
+        $this->composerJsonProvider = $composerJsonProvider;
+        $this->composerJsonRepositoriesUpdater = $composerJsonRepositoriesUpdater;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Remove paths to local packages as repositories in every composer.json');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $rootComposerJson = $this->composerJsonProvider->getRootComposerJson();
+
+        $packagesFileInfos = $this->composerJsonProvider->getPackagesComposerFileInfos();
+        foreach ($packagesFileInfos as $packageFileInfo) {
+            // $symlink => `true`: when executing a package,
+            // any modification to another local package can be seen immediately
+            $this->composerJsonRepositoriesUpdater->processPackage(
+                $packageFileInfo,
+                $rootComposerJson,
+                true
+            );
+        }
+
+        $message = sprintf(
+            'The composer.json for the following packages has been updated, removing the path to all local packages as repositories: "%s"',
+            implode(', ', array_map(
+                function (SmartFileInfo $packageFileInfo): string {
+                    return $packageFileInfo->getRelativeFilePathFromCwd();
+                },
+                $packagesFileInfos
+            ))
+        );
+        $this->symfonyStyle->success($message);
+
+        return ShellCode::SUCCESS;
+    }
+}

--- a/packages/monorepo-builder/src/Command/RemoveSymlinkToLocalPackagesCommand.php
+++ b/packages/monorepo-builder/src/Command/RemoveSymlinkToLocalPackagesCommand.php
@@ -7,7 +7,7 @@ namespace Symplify\MonorepoBuilder\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
-use Symplify\MonorepoBuilder\Testing\ComposerJsonRepositoriesUpdater;
+use Symplify\MonorepoBuilder\Testing\ComposerJsonRepositoriesRemover;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\PackageBuilder\Console\ShellCode;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -20,16 +20,16 @@ final class RemoveSymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
     private $composerJsonProvider;
 
     /**
-     * @var ComposerJsonRepositoriesUpdater
+     * @var ComposerJsonRepositoriesRemover
      */
-    private $composerJsonRepositoriesUpdater;
+    private $composerJsonRepositoriesRemover;
 
     public function __construct(
         ComposerJsonProvider $composerJsonProvider,
-        ComposerJsonRepositoriesUpdater $composerJsonRepositoriesUpdater
+        ComposerJsonRepositoriesRemover $composerJsonRepositoriesRemover
     ) {
         $this->composerJsonProvider = $composerJsonProvider;
-        $this->composerJsonRepositoriesUpdater = $composerJsonRepositoriesUpdater;
+        $this->composerJsonRepositoriesRemover = $composerJsonRepositoriesRemover;
 
         parent::__construct();
     }
@@ -47,7 +47,7 @@ final class RemoveSymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
         foreach ($packagesFileInfos as $packageFileInfo) {
             // $symlink => `true`: when executing a package,
             // any modification to another local package can be seen immediately
-            $this->composerJsonRepositoriesUpdater->processPackage(
+            $this->composerJsonRepositoriesRemover->processPackage(
                 $packageFileInfo,
                 $rootComposerJson,
                 true

--- a/packages/monorepo-builder/src/Command/RemoveSymlinkToLocalPackagesCommand.php
+++ b/packages/monorepo-builder/src/Command/RemoveSymlinkToLocalPackagesCommand.php
@@ -54,15 +54,7 @@ final class RemoveSymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
             );
         }
 
-        $message = sprintf(
-            'The composer.json for the following packages has been updated, removing the path to all local packages as repositories: "%s"',
-            implode(', ', array_map(
-                function (SmartFileInfo $packageFileInfo): string {
-                    return $packageFileInfo->getRelativeFilePathFromCwd();
-                },
-                $packagesFileInfos
-            ))
-        );
+        $message = 'The composer.json for all packages has been updated, removing the symlink to their required local packages';
         $this->symfonyStyle->success($message);
 
         return ShellCode::SUCCESS;

--- a/packages/monorepo-builder/src/Command/SymlinkToLocalPackagesCommand.php
+++ b/packages/monorepo-builder/src/Command/SymlinkToLocalPackagesCommand.php
@@ -54,15 +54,7 @@ final class SymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
             );
         }
 
-        $message = sprintf(
-            'The composer.json for the following packages has been updated, adding the path to all local packages as repositories: "%s"',
-            implode(', ', array_map(
-                function (SmartFileInfo $packageFileInfo): string {
-                    return $packageFileInfo->getRelativeFilePathFromCwd();
-                },
-                $packagesFileInfos
-            ))
-        );
+        $message = 'The composer.json for all packages has been updated, symlinking to their required local packages';
         $this->symfonyStyle->success($message);
 
         return ShellCode::SUCCESS;

--- a/packages/monorepo-builder/src/Command/SymlinkToLocalPackagesCommand.php
+++ b/packages/monorepo-builder/src/Command/SymlinkToLocalPackagesCommand.php
@@ -45,7 +45,13 @@ final class SymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
 
         $packagesFileInfos = $this->composerJsonProvider->getPackagesComposerFileInfos();
         foreach ($packagesFileInfos as $packageFileInfo) {
-            $this->composerJsonRepositoriesUpdater->processPackage($packageFileInfo, $rootComposerJson);
+            // $symlink => `true`: when executing a package,
+            // any modification to another local package can be seen immediately
+            $this->composerJsonRepositoriesUpdater->processPackage(
+                $packageFileInfo,
+                $rootComposerJson,
+                true
+            );
         }
 
         $message = sprintf(

--- a/packages/monorepo-builder/src/Command/SymlinkToLocalPackagesCommand.php
+++ b/packages/monorepo-builder/src/Command/SymlinkToLocalPackagesCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
+use Symplify\MonorepoBuilder\Testing\ComposerJsonRepositoriesUpdater;
+use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
+use Symplify\PackageBuilder\Console\ShellCode;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SymlinkToLocalPackagesCommand extends AbstractSymplifyCommand
+{
+    /**
+     * @var ComposerJsonProvider
+     */
+    private $composerJsonProvider;
+
+    /**
+     * @var ComposerJsonRepositoriesUpdater
+     */
+    private $composerJsonRepositoriesUpdater;
+
+    public function __construct(
+        ComposerJsonProvider $composerJsonProvider,
+        ComposerJsonRepositoriesUpdater $composerJsonRepositoriesUpdater
+    ) {
+        $this->composerJsonProvider = $composerJsonProvider;
+        $this->composerJsonRepositoriesUpdater = $composerJsonRepositoriesUpdater;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Add paths to local packages as repositories in every composer.json, to symlink to their local source code and avoid fetching them from Packagist');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $rootComposerJson = $this->composerJsonProvider->getRootComposerJson();
+
+        $packagesFileInfos = $this->composerJsonProvider->getPackagesComposerFileInfos();
+        foreach ($packagesFileInfos as $packageFileInfo) {
+            $this->composerJsonRepositoriesUpdater->processPackage($packageFileInfo, $rootComposerJson);
+        }
+
+        $message = sprintf(
+            'The composer.json for the following packages has been updated, adding the path to all local packages as repositories: "%s"',
+            implode(', ', array_map(
+                function (SmartFileInfo $packageFileInfo): string {
+                    return $packageFileInfo->getRelativeFilePathFromCwd();
+                },
+                $packagesFileInfos
+            ))
+        );
+        $this->symfonyStyle->success($message);
+
+        return ShellCode::SUCCESS;
+    }
+}


### PR DESCRIPTION
All the local packages in the monorepo should be able to symlink to their required packages, so that when testing them (either executing their local `vendor/bin/phpunit`, or through other means, such as executing them, running a web server on them, etc), modifying the local source code will show the changes immediately, and avoid using the package from Packagist.

For this, I added 2 commands:

1. `symlink-to-local-packages`: It adds all local packages under entry `repositories` in all `composer.json` files, **with symlinks**
2. `remove-symlink-to-local-packages`: Inverse operation, it removes all local package paths from the `repositories` entry in all `composer.json` files

## Why

In my particular case, one of my dependencies is a WordPress plugin. To test it, I execute a command on the plugin's folder, which starts a Docker container with a new WordPress instance, and the plugin active. The plugin references many local packages in the monorepo. With symlinking, modifying the source of any required package will be visible immediately on the web server.

It also makes it easier to contribute to the local packages.

## How to use it

`monorepo-builder symlink-to-local-packages` is meant for development. The idea is to already commit all `composer.json` symlinking to the local packages to the monorepo. Then, any developer cloning the project, browsing to the package, and doing `composer install`, will already have dependencies symlinked to their source code in the same monorepo.

`monorepo-builder remove-symlink-to-local-packages` is meant for production. Hence, it must be executed within `split_monorepo.yml` before deploying the code to the target repo, so that the target repo does not contain the symlinks, and retrieves all packages from Packagist.