### PR TITLE
[Monorepo Builder] Avoid duplicating entries in composer.json's repositories

### DIFF
--- a/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
@@ -54,17 +54,56 @@ final class ComposerJsonSymlinker
                 'url' => $relativePathToLocalPackage,
                 // we need hard copy of files, as in normal composer install of standalone package
                 'options' => [
-                    'symlink' => false,
+                    'symlink' => false
                 ],
             ];
 
             if (array_key_exists(ComposerJsonSection::REPOSITORIES, $packageComposerJson)) {
-                array_unshift($packageComposerJson[ComposerJsonSection::REPOSITORIES], $repositoriesContent);
+                $packageComposerJson = $this->addRepositoryEntryToPackageComposerJson($packageComposerJson, $repositoriesContent);
             } else {
                 $packageComposerJson[ComposerJsonSection::REPOSITORIES][] = $repositoriesContent;
             }
         }
 
         return $packageComposerJson;
+    }
+
+    /**
+     * @param mixed[] $packageComposerJson
+     * @param mixed[] $repositoriesContent
+     * @return mixed[]
+     */
+    private function addRepositoryEntryToPackageComposerJson(
+        array $packageComposerJson,
+        array $repositoriesContent
+    ): array {
+        // First check if this entry already exists. If so, replace it
+        foreach ($packageComposerJson[ComposerJsonSection::REPOSITORIES] as $key => $repository) {
+            if ($this->isSamePackageEntry($repository, $repositoriesContent)) {
+                // Just override the "options"
+                if (isset($repositoriesContent['options'])) {
+                    $packageComposerJson[ComposerJsonSection::REPOSITORIES][$key]['options'] = $repositoriesContent['options'];
+                } else {
+                    unset($packageComposerJson[ComposerJsonSection::REPOSITORIES][$key]['options']);
+                }
+                return $packageComposerJson;
+            }
+        }
+        // Add the new entry
+        array_unshift($packageComposerJson[ComposerJsonSection::REPOSITORIES], $repositoriesContent);
+        return $packageComposerJson;
+    }
+
+    /**
+     * @param mixed[] $repository
+     * @param mixed[] $repositoriesContent
+     * @return bool
+     */
+    private function isSamePackageEntry(
+        array $repository,
+        array $repositoriesContent
+    ): bool {
+        return isset($repository['type']) && $repository['type'] === $repositoriesContent['type']
+            && isset($repository['url']) && $repository['url'] === $repositoriesContent['url'];
     }
 }

--- a/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
+++ b/packages/monorepo-builder/packages/testing/tests/ComposerJson/ComposerJsonSymlinkerTest.php
@@ -90,4 +90,31 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
             ],
         ], $packageComposerJson);
     }
+
+    public function testReusesExistingRepositoryEntry(): void
+    {
+        $mainComposerJson = new SmartFileInfo(__DIR__ . '/composer.json');
+        $packageFileInfo = new SmartFileInfo(__DIR__ . '/packages/package-three/composer.json');
+
+        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
+
+        $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
+            $packageComposerJson,
+            ['example/package-one'],
+            $mainComposerJson
+        );
+
+        $this->assertSame([
+            'name' => 'example/package-three',
+            'repositories' => [
+                [
+                    'type' => 'path',
+                    'url' => '../../packages/package-one',
+                    'options' => [
+                        'symlink' => false,
+                    ],
+                ],
+            ],
+        ], $packageComposerJson);
+    }
 }

--- a/packages/monorepo-builder/packages/testing/tests/ComposerJson/packages/package-three/composer.json
+++ b/packages/monorepo-builder/packages/testing/tests/ComposerJson/packages/package-three/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "example/package-three",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../packages/package-one",
+            "options": {
+                "symlink": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
As requested in https://github.com/symplify/symplify/pull/2712#discussion_r549346977.

Currently, if `composer.json` already has an entry for the local package `packages/package-one`, like this:

```json
{
    "name": "example/package-three",
    "repositories": [
        {
            "type": "path",
            "url": "../../packages/package-one",
            "options": {
                "symlink": true
            }
        }
    ]
}
```

after running `monorepo-builder localize-composer-paths` it would duplicate the entry, like this:

```json
{
    "name": "example/package-three",
    "repositories": [
        {
            "type": "path",
            "url": "../../packages/package-one",
            "options": {
                "symlink": true
            }
        },
        {
            "type": "path",
            "url": "../../packages/package-one",
            "options": {
                "symlink": false
            }
        }
    ]
}
```

In this PR, it checks if the entry exists, and if so it already uses it:


```json
{
    "name": "example/package-three",
    "repositories": [
        {
            "type": "path",
            "url": "../../packages/package-one",
            "options": {
                "symlink": false
            }
        }
    ]
}
```