### PR TITLE
[Monorepo Builder] Don't hardcode split_monorepo.yml, use config in PHP

### DIFF
--- a/.github/workflows/build_scoped_packages.yaml
+++ b/.github/workflows/build_scoped_packages.yaml
@@ -66,7 +66,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
                     package-directory: 'packages-scoped/${{ matrix.scoped_package.directory }}'
-                    split-repository-organization: 'symplify'
+                    split-repository-organization: '${{ matrix.package.organization }}'
                     split-repository-name: '${{ matrix.scoped_package.directory }}-prefixed'
                     tag: ${{ steps.previous_tag.outputs.tag }}
                     user-name: "kaizen-ci"

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -51,13 +51,13 @@ jobs:
 
             -
                 # Uses an action in the root directory
-                name: Monorepo Split of ${{ matrix.package }}
+                name: Monorepo Split of ${{ matrix.package.name }}
                 uses: symplify/github-action-monorepo-split@master
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
-                    package-directory: 'packages/${{ matrix.package }}'
+                    package-directory: '${{ matrix.package.path }}'
                     split-repository-organization: 'symplify'
-                    split-repository-name: '${{ matrix.package }}'
+                    split-repository-name: '${{ matrix.package.name }}'
                     user-name: "kaizen-ci"
                     user-email: "info@kaizen-ci.org"

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -57,7 +57,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
                     package-directory: '${{ matrix.package.path }}'
-                    split-repository-organization: 'symplify'
+                    split-repository-organization: '${{ matrix.package.organization }}'
                     split-repository-name: '${{ matrix.package.name }}'
                     user-name: "kaizen-ci"
                     user-email: "info@kaizen-ci.org"

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -63,7 +63,7 @@ jobs:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
                     package-directory: '${{ matrix.package.path }}'
-                    split-repository-organization: 'symplify'
+                    split-repository-organization: '${{ matrix.package.organization }}'
                     split-repository-name: '${{ matrix.package.name }}'
                     tag: ${{ steps.previous_tag.outputs.tag }}
                     user-name: "kaizen-ci"

--- a/.github/workflows/split_monorepo_tagged.yaml
+++ b/.github/workflows/split_monorepo_tagged.yaml
@@ -57,14 +57,14 @@ jobs:
 
             -
                 # Uses an action in the root directory
-                name: Monorepo Split of ${{ matrix.package }}
+                name: Monorepo Split of ${{ matrix.package.name }}
                 uses: symplify/github-action-monorepo-split@master
                 env:
                     GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
                 with:
-                    package-directory: 'packages/${{ matrix.package }}'
+                    package-directory: '${{ matrix.package.path }}'
                     split-repository-organization: 'symplify'
-                    split-repository-name: '${{ matrix.package }}'
+                    split-repository-name: '${{ matrix.package.name }}'
                     tag: ${{ steps.previous_tag.outputs.tag }}
                     user-name: "kaizen-ci"
                     user-email: "info@kaizen-ci.org"

--- a/.github/workflows/split_tests.yaml
+++ b/.github/workflows/split_tests.yaml
@@ -39,7 +39,7 @@ jobs:
             matrix:
                 package: ${{ fromJson(needs.provide_packages_json.outputs.matrix )}}
 
-        name: Split Tests of ${{ matrix.package }}
+        name: Split Tests of ${{ matrix.package.name }}
 
         steps:
             -   uses: actions/checkout@v2
@@ -51,10 +51,10 @@ jobs:
 
             -   run: composer install --no-progress --ansi
 
-            -   run: packages/monorepo-builder/bin/monorepo-builder localize-composer-paths packages/${{ matrix.package }}/composer.json --ansi
+            -   run: packages/monorepo-builder/bin/monorepo-builder localize-composer-paths ${{ matrix.package.path }}/composer.json --ansi
 
-            -   run: composer update --no-progress --ansi --working-dir packages/${{ matrix.package }}
+            -   run: composer update --no-progress --ansi --working-dir ${{ matrix.package.path }}
 
             -
-                working-directory: packages/${{ matrix.package }}
+                working-directory: ${{ matrix.package.path }}
                 run: vendor/bin/phpunit

--- a/.github/workflows/split_unused_packages.yaml
+++ b/.github/workflows/split_unused_packages.yaml
@@ -69,13 +69,13 @@ jobs:
             # composer install cache - https://github.com/ramsey/composer-install
             -   uses: "ramsey/composer-install@v1"
 
-            -   run: packages/monorepo-builder/bin/monorepo-builder localize-composer-paths ${{ matrix.package_path }}/composer.json --ansi
+            -   run: packages/monorepo-builder/bin/monorepo-builder localize-composer-paths ${{ matrix.package.path }}/composer.json --ansi
 
-            -   run: composer update --no-progress --ansi --working-dir ${{ matrix.package_path }}
+            -   run: composer update --no-progress --ansi --working-dir ${{ matrix.package.path }}
 
-            -   run: composer require icanhazstring/composer-unused --dev --ansi --working-dir ${{ matrix.package_path }}
+            -   run: composer require icanhazstring/composer-unused --dev --ansi --working-dir ${{ matrix.package.path }}
 
             -
-                name: Unused Packages of ${{ matrix.package_path }}
-                working-directory: ${{ matrix.package_path }}
+                name: Unused Packages of ${{ matrix.package.name }}
+                working-directory: ${{ matrix.package.path }}
                 run: composer unused --ansi

--- a/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerJsonSymlinker.php
@@ -54,12 +54,15 @@ final class ComposerJsonSymlinker
                 'type' => 'path',
                 'url' => $relativePathToLocalPackage,
                 'options' => [
-                    'symlink' => $symlink
+                    'symlink' => $symlink,
                 ],
             ];
 
             if (array_key_exists(ComposerJsonSection::REPOSITORIES, $packageComposerJson)) {
-                $packageComposerJson = $this->addRepositoryEntryToPackageComposerJson($packageComposerJson, $repositoriesContent);
+                $packageComposerJson = $this->addRepositoryEntryToPackageComposerJson(
+                    $packageComposerJson,
+                    $repositoriesContent
+                );
             } else {
                 $packageComposerJson[ComposerJsonSection::REPOSITORIES][] = $repositoriesContent;
             }
@@ -97,12 +100,9 @@ final class ComposerJsonSymlinker
     /**
      * @param mixed[] $repository
      * @param mixed[] $repositoriesContent
-     * @return bool
      */
-    private function isSamePackageEntry(
-        array $repository,
-        array $repositoriesContent
-    ): bool {
+    private function isSamePackageEntry(array $repository, array $repositoriesContent): bool
+    {
         return isset($repository['type']) && $repository['type'] === $repositoriesContent['type']
             && isset($repository['url']) && $repository['url'] === $repositoriesContent['url'];
     }

--- a/packages/monorepo-builder/src/Command/PackagesJsonCommand.php
+++ b/packages/monorepo-builder/src/Command/PackagesJsonCommand.php
@@ -32,10 +32,10 @@ final class PackagesJsonCommand extends AbstractSymplifyCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $packagePaths = $this->packageJsonProvider->providePackages();
+        $packageEntries = $this->packageJsonProvider->providePackageEntries();
 
         // must be without spaces, otherwise it breaks GitHub Actions json
-        $json = Json::encode($packagePaths);
+        $json = Json::encode($packageEntries);
         $this->symfonyStyle->writeln($json);
 
         return ShellCode::SUCCESS;

--- a/packages/monorepo-builder/src/Exception/Git/InvalidGitRemoteException.php
+++ b/packages/monorepo-builder/src/Exception/Git/InvalidGitRemoteException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Exception\Git;
+
+use Exception;
+
+final class InvalidGitRemoteException extends Exception
+{
+}

--- a/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
+++ b/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Finder;
 
 use Symfony\Component\Finder\Finder;
-use Symplify\MonorepoBuilder\ValueObject\Option;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+use Symplify\SmartFileSystem\Finder\FinderSanitizer;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
 
 /**
  * @see \Symplify\MonorepoBuilder\Tests\Finder\PackageComposerFinder\PackageComposerFinderTest
@@ -35,9 +36,11 @@ final class PackageComposerFinder
      */
     private $cachedPackageComposerFiles = [];
 
-    public function __construct(ParameterProvider $parameterProvider, FinderSanitizer $finderSanitizer)
+    public function __construct(ParameterProvider $parameterProvider, FinderSanitizer $finderSanitizer, ParameterSupplier $parameterSupplier)
     {
-        $this->packageDirectories = $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES);
+        $this->packageDirectories = $parameterProvider->provideArrayParameter(
+            array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(Option::PACKAGE_DIRECTORIES))
+        );
         $this->packageDirectoriesExcludes = $parameterProvider->provideArrayParameter(
             Option::PACKAGE_DIRECTORIES_EXCLUDES
         );

--- a/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
+++ b/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
@@ -38,9 +38,9 @@ final class PackageComposerFinder
 
     public function __construct(ParameterProvider $parameterProvider, FinderSanitizer $finderSanitizer, ParameterSupplier $parameterSupplier)
     {
-        $this->packageDirectories = $parameterProvider->provideArrayParameter(
-            array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(Option::PACKAGE_DIRECTORIES))
-        );
+        $this->packageDirectories = array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(
+            $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES)
+        ));
         $this->packageDirectoriesExcludes = $parameterProvider->provideArrayParameter(
             Option::PACKAGE_DIRECTORIES_EXCLUDES
         );

--- a/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
+++ b/packages/monorepo-builder/src/Finder/PackageComposerFinder.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Finder;
 
 use Symfony\Component\Finder\Finder;
-use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\MonorepoBuilder\ValueObject\Option;
-use Symplify\SmartFileSystem\Finder\FinderSanitizer;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\SmartFileSystem\Finder\FinderSanitizer;
+use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
  * @see \Symplify\MonorepoBuilder\Tests\Finder\PackageComposerFinder\PackageComposerFinderTest
@@ -36,8 +36,11 @@ final class PackageComposerFinder
      */
     private $cachedPackageComposerFiles = [];
 
-    public function __construct(ParameterProvider $parameterProvider, FinderSanitizer $finderSanitizer, ParameterSupplier $parameterSupplier)
-    {
+    public function __construct(
+        ParameterProvider $parameterProvider,
+        FinderSanitizer $finderSanitizer,
+        ParameterSupplier $parameterSupplier
+    ) {
         $this->packageDirectories = array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(
             $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES)
         ));

--- a/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -44,16 +44,16 @@ final class GithubRepositoryFromRemoteResolver
             return sprintf('%s://%s%s/%s', $urlScheme, $urlHost, $pathDirname, $pathFilename);
         }
 
-        // turn SSH format to "https"
-        if (Strings::startsWith($url, 'git@')) {
-            $url = Strings::substring($url, 0, -4);
-            $url = str_replace(':', '/', $url);
-            $url = Strings::substring($url, Strings::length('git@'));
-
-            return sprintf('%s://%s', self::HTTPS_SCHEME, $url);
+        if (! Strings::startsWith($url, 'git@')) {
+            $this->throwException($url);
         }
 
-        $this->throwException($url);
+        // turn SSH format to "https"
+        $url = Strings::substring($url, 0, -4);
+        $url = str_replace(':', '/', $url);
+        $url = Strings::substring($url, Strings::length('git@'));
+
+        return sprintf('%s://%s', self::HTTPS_SCHEME, $url);
     }
 
     private function throwException(string $url): void

--- a/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Github;
+
+use Nette\Utils\Strings;
+use Symplify\ChangelogLinker\Exception\Git\InvalidGitRemoteException;
+use function parse_url;
+use function pathinfo;
+use function sprintf;
+use function str_replace;
+use const PATHINFO_DIRNAME;
+use const PATHINFO_FILENAME;
+use const PHP_URL_HOST;
+use const PHP_URL_PATH;
+use const PHP_URL_SCHEME;
+
+/**
+ * @see \Symplify\ChangelogLinker\Tests\Github\GithubRepositoryFromRemoteResolverTest
+ */
+final class GithubRepositoryFromRemoteResolver
+{
+    /**
+     * @var string The scheme from web URLs
+     */
+    private const HTTPS_SCHEME = 'https';
+
+    public function resolveFromUrl(string $url): string
+    {
+        // Normalizing "https" url
+        if (Strings::startsWith($url, self::HTTPS_SCHEME)) {
+            $urlScheme = parse_url($url, PHP_URL_SCHEME);
+            $urlHost = parse_url($url, PHP_URL_HOST);
+
+            $urlPath = parse_url($url, PHP_URL_PATH);
+            if ($urlPath === false || $urlPath === null) {
+                $this->throwException($url);
+            }
+
+            $pathDirname = pathinfo($urlPath, PATHINFO_DIRNAME);
+            $pathFilename = pathinfo($urlPath, PATHINFO_FILENAME);
+
+            return sprintf('%s://%s%s/%s', $urlScheme, $urlHost, $pathDirname, $pathFilename);
+        }
+
+        // turn SSH format to "https"
+        if (Strings::startsWith($url, 'git@')) {
+            $url = Strings::substring($url, 0, -4);
+            $url = str_replace(':', '/', $url);
+            $url = Strings::substring($url, Strings::length('git@'));
+
+            return sprintf('%s://%s', self::HTTPS_SCHEME, $url);
+        }
+
+        $this->throwException($url);
+    }
+
+    private function throwException(string $url): void
+    {
+        throw new InvalidGitRemoteException(sprintf(
+            'Remote url "%s" could not be resolved to https form. Have you added it via "git remote add origin"?',
+            $url
+        ));
+    }
+}

--- a/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Github;
 
 use Nette\Utils\Strings;
-use Symplify\ChangelogLinker\Exception\Git\InvalidGitRemoteException;
+use Symplify\MonorepoBuilder\Exception\Git\InvalidGitRemoteException;
 use function parse_url;
 use function pathinfo;
 use function sprintf;

--- a/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryFromRemoteResolver.php
@@ -17,7 +17,7 @@ use const PHP_URL_PATH;
 use const PHP_URL_SCHEME;
 
 /**
- * @see \Symplify\ChangelogLinker\Tests\Github\GithubRepositoryFromRemoteResolverTest
+ * @see \Symplify\MonorepoBuilder\Tests\Github\GithubRepositoryFromRemoteResolverTest
  */
 final class GithubRepositoryFromRemoteResolver
 {

--- a/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Github;
+
+use Nette\Utils\Strings;
+use Symfony\Component\Process\Process;
+
+/**
+ * @see \Symplify\MonorepoBuilder\Tests\Github\GithubRepositoryResolverTest
+ */
+final class GithubRepositoryResolver
+{
+    /**
+     * @var GithubRepositoryFromRemoteResolver
+     */
+    private $githubRepositoryFromRemoteResolver;
+
+    public function __construct(GithubRepositoryFromRemoteResolver $githubRepositoryFromRemoteResolver)
+    {
+        $this->githubRepositoryFromRemoteResolver = $githubRepositoryFromRemoteResolver;
+    }
+
+    public function resolveGitHubRepositoryNameFromRemote(): string
+    {
+        // Get the remote origin URL, with format: https://github.com/account/package
+        $process = new Process(['git', 'config', '--get', 'remote.origin.url']);
+        $process->run();
+        $repositoryOriginUrl = trim($process->getOutput());
+        $repositoryUrl = $this->githubRepositoryFromRemoteResolver->resolveFromUrl($repositoryOriginUrl);
+        return $this->resolveGitHubRepositoryName($repositoryUrl);
+    }
+
+    public function resolveGitHubRepositoryName(string $repositoryUrl): string
+    {
+        // Extract the account name: everything after "github.com/", and before the next "/"
+        $repository = Strings::substring($repositoryUrl, Strings::length('https://github.com/'));
+        return Strings::before($repository, '/');
+    }
+}

--- a/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
@@ -59,7 +59,11 @@ final class GithubRepositoryResolver
         if (isset($this->repositoryOwners[$repositoryOriginUrl])) {
             return $this->repositoryOwners[$repositoryOriginUrl];
         }
+
+        // Extract the owner: everything after "github.com/", and before the next "/"
         $repositoryUrl = $this->githubRepositoryFromRemoteResolver->resolveFromUrl($repositoryOriginUrl);
+
+        // Make sure the format is https://github.com/owner/package
         if (! Strings::startsWith($repositoryUrl, self::GITHUB_URL)) {
             throw new ShouldNotHappenException(
                 sprintf(
@@ -69,7 +73,6 @@ final class GithubRepositoryResolver
                 )
             );
         }
-        // Extract the account name: everything after "github.com/", and before the next "/"
         $repository = Strings::substring($repositoryUrl, Strings::length(self::GITHUB_URL));
         $this->repositoryOwners[$repositoryOriginUrl] = Strings::before($repository, '/');
         return $this->repositoryOwners[$repositoryOriginUrl];

--- a/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
@@ -74,7 +74,16 @@ final class GithubRepositoryResolver
             );
         }
         $repository = Strings::substring($repositoryUrl, Strings::length(self::GITHUB_URL));
-        $this->repositoryOwners[$repositoryOriginUrl] = Strings::before($repository, '/');
+        $owner = Strings::before($repository, '/');
+        if ($owner === null) {
+            throw new ShouldNotHappenException(
+                sprintf(
+                    'Cannot deduce the owner for remote URL "%s"',
+                    $repositoryUrl
+                )
+            );
+        }
+        $this->repositoryOwners[$repositoryOriginUrl] = $owner;
         return $this->repositoryOwners[$repositoryOriginUrl];
     }
 }

--- a/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
+++ b/packages/monorepo-builder/src/Github/GithubRepositoryResolver.php
@@ -6,12 +6,18 @@ namespace Symplify\MonorepoBuilder\Github;
 
 use Nette\Utils\Strings;
 use Symfony\Component\Process\Process;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 /**
  * @see \Symplify\MonorepoBuilder\Tests\Github\GithubRepositoryResolverTest
  */
 final class GithubRepositoryResolver
 {
+    /**
+     * @var string
+     */
+    private const GITHUB_URL = 'https://github.com/';
+
     /**
      * @var GithubRepositoryFromRemoteResolver
      */
@@ -28,14 +34,23 @@ final class GithubRepositoryResolver
         $process = new Process(['git', 'config', '--get', 'remote.origin.url']);
         $process->run();
         $repositoryOriginUrl = trim($process->getOutput());
-        $repositoryUrl = $this->githubRepositoryFromRemoteResolver->resolveFromUrl($repositoryOriginUrl);
-        return $this->resolveGitHubRepositoryName($repositoryUrl);
+        return $this->resolveGitHubRepositoryName($repositoryOriginUrl);
     }
 
-    public function resolveGitHubRepositoryName(string $repositoryUrl): string
+    public function resolveGitHubRepositoryName(string $repositoryOriginUrl): string
     {
+        $repositoryUrl = $this->githubRepositoryFromRemoteResolver->resolveFromUrl($repositoryOriginUrl);
+        if (! Strings::startsWith($repositoryUrl, self::GITHUB_URL)) {
+            throw new ShouldNotHappenException(
+                sprintf(
+                    'Remote URL "%s" is not hosted on GitHub (should start with "%s")',
+                    $repositoryUrl,
+                    self::GITHUB_URL
+                )
+            );
+        }
         // Extract the account name: everything after "github.com/", and before the next "/"
-        $repository = Strings::substring($repositoryUrl, Strings::length('https://github.com/'));
+        $repository = Strings::substring($repositoryUrl, Strings::length(self::GITHUB_URL));
         return Strings::before($repository, '/');
     }
 }

--- a/packages/monorepo-builder/src/Json/PackageJsonProvider.php
+++ b/packages/monorepo-builder/src/Json/PackageJsonProvider.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Json;
 
+use Nette\Utils\Strings;
+use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\MonorepoBuilder\Package\PackageProvider;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class PackageJsonProvider
 {
@@ -12,10 +17,17 @@ final class PackageJsonProvider
      * @var PackageProvider
      */
     private $packageProvider;
+    /**
+     * @var string[]
+     */
+    private $packageDirectoriesData = [];
 
-    public function __construct(PackageProvider $packageProvider)
+    public function __construct(PackageProvider $packageProvider, ParameterProvider $parameterProvider, ParameterSupplier $parameterSupplier)
     {
         $this->packageProvider = $packageProvider;
+        $this->packageDirectoriesData = $parameterSupplier->fillPackageDirectoriesWithDefaultData(
+            $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES)
+        );
     }
 
     /**
@@ -28,9 +40,30 @@ final class PackageJsonProvider
             $packageEntries[] = [
                 'name' => $package->getShortName(),
                 'path' => $package->getRelativePath(),
+                'organization' => $this->getRepoOwnerForPackageDirectory($package->getRealPath()),
             ];
         }
 
         return $packageEntries;
+    }
+
+    /**
+     * @return array<string[]>
+     */
+    private function getRepoOwnerForPackageDirectory(string $packageRealPath): string
+    {
+        // Iterate all entries until finding the one for the package's path
+        foreach ($this->packageDirectoriesData as $packageDirectory => $packageData) {
+            if (Strings::startsWith($packageRealPath, $packageDirectory)) {
+                return (string) $packageData['organization'];
+            }
+        }
+
+        throw new ShouldNotHappenException(
+            sprintf(
+                'There is no organization for the package under path "%s"',
+                $packageRealPath
+            )
+        );
     }
 }

--- a/packages/monorepo-builder/src/Json/PackageJsonProvider.php
+++ b/packages/monorepo-builder/src/Json/PackageJsonProvider.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Json;
 
 use Nette\Utils\Strings;
-use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\MonorepoBuilder\Package\PackageProvider;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class PackageJsonProvider
@@ -17,13 +17,17 @@ final class PackageJsonProvider
      * @var PackageProvider
      */
     private $packageProvider;
+
     /**
      * @var string[]
      */
     private $packageDirectoriesData = [];
 
-    public function __construct(PackageProvider $packageProvider, ParameterProvider $parameterProvider, ParameterSupplier $parameterSupplier)
-    {
+    public function __construct(
+        PackageProvider $packageProvider,
+        ParameterProvider $parameterProvider,
+        ParameterSupplier $parameterSupplier
+    ) {
         $this->packageProvider = $packageProvider;
         $this->packageDirectoriesData = $parameterSupplier->fillPackageDirectoriesWithDefaultData(
             $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES)
@@ -60,10 +64,7 @@ final class PackageJsonProvider
         }
 
         throw new ShouldNotHappenException(
-            sprintf(
-                'There is no organization for the package under path "%s"',
-                $packageRealPath
-            )
+            sprintf('There is no organization for the package under path "%s"', $packageRealPath)
         );
     }
 }

--- a/packages/monorepo-builder/src/Json/PackageJsonProvider.php
+++ b/packages/monorepo-builder/src/Json/PackageJsonProvider.php
@@ -19,15 +19,18 @@ final class PackageJsonProvider
     }
 
     /**
-     * @return string[]
+     * @return array<string[]>
      */
-    public function providePackages(): array
+    public function providePackageEntries(): array
     {
-        $packageShortNames = [];
+        $packageEntries = [];
         foreach ($this->packageProvider->provide() as $package) {
-            $packageShortNames[] = $package->getShortName();
+            $packageEntries[] = [
+                'name' => $package->getShortName(),
+                'path' => $package->getRelativePath(),
+            ];
         }
 
-        return $packageShortNames;
+        return $packageEntries;
     }
 }

--- a/packages/monorepo-builder/src/Json/PackageJsonProvider.php
+++ b/packages/monorepo-builder/src/Json/PackageJsonProvider.php
@@ -19,7 +19,7 @@ final class PackageJsonProvider
     private $packageProvider;
 
     /**
-     * @var string[]
+     * @var array<string, mixed[]>
      */
     private $packageDirectoriesData = [];
 
@@ -51,9 +51,6 @@ final class PackageJsonProvider
         return $packageEntries;
     }
 
-    /**
-     * @return array<string[]>
-     */
     private function getRepoOwnerForPackageDirectory(string $packageRealPath): string
     {
         // Iterate all entries until finding the one for the package's path

--- a/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
+++ b/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
@@ -23,10 +23,10 @@ final class ParameterSupplier
     }
 
     /**
-     * @var mixed[]
+     * @var mixed[] $packageDirectoriesData
      * @return array<string, mixed[]>
      */
-    public function fillPackageDirectoriesWithDefaultData(array $packageDirectoriesData)
+    public function fillPackageDirectoriesWithDefaultData(array $packageDirectoriesData): array
     {
         $completePackageDirectoriesData = [];
         foreach ($packageDirectoriesData as $packageDirectory => $data) {

--- a/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
+++ b/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
@@ -43,7 +43,7 @@ final class ParameterSupplier
             }
             // If the organization is not provided, add the default one
             if (! isset($data['organization'])) {
-                $data['organization'] = $this->githubRepositoryResolver->resolveGitHubRepositoryNameFromRemote();
+                $data['organization'] = $this->githubRepositoryResolver->resolveGitHubRepositoryOwnerFromRemote();
             }
             $completePackageDirectoriesData[$packageDirectory] = $data;
         }

--- a/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
+++ b/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
@@ -30,13 +30,16 @@ final class ParameterSupplier
     {
         $completePackageDirectoriesData = [];
         foreach ($packageDirectoriesData as $packageDirectory => $data) {
-            // If the key is an int, then the package directory is the value
+            // Check if the array is passed as [ value ] instead of [ key => value]
             if (is_int($packageDirectory)) {
+                // The package directory is the array's value, and it has no data
                 $packageDirectory = $data;
                 $data = [];
             }
             if (! is_string($packageDirectory) || ! is_array($data)) {
-                throw new ShouldNotHappenException();
+                throw new ShouldNotHappenException(
+                    'The package directory must be a string, and its configured data must be an array'
+                );
             }
             // If the organization is not provided, add the default one
             if (! isset($data['organization'])) {

--- a/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
+++ b/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
@@ -23,7 +23,7 @@ final class ParameterSupplier
     }
 
     /**
-     * @var mixed[] $packageDirectoriesData
+     * @var mixed[]
      * @return array<string, mixed[]>
      */
     public function fillPackageDirectoriesWithDefaultData(array $packageDirectoriesData)

--- a/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
+++ b/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
@@ -36,6 +36,10 @@ final class ParameterSupplier
                 $packageDirectory = $data;
                 $data = [];
             }
+            // Empty values: replace with empty array
+            if ($data === null || $data === '') {
+                $data = [];
+            }
             if (! is_string($packageDirectory) || ! is_array($data)) {
                 throw new ShouldNotHappenException(
                     'The package directory must be a string, and its configured data must be an array'

--- a/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
+++ b/packages/monorepo-builder/src/Parameter/ParameterSupplier.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Parameter;
+
+use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
+
+/**
+ * @see \Symplify\MonorepoBuilder\Tests\Parameter\ParameterSupplierTest
+ */
+final class ParameterSupplier
+{
+    /**
+     * @var GithubRepositoryResolver
+     */
+    private $githubRepositoryResolver;
+
+    public function __construct(GithubRepositoryResolver $githubRepositoryResolver)
+    {
+        $this->githubRepositoryResolver = $githubRepositoryResolver;
+    }
+
+    /**
+     * @var mixed[] $packageDirectoriesData
+     * @return array<string, mixed[]>
+     */
+    public function fillPackageDirectoriesWithDefaultData(array $packageDirectoriesData)
+    {
+        $completePackageDirectoriesData = [];
+        foreach ($packageDirectoriesData as $packageDirectory => $data) {
+            // If the key is an int, then the package directory is the value
+            if (is_int($packageDirectory)) {
+                $packageDirectory = $data;
+                $data = [];
+            }
+            if (! is_string($packageDirectory) || ! is_array($data)) {
+                throw new ShouldNotHappenException();
+            }
+            // If the organization is not provided, add the default one
+            if (! isset($data['organization'])) {
+                $data['organization'] = $this->githubRepositoryResolver->resolveGitHubRepositoryNameFromRemote();
+            }
+            $completePackageDirectoriesData[$packageDirectory] = $data;
+        }
+        return $completePackageDirectoriesData;
+    }
+}

--- a/packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php
+++ b/packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php
@@ -25,9 +25,9 @@ final class SourcesPresenceValidator
     public function __construct(ComposerJsonProvider $composerJsonProvider, ParameterProvider $parameterProvider, ParameterSupplier $parameterSupplier)
     {
         $this->composerJsonProvider = $composerJsonProvider;
-        $this->packageDirectories = $parameterProvider->provideArrayParameter(
-            array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(Option::PACKAGE_DIRECTORIES))
-        );
+        $this->packageDirectories = array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(
+            $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES)
+        ));
     }
 
     public function validatePackageComposerJsons(): void

--- a/packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php
+++ b/packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Validator;
 
-use Symplify\MonorepoBuilder\Exception\Validator\InvalidComposerJsonSetupException;
-use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
 use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
+use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
+use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
+use Symplify\MonorepoBuilder\Exception\Validator\InvalidComposerJsonSetupException;
 
 final class SourcesPresenceValidator
 {
@@ -21,10 +22,12 @@ final class SourcesPresenceValidator
      */
     private $composerJsonProvider;
 
-    public function __construct(ComposerJsonProvider $composerJsonProvider, ParameterProvider $parameterProvider)
+    public function __construct(ComposerJsonProvider $composerJsonProvider, ParameterProvider $parameterProvider, ParameterSupplier $parameterSupplier)
     {
         $this->composerJsonProvider = $composerJsonProvider;
-        $this->packageDirectories = $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES);
+        $this->packageDirectories = $parameterProvider->provideArrayParameter(
+            array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(Option::PACKAGE_DIRECTORIES))
+        );
     }
 
     public function validatePackageComposerJsons(): void

--- a/packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php
+++ b/packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Validator;
 
+use Symplify\MonorepoBuilder\Exception\Validator\InvalidComposerJsonSetupException;
+use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
+use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
 use Symplify\MonorepoBuilder\ValueObject\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
-use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
-use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
-use Symplify\MonorepoBuilder\Exception\Validator\InvalidComposerJsonSetupException;
 
 final class SourcesPresenceValidator
 {
@@ -22,8 +22,11 @@ final class SourcesPresenceValidator
      */
     private $composerJsonProvider;
 
-    public function __construct(ComposerJsonProvider $composerJsonProvider, ParameterProvider $parameterProvider, ParameterSupplier $parameterSupplier)
-    {
+    public function __construct(
+        ComposerJsonProvider $composerJsonProvider,
+        ParameterProvider $parameterProvider,
+        ParameterSupplier $parameterSupplier
+    ) {
         $this->composerJsonProvider = $composerJsonProvider;
         $this->packageDirectories = array_keys($parameterSupplier->fillPackageDirectoriesWithDefaultData(
             $parameterProvider->provideArrayParameter(Option::PACKAGE_DIRECTORIES)

--- a/packages/monorepo-builder/src/ValueObject/Package.php
+++ b/packages/monorepo-builder/src/ValueObject/Package.php
@@ -65,4 +65,9 @@ final class Package
     {
         return $this->rootDirectoryFileInfo->getRelativeFilePathFromCwd();
     }
+
+    public function getRealPath(): string
+    {
+        return $this->rootDirectoryFileInfo->getRealPath();
+    }
 }

--- a/packages/monorepo-builder/tests/Github/GithubRepositoryFromRemoteResolverTest.php
+++ b/packages/monorepo-builder/tests/Github/GithubRepositoryFromRemoteResolverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Github;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+use Symplify\MonorepoBuilder\Exception\Git\InvalidGitRemoteException;
+use Symplify\MonorepoBuilder\Github\GithubRepositoryFromRemoteResolver;
+
+final class GithubRepositoryFromRemoteResolverTest extends TestCase
+{
+    /**
+     * @var GithubRepositoryFromRemoteResolver
+     */
+    private $githubRepositoryFromRemoteResolver;
+
+    protected function setUp(): void
+    {
+        $this->githubRepositoryFromRemoteResolver = new GithubRepositoryFromRemoteResolver();
+    }
+
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $commitHash, string $expectedHttpsUrl): void
+    {
+        $this->assertSame($expectedHttpsUrl, $this->githubRepositoryFromRemoteResolver->resolveFromUrl($commitHash));
+    }
+
+    public function provideData(): Iterator
+    {
+        yield ['git@github.com:symplify/symplify.git', 'https://github.com/symplify/symplify'];
+        yield ['https://github.com/symplify/symplify.git', 'https://github.com/symplify/symplify'];
+        yield ['https://UserName@github.com/symplify/symplify.git', 'https://github.com/symplify/symplify'];
+        yield [
+            'https://UserName:PassWord@github.com:443/symplify/symplify.git',
+            'https://github.com/symplify/symplify',
+        ];
+        yield ['https://www.my-company.com/symplify/symplify.git', 'https://www.my-company.com/symplify/symplify'];
+        yield ['https://gitlab.com/my-group/my-user/my-repo.git', 'https://gitlab.com/my-group/my-user/my-repo'];
+        yield ['https://git/user/project.git', 'https://git/user/project'];
+        yield ['git@github.com:space/low-orbit.git', 'https://github.com/space/low-orbit'];
+    }
+
+    public function testInvalid(): void
+    {
+        $this->expectException(InvalidGitRemoteException::class);
+        $this->githubRepositoryFromRemoteResolver->resolveFromUrl('http://url.git');
+    }
+}

--- a/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
+++ b/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
@@ -9,7 +9,6 @@ use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
 use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
-use Symplify\MonorepoBuilder\Exception\Git\InvalidGitRemoteException;
 
 final class GithubRepositoryResolverTest extends AbstractKernelTestCase
 {
@@ -46,6 +45,7 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
             'symplify',
         ];
         yield ['git@github.com:space/low-orbit.git', 'space'];
+        yield ['https://github.com/symplify/symplify', 'symplify'];
     }
 
     /**

--- a/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
+++ b/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
 use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 use Symplify\MonorepoBuilder\Exception\Git\InvalidGitRemoteException;
 
 final class GithubRepositoryResolverTest extends AbstractKernelTestCase
@@ -27,9 +28,12 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
     /**
      * @dataProvider provideData()
      */
-    public function test(string $commitHash, string $expectedName): void
+    public function test(string $remoteUrl, string $expectedName): void
     {
-        $this->assertSame($expectedName, $this->githubRepositoryResolver->resolveGitHubRepositoryName($commitHash));
+        $this->assertSame(
+            $expectedName,
+            $this->githubRepositoryResolver->resolveGitHubRepositoryName($remoteUrl)
+        );
     }
 
     public function provideData(): Iterator
@@ -41,15 +45,22 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
             'https://UserName:PassWord@github.com:443/symplify/symplify.git',
             'symplify',
         ];
-        yield ['https://www.my-company.com/symplify/symplify.git', 'symplify'];
-        yield ['https://gitlab.com/my-group/my-user/my-repo.git', 'my-user'];
-        yield ['https://git/user/project.git', 'user'];
         yield ['git@github.com:space/low-orbit.git', 'space'];
     }
 
-    public function testInvalid(): void
+    /**
+     * @dataProvider provideInvalidData()
+     */
+    public function testInvalid(string $remoteUrl): void
     {
-        $this->expectException(InvalidGitRemoteException::class);
-        $this->githubRepositoryResolver->resolveGitHubRepositoryName('http://url.git');
+        $this->expectException(ShouldNotHappenException::class);
+        $this->githubRepositoryResolver->resolveGitHubRepositoryName($remoteUrl);
+    }
+
+    public function provideInvalidData(): Iterator
+    {
+        yield ['https://www.my-company.com/symplify/symplify.git'];
+        yield ['https://gitlab.com/my-group/my-user/my-repo.git'];
+        yield ['https://git/user/project.git'];
     }
 }

--- a/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
+++ b/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
@@ -32,7 +32,7 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
     {
         $this->assertSame(
             $expectedName,
-            $this->githubRepositoryResolver->resolveGitHubRepositoryName($remoteUrl)
+            $this->githubRepositoryResolver->resolveGitHubRepositoryOwner($remoteUrl)
         );
     }
 
@@ -54,7 +54,7 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
     public function testInvalid(string $remoteUrl): void
     {
         $this->expectException(ShouldNotHappenException::class);
-        $this->githubRepositoryResolver->resolveGitHubRepositoryName($remoteUrl);
+        $this->githubRepositoryResolver->resolveGitHubRepositoryOwner($remoteUrl);
     }
 
     public function provideInvalidData(): Iterator

--- a/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
+++ b/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Github;
+
+use Iterator;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
+use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
+use Symplify\MonorepoBuilder\Exception\Git\InvalidGitRemoteException;
+
+final class GithubRepositoryResolverTest extends AbstractKernelTestCase
+{
+    /**
+     * @var GithubRepositoryResolver
+     */
+    private $githubRepositoryResolver;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(MonorepoBuilderKernel::class);
+
+        $this->githubRepositoryResolver = $this->getService(GithubRepositoryResolver::class);
+    }
+
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(string $commitHash, string $expectedName): void
+    {
+        $this->assertSame($expectedName, $this->githubRepositoryResolver->resolveGitHubRepositoryName($commitHash));
+    }
+
+    public function provideData(): Iterator
+    {
+        yield ['git@github.com:symplify/symplify.git', 'symplify'];
+        yield ['https://github.com/symplify/symplify.git', 'symplify'];
+        yield ['https://UserName@github.com/symplify/symplify.git', 'symplify'];
+        yield [
+            'https://UserName:PassWord@github.com:443/symplify/symplify.git',
+            'symplify',
+        ];
+        yield ['https://www.my-company.com/symplify/symplify.git', 'symplify'];
+        yield ['https://gitlab.com/my-group/my-user/my-repo.git', 'my-user'];
+        yield ['https://git/user/project.git', 'user'];
+        yield ['git@github.com:space/low-orbit.git', 'space'];
+    }
+
+    public function testInvalid(): void
+    {
+        $this->expectException(InvalidGitRemoteException::class);
+        $this->githubRepositoryResolver->resolveGitHubRepositoryName('http://url.git');
+    }
+}

--- a/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
+++ b/packages/monorepo-builder/tests/Github/GithubRepositoryResolverTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Tests\Github;
 
 use Iterator;
-use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
 use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class GithubRepositoryResolverTest extends AbstractKernelTestCase
@@ -29,10 +29,7 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
      */
     public function test(string $remoteUrl, string $expectedName): void
     {
-        $this->assertSame(
-            $expectedName,
-            $this->githubRepositoryResolver->resolveGitHubRepositoryOwner($remoteUrl)
-        );
+        $this->assertSame($expectedName, $this->githubRepositoryResolver->resolveGitHubRepositoryOwner($remoteUrl));
     }
 
     public function provideData(): Iterator
@@ -40,10 +37,7 @@ final class GithubRepositoryResolverTest extends AbstractKernelTestCase
         yield ['git@github.com:symplify/symplify.git', 'symplify'];
         yield ['https://github.com/symplify/symplify.git', 'symplify'];
         yield ['https://UserName@github.com/symplify/symplify.git', 'symplify'];
-        yield [
-            'https://UserName:PassWord@github.com:443/symplify/symplify.git',
-            'symplify',
-        ];
+        yield ['https://UserName:PassWord@github.com:443/symplify/symplify.git', 'symplify'];
         yield ['git@github.com:space/low-orbit.git', 'space'];
         yield ['https://github.com/symplify/symplify', 'symplify'];
     }

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -8,6 +8,7 @@ use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
 use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class ParameterSupplierTest extends AbstractKernelTestCase
 {
@@ -32,9 +33,6 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
     {
         $completeConfig = [
             'symplify/monorepo-builder' => [
-                'organization' => 'symplify',
-            ],
-            'symplify/package-builder' => [
                 'organization' => 'symplify',
             ],
             'symplify/package-for-migrify' => [
@@ -107,6 +105,18 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
         $this->assertEquals(
             $configAfter,
             $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($configBefore)
+        );
+    }
+
+    public function testIncorrectConfig(): void
+    {
+        $this->expectException(ShouldNotHappenException::class);
+        $config = [
+            'symplify/monorepo-builder' => 3,
+        ];
+        $this->assertEquals(
+            $config,
+            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
         );
     }
 }

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -112,7 +112,7 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
     {
         $this->expectException(ShouldNotHappenException::class);
         $config = [
-            'symplify/monorepo-builder' => 3,
+            'symplify/monorepo-builder' => 'symplify',
         ];
         $this->assertEquals(
             $config,

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -23,9 +23,20 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
         $this->parameterSupplier = $this->getService(ParameterSupplier::class);
     }
 
-    public function testPackageDirectoriesAreComplete(): void
+    /**
+     * @dataProvider provideData()
+     */
+    public function testPackageDirectoriesAreComplete(array $configBefore, $configAfter): void
     {
-        $config = [
+        $this->assertEquals(
+            $configAfter,
+            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($configBefore)
+        );
+    }
+
+    public function provideData(): Iterator
+    {
+        $completeConfig = [
             'symplify/monorepo-builder' => [
                 'organization' => 'symplify',
             ],
@@ -36,71 +47,23 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
                 'organization' => 'migrify',
             ],
         ];
-        $this->assertEquals(
-            $config,
-            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
-        );
+        yield [$completeConfig, $completeConfig];
     }
 
-    public function testFillPackageDirectories(): void
-    {
-        $config = [
-            'symplify/monorepo-builder' => [
-                'foo' => 'bar',
-            ],
-            'symplify/package-builder' => [
-                'organization' => 'symplify',
-            ],
-            'symplify/package-for-migrify' => [],
-        ];
-        $this->assertEquals(
-            $config,
-            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
-        );
-    }
-
-    // /**
-    //  * @dataProvider provideDataAlias()
-    //  */
-    // public function testAlias(string $currentVersion, string $expectedVersion): void
+    // public function testFillPackageDirectories(): void
     // {
-    //     $this->assertSame($expectedVersion, $this->parameterSupplier->getNextAliasFormat($currentVersion));
-    // }
-
-    // public function provideDataAlias(): Iterator
-    // {
-    //     yield ['v4.0.0', '4.1-dev'];
-    //     yield ['4.0.0', '4.1-dev'];
-    //     yield ['4.5.0', '4.6-dev'];
-    //     yield ['v8.0-beta', '8.0-dev'];
-    // }
-
-    // /**
-    //  * @dataProvider provideDataForRequiredNextVersion()
-    //  */
-    // public function testRequiredNextVersion(string $currentVersion, string $expectedVersion): void
-    // {
-    //     $this->assertSame($expectedVersion, $this->parameterSupplier->getRequiredNextFormat($currentVersion));
-    // }
-
-    // public function provideDataForRequiredNextVersion(): Iterator
-    // {
-    //     yield ['v4.0.0', '^4.1'];
-    //     yield ['4.0.0', '^4.1'];
-    //     yield ['8.0-beta', '^8.0'];
-    // }
-
-    // /**
-    //  * @dataProvider provideDataForRequiredVersion()
-    //  */
-    // public function testRequiredVersion(string $currentVersion, string $expectedVersion): void
-    // {
-    //     $this->assertSame($expectedVersion, $this->parameterSupplier->getRequiredFormat($currentVersion));
-    // }
-
-    // public function provideDataForRequiredVersion(): Iterator
-    // {
-    //     yield ['v4.0.0', '^4.0'];
-    //     yield ['4.0.0', '^4.0'];
+    //     $config = [
+    //         'symplify/monorepo-builder' => [
+    //             'foo' => 'bar',
+    //         ],
+    //         'symplify/package-builder' => [
+    //             'organization' => 'symplify',
+    //         ],
+    //         'symplify/package-for-migrify' => [],
+    //     ];
+    //     $this->assertEquals(
+    //         $config,
+    //         $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
+    //     );
     // }
 }

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Tests\Parameter;
 
-use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
-use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\MonorepoBuilder\Github\GithubRepositoryResolver;
 use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
+use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class ParameterSupplierTest extends AbstractKernelTestCase
@@ -16,6 +16,7 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
      * @var ParameterSupplier
      */
     private $parameterSupplier;
+
     /**
      * @var GithubRepositoryResolver
      */
@@ -39,7 +40,7 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
                 'organization' => 'migrify',
             ],
         ];
-        $this->assertEquals(
+        $this->assertSame(
             $completeConfig,
             $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($completeConfig)
         );
@@ -81,7 +82,7 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
                 'organization' => 'migrify',
             ],
         ];
-        $this->assertEquals(
+        $this->assertSame(
             $configAfter,
             $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($configBefore)
         );
@@ -90,10 +91,7 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
     public function testPackageDirectoriesAsKeys(): void
     {
         $repoOwner = $this->githubRepositoryResolver->resolveGitHubRepositoryOwnerFromRemote();
-        $configBefore = [
-            'symplify/monorepo-builder',
-            'rector/rector',
-        ];
+        $configBefore = ['symplify/monorepo-builder', 'rector/rector'];
         $configAfter = [
             'symplify/monorepo-builder' => [
                 'organization' => $repoOwner,
@@ -102,7 +100,7 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
                 'organization' => $repoOwner,
             ],
         ];
-        $this->assertEquals(
+        $this->assertSame(
             $configAfter,
             $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($configBefore)
         );
@@ -114,9 +112,6 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
         $config = [
             'symplify/monorepo-builder' => 'symplify',
         ];
-        $this->assertEquals(
-            $config,
-            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
-        );
+        $this->assertSame($config, $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config));
     }
 }

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -88,4 +88,25 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
             $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($configBefore)
         );
     }
+
+    public function testPackageDirectoriesAsKeys(): void
+    {
+        $repoOwner = $this->githubRepositoryResolver->resolveGitHubRepositoryOwnerFromRemote();
+        $configBefore = [
+            'symplify/monorepo-builder',
+            'rector/rector',
+        ];
+        $configAfter = [
+            'symplify/monorepo-builder' => [
+                'organization' => $repoOwner,
+            ],
+            'rector/rector' => [
+                'organization' => $repoOwner,
+            ],
+        ];
+        $this->assertEquals(
+            $configAfter,
+            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($configBefore)
+        );
+    }
 }

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Utils;
+
+use Iterator;
+use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
+use Symplify\MonorepoBuilder\Parameter\ParameterSupplier;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+
+final class ParameterSupplierTest extends AbstractKernelTestCase
+{
+    /**
+     * @var ParameterSupplier
+     */
+    private $parameterSupplier;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(MonorepoBuilderKernel::class);
+
+        $this->parameterSupplier = $this->getService(ParameterSupplier::class);
+    }
+
+    public function testPackageDirectoriesAreComplete(): void
+    {
+        $config = [
+            'symplify/monorepo-builder' => [
+                'organization' => 'symplify',
+            ],
+            'symplify/package-builder' => [
+                'organization' => 'symplify',
+            ],
+            'symplify/package-for-migrify' => [
+                'organization' => 'migrify',
+            ],
+        ];
+        $this->assertEquals(
+            $config,
+            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
+        );
+    }
+
+    public function testFillPackageDirectories(): void
+    {
+        $config = [
+            'symplify/monorepo-builder' => [
+                'foo' => 'bar',
+            ],
+            'symplify/package-builder' => [
+                'organization' => 'symplify',
+            ],
+            'symplify/package-for-migrify' => [],
+        ];
+        $this->assertEquals(
+            $config,
+            $this->parameterSupplier->fillPackageDirectoriesWithDefaultData($config)
+        );
+    }
+
+    // /**
+    //  * @dataProvider provideDataAlias()
+    //  */
+    // public function testAlias(string $currentVersion, string $expectedVersion): void
+    // {
+    //     $this->assertSame($expectedVersion, $this->parameterSupplier->getNextAliasFormat($currentVersion));
+    // }
+
+    // public function provideDataAlias(): Iterator
+    // {
+    //     yield ['v4.0.0', '4.1-dev'];
+    //     yield ['4.0.0', '4.1-dev'];
+    //     yield ['4.5.0', '4.6-dev'];
+    //     yield ['v8.0-beta', '8.0-dev'];
+    // }
+
+    // /**
+    //  * @dataProvider provideDataForRequiredNextVersion()
+    //  */
+    // public function testRequiredNextVersion(string $currentVersion, string $expectedVersion): void
+    // {
+    //     $this->assertSame($expectedVersion, $this->parameterSupplier->getRequiredNextFormat($currentVersion));
+    // }
+
+    // public function provideDataForRequiredNextVersion(): Iterator
+    // {
+    //     yield ['v4.0.0', '^4.1'];
+    //     yield ['4.0.0', '^4.1'];
+    //     yield ['8.0-beta', '^8.0'];
+    // }
+
+    // /**
+    //  * @dataProvider provideDataForRequiredVersion()
+    //  */
+    // public function testRequiredVersion(string $currentVersion, string $expectedVersion): void
+    // {
+    //     $this->assertSame($expectedVersion, $this->parameterSupplier->getRequiredFormat($currentVersion));
+    // }
+
+    // public function provideDataForRequiredVersion(): Iterator
+    // {
+    //     yield ['v4.0.0', '^4.0'];
+    //     yield ['4.0.0', '^4.0'];
+    // }
+}

--- a/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
+++ b/packages/monorepo-builder/tests/Parameter/ParameterSupplierTest.php
@@ -58,9 +58,9 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
             'symplify/package-for-migrify' => [
                 'branch' => 'main',
             ],
-            'symplify/package-for-migrify' => [
+            'symplify/package-for-rector' => [
                 'branch' => 'main',
-                'organization' => 'migrify',
+                'organization' => 'rector',
             ],
         ];
         $configAfter = [
@@ -77,9 +77,9 @@ final class ParameterSupplierTest extends AbstractKernelTestCase
                 'branch' => 'main',
                 'organization' => $repoOwner,
             ],
-            'symplify/package-for-migrify' => [
+            'symplify/package-for-rector' => [
                 'branch' => 'main',
-                'organization' => 'migrify',
+                'organization' => 'rector',
             ],
         ];
         $this->assertSame(

--- a/packages/phpstan-rules/src/Rules/CheckRequiredInterfaceInContractNamespaceRule.php
+++ b/packages/phpstan-rules/src/Rules/CheckRequiredInterfaceInContractNamespaceRule.php
@@ -43,7 +43,7 @@ final class CheckRequiredInterfaceInContractNamespaceRule extends AbstractSympli
      */
     public function process(Node $node, Scope $scope): array
     {
-        /** @var Namespace_|null */
+        /** @var Namespace_|null $namespace */
         $namespace = $node->getAttribute(PHPStanAttributeKey::PARENT);
         if (! $namespace instanceof Namespace_) {
             return [];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -281,6 +281,9 @@ parameters:
                 - packages/package-builder/src/Parameter/ParameterProvider.php # 26
                 - packages/skipper/src/Skipper/Skipper.php # 50
                 - packages/phpstan-rules/src/Rules/CheckClassNamespaceFollowPsr4Rule.php #31
+                - packages/monorepo-builder/src/Finder/PackageComposerFinder.php #44
+                - packages/monorepo-builder/src/Json/PackageJsonProvider.php #32
+                - packages/monorepo-builder/src/Validator/SourcesPresenceValidator.php #31
 
         # false positives
         - '#Constant Symplify\\ChangelogLinker\\Tests\\ChangeTree\\ChangeFactory\\ChangeFactoryTest\:\:PULL_REQUEST is unused#'


### PR DESCRIPTION
Fixes #2698

What I have done:

- Function `providePackageEntries` in `PackageJsonProvider` returns an array of 3 items: `name`, `path` and `organization`
- Data for `name` and `path` can be already deduced from the package
- Data for a package's `organization` must be provided, using `Option::PACKAGE_DIRECTORIES` in `monorepo-builder.php` like this:

```php
$parameters->set(Option::PACKAGE_DIRECTORIES, [
    __DIR__ . '/packages' => [
        'organization' => 'symplify',
    ],
    __DIR__ . '/projects' => [
        'organization' => 'migrify',
    ],
]);
```

Notice that each entry can pass an array, so it's `['organization' => 'symplify']` instead of directly `symplify`. This is because we can use this config to pass other inputs too, for instance the `branch`. (If passing `symplify` straight, it throws a `ShouldNotHappenException`).

Passing no `organization` in the array, or even no array, also works:

```php
$parameters->set(Option::PACKAGE_DIRECTORIES, [
    __DIR__ . '/packages' => [],
    __DIR__ . '/projects',
]);
```

In this case, the `organization` is initialized with a default value, which is the GitHub repo owner from the current remote. For that I create services `ParameterSupplier`, to format the config, and `GithubRepositoryResolver`, to obtain the owner of the current repo.

Hence, there's no need to provide the default repo, and the current default configuration still works:

```php
$parameters->set(Option::PACKAGE_DIRECTORIES, [
    __DIR__ . '/packages',
]);
```

Mixing up config with/out value also works:

```php
$parameters->set(Option::PACKAGE_DIRECTORIES, [
    __DIR__ . '/packages' => [
        'organization' => 'symplify',
    ],
    __DIR__ . '/projects',
]);
```

## Things to fix

`GithubRepositoryResolver` uses `GithubRepositoryFromRemoteResolver`, which existed on `changelog-linker`. Because `monorepo-builder` does not use `changelog-linker` or vice versa, I temporarily duplicated these source files.

So I need to extract them into a common package. Which one?
