### PR TITLE
[PHPStanRules] Skip ClassNameRespectsParentSuffixRule on anonymous class

### DIFF
--- a/packages/phpstan-rules/src/Rules/ClassNameRespectsParentSuffixRule.php
+++ b/packages/phpstan-rules/src/Rules/ClassNameRespectsParentSuffixRule.php
@@ -23,6 +23,12 @@ final class ClassNameRespectsParentSuffixRule extends AbstractSymplifyRule
     public const ERROR_MESSAGE = 'Class "%s" should have suffix "%s" by parent class/interface';
 
     /**
+     * @see https://regex101.com/r/ChpDsj/1
+     * @var string
+     */
+    private const ANONYMOUS_CLASS_REGEX = '#^AnonymousClass[\w+]#';
+
+    /**
      * @var string[]
      */
     private const DEFAULT_PARENT_CLASSES = [
@@ -78,11 +84,15 @@ final class ClassNameRespectsParentSuffixRule extends AbstractSymplifyRule
             return [];
         }
 
+        $class = (string) $shortClassName;
+        if (Strings::match($class, self::ANONYMOUS_CLASS_REGEX)) {
+            return [];
+        }
+
         if ($node->extends !== null) {
             return $this->processParent($node, $node->extends);
         }
 
-        $class = (string) $shortClassName;
         foreach ($node->implements as $implement) {
             $errorMessages = $this->processClassNameAndShort($class, $implement->getLast());
             if ($errorMessages !== []) {

--- a/packages/phpstan-rules/tests/Rules/ClassNameRespectsParentSuffixRule/ClassNameRespectsParentSuffixRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/ClassNameRespectsParentSuffixRule/ClassNameRespectsParentSuffixRuleTest.php
@@ -34,6 +34,7 @@ final class ClassNameRespectsParentSuffixRuleTest extends AbstractServiceAwareRu
         yield [__DIR__ . '/Fixture/SkipCommand.php', []];
         yield [__DIR__ . '/Fixture/SkipSomeEventSubscriber.php', []];
         yield [__DIR__ . '/Fixture/SkipFixer.php', []];
+        yield [__DIR__ . '/Fixture/SkipAnonymousClass.php', []];
 
         $errorMessage = sprintf(ClassNameRespectsParentSuffixRule::ERROR_MESSAGE, 'NonTestSuffix', 'TestCase');
         yield [__DIR__ . '/Fixture/NonTestSuffix.php', [[$errorMessage, 9]]];

--- a/packages/phpstan-rules/tests/Rules/ClassNameRespectsParentSuffixRule/Fixture/SkipAnonymousClass.php
+++ b/packages/phpstan-rules/tests/Rules/ClassNameRespectsParentSuffixRule/Fixture/SkipAnonymousClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ClassNameRespectsParentSuffixRule\Fixture;
+
+use Symfony\Component\Console\Command\Command;
+
+class SkipAnonymousClass
+{
+    public function run()
+    {
+        $someClass = new class extends Command
+        {
+        };
+    }
+}


### PR DESCRIPTION
Fixes #2717