### PR TITLE
[ci] add split_repository lockdown with message

### DIFF
--- a/packages/astral/.github/workflows/split_repository.yaml
+++ b/packages/astral/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/autodiscovery/.github/workflows/split_repository.yaml
+++ b/packages/autodiscovery/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/autowire-array-parameter/.github/workflows/split_repository.yaml
+++ b/packages/autowire-array-parameter/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/changelog-linker/.github/workflows/split_repository.yaml
+++ b/packages/changelog-linker/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/class-presence/.github/workflows/split_repository.yaml
+++ b/packages/class-presence/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/coding-standard/.github/workflows/split_repository.yaml
+++ b/packages/coding-standard/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/composer-json-manipulator/.github/workflows/split_repository.yaml
+++ b/packages/composer-json-manipulator/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/config-transformer/.github/workflows/split_repository.yaml
+++ b/packages/config-transformer/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/console-color-diff/.github/workflows/split_repository.yaml
+++ b/packages/console-color-diff/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/console-package-builder/config/workflows/split_repository.yaml
+++ b/packages/console-package-builder/config/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/easy-ci/.github/workflows/split_repository.yaml
+++ b/packages/easy-ci/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/easy-coding-standard-tester/.github/workflows/split_repository.yaml
+++ b/packages/easy-coding-standard-tester/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/easy-coding-standard/.github/workflows/split_repository.yaml
+++ b/packages/easy-coding-standard/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/easy-hydrator/.github/workflows/split_repository.yaml
+++ b/packages/easy-hydrator/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/easy-testing/.github/workflows/split_repository.yaml
+++ b/packages/easy-testing/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/flex-loader/.github/workflows/split_repository.yaml
+++ b/packages/flex-loader/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/latte-to-twig-converter/.github/workflows/split_repository.yaml
+++ b/packages/latte-to-twig-converter/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/markdown-diff/.github/workflows/split_repository.yaml
+++ b/packages/markdown-diff/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/monorepo-builder/.github/workflows/split_repository.yaml
+++ b/packages/monorepo-builder/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/neon-to-yaml-converter/.github/workflows/split_repository.yaml
+++ b/packages/neon-to-yaml-converter/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/package-builder/.github/workflows/split_repository.yaml
+++ b/packages/package-builder/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/package-scoper/.github/workflows/split_repository.yaml
+++ b/packages/package-scoper/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/php-config-printer/.github/workflows/split_repository.yaml
+++ b/packages/php-config-printer/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/phpmd-decomposer/.github/workflows/split_repository.yaml
+++ b/packages/phpmd-decomposer/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/phpstan-extensions/.github/workflows/split_repository.yaml
+++ b/packages/phpstan-extensions/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/phpstan-php-config/.github/workflows/split_repository.yaml
+++ b/packages/phpstan-php-config/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/phpstan-rules/.github/workflows/split_repository.yaml
+++ b/packages/phpstan-rules/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/phpunit-upgrader/.github/workflows/split_repository.yaml
+++ b/packages/phpunit-upgrader/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/psr4-switcher/.github/workflows/split_repository.yaml
+++ b/packages/psr4-switcher/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/rule-doc-generator/.github/workflows/split_repository.yaml
+++ b/packages/rule-doc-generator/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/set-config-resolver/.github/workflows/split_repository.yaml
+++ b/packages/set-config-resolver/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/simple-php-doc-parser/.github/workflows/split_repository.yaml
+++ b/packages/simple-php-doc-parser/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/skipper/.github/workflows/split_repository.yaml
+++ b/packages/skipper/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/smart-file-system/.github/workflows/split_repository.yaml
+++ b/packages/smart-file-system/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/sniffer-fixer-to-ecs-converter/.github/workflows/split_repository.yaml
+++ b/packages/sniffer-fixer-to-ecs-converter/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/static-detector/.github/workflows/split_repository.yaml
+++ b/packages/static-detector/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/symfony-route-usage/.github/workflows/split_repository.yaml
+++ b/packages/symfony-route-usage/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/symfony-static-dumper/.github/FUNDING.yaml
+++ b/packages/symfony-static-dumper/.github/FUNDING.yaml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+github: tomasvotruba

--- a/packages/symfony-static-dumper/.github/workflows/split_repository.yaml
+++ b/packages/symfony-static-dumper/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/symplify-kernel/.github/FUNDING.yaml
+++ b/packages/symplify-kernel/.github/FUNDING.yaml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+github: tomasvotruba

--- a/packages/symplify-kernel/.github/workflows/split_repository.yaml
+++ b/packages/symplify-kernel/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/template-checker/.github/workflows/split_repository.yaml
+++ b/packages/template-checker/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you

--- a/packages/vendor-patches/.github/workflows/split_repository.yaml
+++ b/packages/vendor-patches/.github/workflows/split_repository.yaml
@@ -1,0 +1,26 @@
+# đ€e https://github.com/dear-github/dear-github/issues/84#issuecomment-696475017
+name: 'Split Repository'
+
+on:
+    pull_request:
+        types: opened
+
+jobs:
+    lockdown:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                # see https://github.com/marketplace/actions/repo-lockdown
+                uses: dessant/repo-lockdown@v2
+                with:
+                    github-token: ${{ secrets.ACCESS_TOKEN }}
+                    pr-comment: |
+                        Hi, thank you for you contribution.
+
+                        Unfortunatelly, this repository is read-only. It's a split from our main monorepo repository.
+
+                        We'd like to kindly ask you to move the contribution there - https://github.com/symplify/symplify.
+
+                        We'll check it, review it and give you feed back right way.
+
+                        Thank you


### PR DESCRIPTION
This is the best workaround I've found to prevent PRs on split packages.

Do you want to GitHub have an option to disable PRs? 
Go for https://github.com/dear-github/dear-github/issues/84 and :+1: 


cc @lulco