### PR TITLE
[Test] Test for SmartFileSystem::readFileToSmartFileInfo()

### DIFF
--- a/packages/smart-file-system/src/SmartFileSystem.php
+++ b/packages/smart-file-system/src/SmartFileSystem.php
@@ -9,6 +9,9 @@ use Nette\Utils\Strings;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
+/**
+ * @see \Symplify\SmartFileSystem\Tests\SmartFileSystem\SmartFileSystemTest
+ */
 final class SmartFileSystem extends Filesystem
 {
     /**

--- a/packages/smart-file-system/tests/SmartFileSystem/SmartFileSystemTest.php
+++ b/packages/smart-file-system/tests/SmartFileSystem/SmartFileSystemTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SmartFileSystem\Tests\SmartFileSystem;
+
+use PHPUnit\Framework\TestCase;
+use Symplify\SmartFileSystem\SmartFileSystem;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class SmartFileSystemTest extends TestCase
+{
+    /**
+     * @var SmartFileSystem
+     */
+    private $smartFileSystem;
+
+    protected function setUp(): void
+    {
+        $this->smartFileSystem = new SmartFileSystem();
+    }
+
+    public function testReadFileToSmartFileInfo(): void
+    {
+        $this->assertInstanceof(
+            SmartFileInfo::class,
+            $this->smartFileSystem->readFileToSmartFileInfo(__DIR__ . '/Source/file.txt')
+        );
+    }
+}

--- a/packages/smart-file-system/tests/SmartFileSystem/SmartFileSystemTest.php
+++ b/packages/smart-file-system/tests/SmartFileSystem/SmartFileSystemTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Symplify\SmartFileSystem\Tests\SmartFileSystem;
 
 use PHPUnit\Framework\TestCase;
-use Symplify\SmartFileSystem\SmartFileSystem;
 use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SmartFileSystem\SmartFileSystem;
 
 final class SmartFileSystemTest extends TestCase
 {
@@ -22,9 +22,7 @@ final class SmartFileSystemTest extends TestCase
 
     public function testReadFileToSmartFileInfo(): void
     {
-        $this->assertInstanceof(
-            SmartFileInfo::class,
-            $this->smartFileSystem->readFileToSmartFileInfo(__DIR__ . '/Source/file.txt')
-        );
+        $readFileToSmartFileInfo = $this->smartFileSystem->readFileToSmartFileInfo(__DIR__ . '/Source/file.txt');
+        $this->assertInstanceof(SmartFileInfo::class, $readFileToSmartFileInfo);
     }
 }

--- a/packages/smart-file-system/tests/SmartFileSystem/Source/file.txt
+++ b/packages/smart-file-system/tests/SmartFileSystem/Source/file.txt
@@ -1,0 +1,1 @@
+some content


### PR DESCRIPTION
to avoid rector notice that make public method to private mehtod for `SmartFileSystem::readFileToSmartFileInfo()` method.