### PR TITLE
Fix small typo in docs for rule NoProtectedElementInFinalClassRule

### DIFF
--- a/packages/phpstan-rules/docs/rules_overview.md
+++ b/packages/phpstan-rules/docs/rules_overview.md
@@ -3081,7 +3081,7 @@ Instead of protected element in final class use private element or contract meth
 ```php
 final class SomeClass
 {
-    private function run()
+    protected function run()
     {
     }
 }


### PR DESCRIPTION
`Before` and `after` were the same. In the `before` section there should be `protected` instead of `private`.

PS: Sorry for the previous wrong PR in monorepo split. :) 