### PR TITLE
Use PHPStan's rich parser in ParentClassMethodNodeResolver (Fix compatibility with PHPStan 0.12.70)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ocramius/package-versions": "^1.4",
         "phar-io/version": "^3.0.3",
         "phpstan/phpdoc-parser": "^0.4.9",
-        "phpstan/phpstan": "^0.12.64, <0.12.70",
+        "phpstan/phpstan": "^0.12.64",
         "phpunit/phpunit": "^9.5",
         "psr/simple-cache": "^1.0",
         "sebastian/diff": "^3.0|^4.0",

--- a/packages/phpstan-rules/src/ParentClassMethodNodeResolver.php
+++ b/packages/phpstan-rules/src/ParentClassMethodNodeResolver.php
@@ -10,34 +10,27 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
-use PhpParser\Parser;
 use PHPStan\Analyser\Scope;
+use PHPStan\Parser\Parser;
 use PHPStan\Reflection\ClassReflection;
 use ReflectionMethod;
-use Symplify\SmartFileSystem\SmartFileSystem;
 use Throwable;
 
 final class ParentClassMethodNodeResolver
 {
     /**
-     * @var SmartFileSystem
-     */
-    private $smartFileSystem;
-
-    /**
      * @var Parser
      */
-    private $phpParser;
+    private $parser;
 
     /**
      * @var NodeFinder
      */
     private $nodeFinder;
 
-    public function __construct(SmartFileSystem $smartFileSystem, Parser $phpParser, NodeFinder $nodeFinder)
+    public function __construct(Parser $parser, NodeFinder $nodeFinder)
     {
-        $this->smartFileSystem = $smartFileSystem;
-        $this->phpParser = $phpParser;
+        $this->parser = $parser;
         $this->nodeFinder = $nodeFinder;
     }
 
@@ -147,7 +140,6 @@ final class ParentClassMethodNodeResolver
      */
     private function parseFileToNodes(string $filePath): array
     {
-        $fileContent = $this->smartFileSystem->readFile($filePath);
-        return (array) $this->phpParser->parse($fileContent);
+        return $this->parser->parseFile($filePath);
     }
 }


### PR DESCRIPTION
The reason why it doesn't work is that calling PhpParser directly causes to call [PhpParserDecorator](https://github.com/phpstan/phpstan-src/blob/master/src/Parser/PhpParserDecorator.php) which in turn calls `PHPStan\Parser\Parser::parseString()`. For some reason the abstract class was already cached in [CachedParser](https://github.com/phpstan/phpstan-src/blob/master/src/Parser/CachedParser.php) when parsed as string which means that the [RichParser.php](https://github.com/phpstan/phpstan-src/blob/master/src/Parser/RichParser.php) with the NodeConnectingVisitor wasn't used, so the `$node->getAttribute('parent')` was missing.

I might also fix this in PHPStan in CachedParser so that this situation doesn't happen but for now, this fixes it ;)