### PR TITLE
[CodingStandard] Add DocBlockLineLengthFixer

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -42,9 +42,6 @@ jobs:
                             packages/easy-coding-standard/bin/ecs --ansi
                             # packages/rule-doc-generator/bin/rule-doc-generator --ansi
 
-                            # test "check" options
-                            packages/easy-coding-standard/bin/ecs check packages/changelog-linker/src --no-progress-bar --no-error-table --clear-cache --ansi
-
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
 

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -224,8 +224,9 @@ CODE_SAMPLE
                 $paragraphLines[$paragraphIndex] = [];
             }
 
-            if (trim($line) === '') {
-                $paragraphIndex++;
+            $line = trim($line);
+            if ($line === '') {
+                ++$paragraphIndex;
             } else {
                 $paragraphLines[$paragraphIndex][] = $line;
             }

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -190,7 +190,9 @@ CODE_SAMPLE
         $collectDescriptionLines = true;
 
         foreach ($docBlockLines as $docBlockLine) {
-            if (Strings::startsWith($docBlockLine, '@')) {
+            if (Strings::startsWith($docBlockLine, '@')
+                || Strings::startsWith($docBlockLine, '{@')) {
+                // The line has a special meaning (it's an annotation, or something like {@inheritdoc})
                 $collectDescriptionLines = false;
             }
 

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -224,10 +224,7 @@ CODE_SAMPLE
             }
         }
 
-        return new DocBlockLines(
-            $descriptionLines,
-            $otherLines
-        );
+        return new DocBlockLines($descriptionLines, $otherLines);
     }
 
     /**

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -64,7 +64,7 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
                     continue;
                 }
 
-                $extraDocBlockLines = str_split($docBlockLine, $this->lineLength);
+                $extraDocBlockLines = explode(PHP_EOL, wordwrap($docBlockLine, $this->lineLength));
                 $extraDocBlockLines = $this->standardizeExtraLines($extraDocBlockLines);
                 array_splice($docBlockLines, 1, 1, $extraDocBlockLines);
             }

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -156,11 +156,12 @@ CODE_SAMPLE
 
     private function resolveIndentationStringFor(string $docBlock): string
     {
-        if (preg_match(self::INDENTATION_BEFORE_ASTERISK_REGEX, $docBlock, $matches)) {
-            return $matches[1];
+        $matches = Strings::match($docBlock, self::INDENTATION_BEFORE_ASTERISK_REGEX);
+        if ($matches === null) {
+            return '';
         }
 
-        return '';
+        return $matches[1];
     }
 
     /**

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\LineLength;
+
+use Nette\Utils\Strings;
+use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
+use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Symplify\CodingStandard\Tests\Fixer\LineLength\DocBlockLineLengthFixer\DocBlockLineLengthFixerTest
+ */
+final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements ConfigurableRuleInterface, ConfigurableFixerInterface, DocumentedRuleInterface
+{
+    /**
+     * @api
+     * @var string
+     */
+    public const LINE_LENGTH = 'line_length';
+
+    /**
+     * @var string
+     */
+    private const ERROR_MESSAGE = 'Docblock lenght should fit expected width';
+
+    /**
+     * @var int
+     */
+    private $lineLength = 120;
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(self::ERROR_MESSAGE, []);
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        // function arguments, function call parameters, lambda use()
+        for ($position = count($tokens) - 1; $position >= 0; --$position) {
+            /** @var Token $token */
+            $token = $tokens[$position];
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
+                continue;
+            }
+
+            $docBlockLines = explode(PHP_EOL, $token->getContent());
+            foreach ($docBlockLines as $docBlockLine) {
+                if (Strings::length($docBlockLine) <= $this->lineLength) {
+                    continue;
+                }
+
+                $extraDocBlockLines = str_split($docBlockLine, $this->lineLength);
+                $extraDocBlockLines = $this->standardizeExtraLines($extraDocBlockLines);
+                array_splice($docBlockLines, 1, 1, $extraDocBlockLines);
+            }
+
+            $newDocBlockContent = implode(PHP_EOL, $docBlockLines);
+            if ($token->getContent() === $newDocBlockContent) {
+                continue;
+            }
+
+            $tokens[$position] = new Token([T_DOC_COMMENT, $newDocBlockContent]);
+        }
+    }
+
+    /**
+     * @param mixed[]|null $configuration
+     */
+    public function configure(?array $configuration = null): void
+    {
+        $this->lineLength = $configuration[self::LINE_LENGTH] ?? 120;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+/**
+ * Super long doc block description
+ */
+function some()
+{
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+/**
+ * Super long doc
+ * block description
+ */
+function some()
+{
+}
+CODE_SAMPLE
+                ,
+                [
+                    self::LINE_LENGTH => 40,
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @param string[] $extraDocBlockLines
+     * @return string[]
+     */
+    private function standardizeExtraLines(array $extraDocBlockLines): array
+    {
+        $extraDocBlockLines = $this->prependLinesWithAsterisk($extraDocBlockLines);
+        return $this->rtrimLines($extraDocBlockLines);
+    }
+
+    /**
+     * @param string[] $extraDocBlockLines
+     * @return string[]
+     */
+    private function prependLinesWithAsterisk(array $extraDocBlockLines): array
+    {
+        foreach ($extraDocBlockLines as $extraKey => $extraDocBlockLine) {
+            if ($extraKey === 0) {
+                continue;
+            }
+
+            $extraDocBlockLines[$extraKey] = ' * ' . $extraDocBlockLine;
+        }
+
+        return $extraDocBlockLines;
+    }
+
+    /**
+     * @param string[] $lines
+     * @return string[]
+     */
+    private function rtrimLines(array $lines): array
+    {
+        foreach ($lines as $extraKey => $extraDocBlockLine) {
+            $lines[$extraKey] = rtrim($extraDocBlockLine);
+        }
+
+        return $lines;
+    }
+}

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -54,7 +54,7 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
         for ($position = count($tokens) - 1; $position >= 0; --$position) {
             /** @var Token $token */
             $token = $tokens[$position];
-            if (!$token->isGivenKind(T_DOC_COMMENT)) {
+            if (! $token->isGivenKind(T_DOC_COMMENT)) {
                 continue;
             }
 
@@ -76,7 +76,8 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
                 function (string $paragraph) use ($maximumLineLength): string {
                     return wordwrap($paragraph, $maximumLineLength);
                 },
-                $paragraphs);
+                $paragraphs
+            );
 
             $wrappedDescription = implode(PHP_EOL . PHP_EOL, $lineWrappedParagraphs);
             if (count($otherLines) > 0) {
@@ -142,7 +143,6 @@ CODE_SAMPLE
     }
 
     /**
-     * @param string $docBlock
      * @return string[]
      */
     private function getDocBlockLines(string $docBlock): array
@@ -215,7 +215,7 @@ CODE_SAMPLE
         $paragraphIndex = 0;
 
         foreach ($descriptionLines as $line) {
-            if (!isset($paragraphLines[$paragraphIndex])) {
+            if (! isset($paragraphLines[$paragraphIndex])) {
                 $paragraphLines[$paragraphIndex] = [];
             }
 
@@ -226,11 +226,8 @@ CODE_SAMPLE
             }
         }
 
-        return array_map(
-            function (array $lines): string {
-                return implode(' ', $lines);
-            },
-            $paragraphLines
-        );
+        return array_map(function (array $lines): string {
+            return implode(' ', $lines);
+        }, $paragraphLines);
     }
 }

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -12,6 +12,7 @@ use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
+use Symplify\CodingStandard\ValueObject\DocBlockLines;
 use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -65,7 +66,8 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
             // The available line length is the configured line length, minus the existing indentation, minus ' * '
             $maximumLineLength = $this->lineLength - strlen($indentationString) - 3;
 
-            [$descriptionLines, $otherLines] = $this->splitLines($docBlockLines);
+            $lines = $this->splitLines($docBlockLines);
+            $descriptionLines = $lines->descriptionLines();
             if (count($descriptionLines) === 0) {
                 continue;
             }
@@ -80,6 +82,7 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
             );
 
             $wrappedDescription = implode(PHP_EOL . PHP_EOL, $lineWrappedParagraphs);
+            $otherLines = $lines->otherLines();
             if (count($otherLines) > 0) {
                 $wrappedDescription .= "\n";
             }
@@ -180,9 +183,8 @@ CODE_SAMPLE
 
     /**
      * @param string[] $docBlockLines
-     * @return array<{string[]},{string[]}>
      */
-    private function splitLines(array $docBlockLines): array
+    private function splitLines(array $docBlockLines): DocBlockLines
     {
         $descriptionLines = [];
         $otherLines = [];
@@ -203,7 +205,10 @@ CODE_SAMPLE
             }
         }
 
-        return [$descriptionLines, $otherLines];
+        return new DocBlockLines(
+            $descriptionLines,
+            $otherLines
+        );
     }
 
     /**

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -38,7 +38,7 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
      * @see https://regex101.com/r/F2ZZHa/1
      * @var string
      */
-    private const INDENTATION_BEFORE_ASTERISK_REGEX = '/^([\s]*) \*/m';
+    private const INDENTATION_BEFORE_ASTERISK_REGEX = '/^(?<indentation>\s*) \*/m';
 
     /**
      * @see https://regex101.com/r/CUxOj5/1
@@ -161,7 +161,7 @@ CODE_SAMPLE
             return '';
         }
 
-        return $matches[1];
+        return $matches['indentation'];
     }
 
     /**

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -35,6 +35,24 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
     private const ERROR_MESSAGE = 'Docblock lenght should fit expected width';
 
     /**
+     * @see https://regex101.com/r/F2ZZHa/1
+     * @var string
+     */
+    private const INDENTATION_BEFORE_ASTERISK_REGEX = '/^([\s]*) \*/m';
+
+    /**
+     * @see https://regex101.com/r/CUxOj5/1
+     * @var string
+     */
+    private const BEGINNING_OF_DOC_BLOCK_REGEX = '/^(\/\*\*[\n]?)/';
+
+    /**
+     * @see https://regex101.com/r/otQGPe/1
+     * @var string
+     */
+    private const END_OF_DOC_BLOCK_REGEX = '/(\*\/)$/';
+
+    /**
      * @var int
      */
     private $lineLength = 120;
@@ -138,7 +156,7 @@ CODE_SAMPLE
 
     private function resolveIndentationStringFor(string $docBlock): string
     {
-        if (preg_match('/^([\s]*) \*/m', $docBlock, $matches)) {
+        if (preg_match(self::INDENTATION_BEFORE_ASTERISK_REGEX, $docBlock, $matches)) {
             return $matches[1];
         }
 
@@ -151,9 +169,9 @@ CODE_SAMPLE
     private function getDocBlockLines(string $docBlock): array
     {
         // Remove the prefix '/**'
-        $docBlock = Strings::replace($docBlock, '/^(\/\*\*[\n]?)/');
+        $docBlock = Strings::replace($docBlock, self::BEGINNING_OF_DOC_BLOCK_REGEX);
         // Remove the suffix '*/'
-        $docBlock = Strings::replace($docBlock, '/(\*\/)$/');
+        $docBlock = Strings::replace($docBlock, self::END_OF_DOC_BLOCK_REGEX);
         // Remove extra whitespace at the end
         $docBlock = rtrim($docBlock);
 

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -105,7 +105,7 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
                 $wrappedDescription .= "\n";
             }
 
-            $reformattedLines = array_merge(explode(PHP_EOL, $wrappedDescription), $otherLines);
+            $reformattedLines = array_merge($this->getLines($wrappedDescription), $otherLines);
 
             $newDocBlockContent = $this->formatLinesAsDocBlockContent($reformattedLines, $indentationString);
             if ($docBlock === $newDocBlockContent) {
@@ -176,7 +176,7 @@ CODE_SAMPLE
         // Remove extra whitespace at the end
         $docBlock = rtrim($docBlock);
 
-        $docBlockLines = explode(PHP_EOL, $docBlock);
+        $docBlockLines = $this->getLines($docBlock);
 
         return array_map(
             function (string $line): string {
@@ -254,5 +254,13 @@ CODE_SAMPLE
         return array_map(function (array $lines): string {
             return implode(' ', $lines);
         }, $paragraphLines);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getLines(string $string): array
+    {
+        return explode(PHP_EOL, $string);
     }
 }

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -35,7 +35,7 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
     private const ERROR_MESSAGE = 'Docblock lenght should fit expected width';
 
     /**
-     * @see https://regex101.com/r/F2ZZHa/1
+     * @see https://regex101.com/r/DNWfB6/1
      * @var string
      */
     private const INDENTATION_BEFORE_ASTERISK_REGEX = '/^(?<indentation>\s*) \*/m';

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -60,6 +60,15 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
 
             $docBlockLines = explode(PHP_EOL, $token->getContent());
             foreach ($docBlockLines as $docBlockLine) {
+                if (Strings::match($docBlockLine, '/^[\s]*\*[\s]*@/')) {
+                    /*
+                     * The line looks like it contains an annotation. This fixer doesn't know how to
+                     * reformat those lines. They are assumed to be at the bottom of the doc block,
+                     * so we should just stop trying to reformat the doc block here.
+                     */
+                    break;
+                }
+
                 if (Strings::length($docBlockLine) <= $this->lineLength) {
                     continue;
                 }

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -85,8 +85,8 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
             $maximumLineLength = $this->lineLength - strlen($indentationString) - 3;
 
             $lines = $this->splitLines($docBlockLines);
-            $descriptionLines = $lines->descriptionLines();
-            if (count($descriptionLines) === 0) {
+            $descriptionLines = $lines->getDescriptionLines();
+            if ($descriptionLines === []) {
                 continue;
             }
 
@@ -100,8 +100,8 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
             );
 
             $wrappedDescription = implode(PHP_EOL . PHP_EOL, $lineWrappedParagraphs);
-            $otherLines = $lines->otherLines();
-            if (count($otherLines) > 0) {
+            $otherLines = $lines->getOtherLines();
+            if ($otherLines !== []) {
                 $wrappedDescription .= "\n";
             }
 
@@ -195,7 +195,7 @@ CODE_SAMPLE
         }
 
         array_unshift($docBlockLines, '/**');
-        array_push($docBlockLines, $indentationString . ' */');
+        $docBlockLines[] = $indentationString . ' */';
 
         return implode(PHP_EOL, $docBlockLines);
     }

--- a/packages/coding-standard/src/ValueObject/DocBlockLines.php
+++ b/packages/coding-standard/src/ValueObject/DocBlockLines.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\ValueObject;
+
+final class DocBlockLines
+{
+    /**
+     * @var array<string>
+     */
+    private $descriptionLines;
+
+    /**
+     * @var array<string>
+     */
+    private $otherLines;
+
+    /**
+     * @param array<string> $descriptionLines
+     * @param array<string> $otherLines
+     */
+    public function __construct(array $descriptionLines, array $otherLines)
+    {
+        $this->descriptionLines = $descriptionLines;
+        $this->otherLines = $otherLines;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function descriptionLines(): array
+    {
+        return $this->descriptionLines;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function otherLines(): array
+    {
+        return $this->otherLines;
+    }
+}

--- a/packages/coding-standard/src/ValueObject/DocBlockLines.php
+++ b/packages/coding-standard/src/ValueObject/DocBlockLines.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Symplify\CodingStandard\ValueObject;

--- a/packages/coding-standard/src/ValueObject/DocBlockLines.php
+++ b/packages/coding-standard/src/ValueObject/DocBlockLines.php
@@ -9,12 +9,12 @@ final class DocBlockLines
     /**
      * @var array<string>
      */
-    private $descriptionLines;
+    private $descriptionLines = [];
 
     /**
      * @var array<string>
      */
-    private $otherLines;
+    private $otherLines = [];
 
     /**
      * @param array<string> $descriptionLines
@@ -29,7 +29,7 @@ final class DocBlockLines
     /**
      * @return array<string>
      */
-    public function descriptionLines(): array
+    public function getDescriptionLines(): array
     {
         return $this->descriptionLines;
     }
@@ -37,7 +37,7 @@ final class DocBlockLines
     /**
      * @return array<string>
      */
-    public function otherLines(): array
+    public function getOtherLines(): array
     {
         return $this->otherLines;
     }

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\LineLength\DocBlockLineLengthFixer;
+
+use Iterator;
+use Symplify\CodingStandard\Fixer\LineLength\DocBlockLineLengthFixer;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DocBlockLineLengthFixerTest extends AbstractCheckerTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture');
+    }
+
+    protected function getCheckerClass(): string
+    {
+        return DocBlockLineLengthFixer::class;
+    }
+
+    /**
+     * @return array<string, int|bool>
+     */
+    protected function getCheckerConfiguration(): array
+    {
+        return [
+            DocBlockLineLengthFixer::LINE_LENGTH => 40,
+        ];
+    }
+}

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/do_not_reformat_annotations.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/do_not_reformat_annotations.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Some very long line that occurs as a description
+ *
+ * @internal Annotations will be left alone by this fixer
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Some very long line that occurs as a
+ * description
+ *
+ * @internal Annotations will be left alone by this fixer
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/do_not_reformat_inheritdoc.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/do_not_reformat_inheritdoc.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Some very long line that occurs as a description
+ * {@inheritdoc}
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Some very long line that occurs as a
+ * description
+ *
+ * {@inheritdoc}
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/indented_doc_block.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/indented_doc_block.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+class Foo
+{
+    /**
+     * Some very long line that occurs as a description
+     */
+    public function bar()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+class Foo
+{
+    /**
+     * Some very long line that occurs
+     * as a description
+     */
+    public function bar()
+    {
+    }
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/inline_doc_block.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/inline_doc_block.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Some very long line that occurs as a description
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Some very long line that occurs as a
+ * description
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/make_multi_line_if_needed.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/make_multi_line_if_needed.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+/** Some very long line that occurs as a description */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Some very long line that occurs as a
+ * description
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/skip_doc_block_with_only_annotations.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/skip_doc_block_with_only_annotations.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @internal Annotations will be left alone by this fixer
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * @internal Annotations will be left alone by this fixer
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/skip_single_line_doc_block_with_only_annotations.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/skip_single_line_doc_block_with_only_annotations.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+/** @internal Annotations will be left alone by this fixer */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/** @internal Annotations will be left alone by this fixer */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/word_wrapping.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/word_wrapping.php.inc
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Word-wrapping will be used so we don't break existing words
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Word-wrapping will be used so we
+ * don't break existing words
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/word_wrapping_with_multiple_lines.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/word_wrapping_with_multiple_lines.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Word-wrapping will be used so we don't break existing words.
+ * Same paragraph.
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Word-wrapping will be used so we
+ * don't break existing words. Same
+ * paragraph.
+ */
+function run()
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/word_wrapping_with_multiple_paragraphs.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/Fixture/word_wrapping_with_multiple_paragraphs.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Word-wrapping will be used so we don't break existing words.
+ * Same paragraph.
+ *
+ * Another paragraph. Word-wrapping will be used so we don't break existing words.
+ * Same paragraph
+ */
+function run()
+{
+}
+
+?>
+-----
+<?php
+
+/**
+ * Word-wrapping will be used so we
+ * don't break existing words. Same
+ * paragraph.
+ *
+ * Another paragraph. Word-wrapping will
+ * be used so we don't break existing
+ * words. Same paragraph
+ */
+function run()
+{
+}
+
+?>


### PR DESCRIPTION
This continues @TomasVotruba 's work in #2879 

Things I'd still like to add:

- [x] If a doc block description contains multiple paragraphs, they should be word-wrapped separately, not together.

But I'd love some feedback as well. Also, do you test this on real projects? It will be interesting to find out how it works in the real world.

~I have at least one concern: this new fixer looks like it's just adding more behavior to the existing `LineLengthFixer`. Shouldn't the two be merged? Not sure myself.~ As Tomas writes: "Line lenght is sensitive topic, so it's better to have it opt-in as a standalone rule."