### PR TITLE
Allow PrettyVersion 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "friendsofphp/php-cs-fixer": "^2.17.3",
         "guzzlehttp/guzzle": "^7.2",
         "j7mbo/twitter-api-php": "^1.0.6",
-        "jean85/pretty-package-versions": "^1.5",
+        "jean85/pretty-package-versions": "^1.5|^2.0.1",
         "knplabs/doctrine-behaviors": "^2.0.7",
         "nette/di": "^3.0",
         "nette/finder": "^2.5",

--- a/packages/easy-coding-standard/src/Console/EasyCodingStandardConsoleApplication.php
+++ b/packages/easy-coding-standard/src/Console/EasyCodingStandardConsoleApplication.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\Console;
 
 use Composer\XdebugHandler\XdebugHandler;
+use Jean85\Exception\ReplacedPackageException;
 use Jean85\PrettyVersions;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -39,7 +40,11 @@ final class EasyCodingStandardConsoleApplication extends AbstractSymplifyConsole
         NoCheckersLoaderReporter $noCheckersLoaderReporter,
         array $commands
     ) {
-        $version = PrettyVersions::getVersion('symplify/easy-coding-standard');
+        try {
+            $version = PrettyVersions::getVersion('symplify/easy-coding-standard');
+        } catch (\OutOfBoundsException | ReplacedPackageException $exception) {
+            $version = PrettyVersions::getVersion('symplify/symplify');
+        }
 
         parent::__construct($commands, 'EasyCodingStandard', $version->getPrettyVersion());
 

--- a/packages/easy-coding-standard/src/Console/Output/JsonOutputFormatter.php
+++ b/packages/easy-coding-standard/src/Console/Output/JsonOutputFormatter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandard\Console\Output;
 
+use Jean85\Exception\ReplacedPackageException;
 use Jean85\PrettyVersions;
 use Nette\Utils\Json;
 use Symplify\EasyCodingStandard\Configuration\Configuration;
@@ -92,7 +93,11 @@ final class JsonOutputFormatter implements OutputFormatterInterface
      */
     private function createBaseErrorsArray(ErrorAndDiffResult $errorAndDiffResult): array
     {
-        $version = PrettyVersions::getVersion('symplify/easy-coding-standard');
+        try {
+            $version = PrettyVersions::getVersion('symplify/easy-coding-standard');
+        } catch (\OutOfBoundsException | ReplacedPackageException $exception) {
+            $version = PrettyVersions::getVersion('symplify/symplify');
+        }
 
         return [
             'meta' => [

--- a/packages/monorepo-builder/packages/init/src/Composer/PackageNameVersionProvider.php
+++ b/packages/monorepo-builder/packages/init/src/Composer/PackageNameVersionProvider.php
@@ -32,7 +32,7 @@ final class PackageNameVersionProvider
         $version = null;
 
         try {
-            $prettyVersion = $this->getPrettyVersion($packageName);
+            $prettyVersion = $this->getPrettyVersion($packageName, 'symplify/symplify');
 
             $version = new Version(str_replace('x-dev', '0', $prettyVersion));
         } catch (OutOfBoundsException | InvalidVersionException $exceptoin) {
@@ -48,15 +48,17 @@ final class PackageNameVersionProvider
     }
 
     /**
-     * Workaround for when this is executed in the monorepo
+     * Workaround for when the required package is executed in the monorepo or replaced in any other way
+     * @see https://github.com/symplify/symplify/pull/2901#issuecomment-771536136
+     * @see https://github.com/Jean85/pretty-package-versions/pull/16#issuecomment-620550459
      */
-    private function getPrettyVersion(string $packageName): string
+    private function getPrettyVersion(string $packageName, string $replacingPackageName = 'symplify/symplify'): string
     {
         try {
             return PrettyVersions::getVersion($packageName)
                 ->getPrettyVersion();
         } catch (OutOfBoundsException | ReplacedPackageException $exception) {
-            return PrettyVersions::getVersion('symplify/symplify')
+            return PrettyVersions::getVersion($replacingPackageName)
                 ->getPrettyVersion();
         }
     }

--- a/packages/monorepo-builder/packages/init/src/Composer/PackageNameVersionProvider.php
+++ b/packages/monorepo-builder/packages/init/src/Composer/PackageNameVersionProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Init\Composer;
 
+use Jean85\Exception\ReplacedPackageException;
 use Jean85\PrettyVersions;
 use Nette\Utils\Json as NetteJson;
 use OutOfBoundsException;
@@ -31,8 +32,7 @@ final class PackageNameVersionProvider
         $version = null;
 
         try {
-            $prettyVersion = PrettyVersions::getVersion($packageName)
-                ->getPrettyVersion();
+            $prettyVersion = $this->getPrettyVersion($packageName);
 
             $version = new Version(str_replace('x-dev', '0', $prettyVersion));
         } catch (OutOfBoundsException | InvalidVersionException $exceptoin) {
@@ -45,6 +45,20 @@ final class PackageNameVersionProvider
         }
 
         return sprintf('^%d.%d', $version->getMajor()->getValue(), $version->getMinor()->getValue());
+    }
+
+    /**
+     * Workaround for when this is executed in the monorepo
+     */
+    private function getPrettyVersion(string $packageName): string
+    {
+        try {
+            return PrettyVersions::getVersion($packageName)
+                ->getPrettyVersion();
+        } catch (OutOfBoundsException | ReplacedPackageException $exception) {
+            return PrettyVersions::getVersion('symplify/symplify')
+                ->getPrettyVersion();
+        }
     }
 
     /**


### PR DESCRIPTION
This simple bump allows for the 2.0 version of this lib, which leverages Composer 2 APIs and drops any sub dependency.

There are basically no BC; for more details, see the [the changelog](https://github.com/Jean85/pretty-package-versions/blob/2.x/CHANGELOG.md).

(porting of https://github.com/symplify/easy-coding-standard/pull/14 as requested)