### PR TITLE
[ECS] Deprecate "upgrade" sets, use Rector instead

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -19,8 +19,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
 
     $parameters->set(Option::SETS, [
-        SetList::PHP_70,
-        SetList::PHP_71,
         SetList::CLEAN_CODE,
         SetList::SYMPLIFY,
         SetList::COMMON,

--- a/packages/easy-coding-standard/config/set/php56-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/php56-migration-risky.php
@@ -6,6 +6,11 @@ use PhpCsFixer\Fixer\Alias\PowToExponentiationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_56_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PowToExponentiationFixer::class);
 };

--- a/packages/easy-coding-standard/config/set/php70-migration.php
+++ b/packages/easy-coding-standard/config/set/php70-migration.php
@@ -7,6 +7,11 @@ use PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_70_MIGRATION is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(TernaryToNullCoalescingFixer::class);
     $services->set(BacktickToShellExecFixer::class);

--- a/packages/easy-coding-standard/config/set/php70.php
+++ b/packages/easy-coding-standard/config/set/php70.php
@@ -12,6 +12,11 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_70 is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
 
     $services->set(ArraySyntaxFixer::class)

--- a/packages/easy-coding-standard/config/set/php71-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/php71-migration-risky.php
@@ -12,6 +12,11 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_71_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(CombineNestedDirnameFixer::class);
     $services->set(DeclareStrictTypesFixer::class);

--- a/packages/easy-coding-standard/config/set/php71-migration.php
+++ b/packages/easy-coding-standard/config/set/php71-migration.php
@@ -8,6 +8,11 @@ use PhpCsFixer\Fixer\Operator\TernaryToNullCoalescingFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_71_MIGRATION is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(TernaryToNullCoalescingFixer::class);
     $services->set(VisibilityRequiredFixer::class)

--- a/packages/easy-coding-standard/config/set/php71.php
+++ b/packages/easy-coding-standard/config/set/php71.php
@@ -10,6 +10,11 @@ use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_71 is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
 
     $services->set(VisibilityRequiredFixer::class)

--- a/packages/easy-coding-standard/config/set/php73-migration.php
+++ b/packages/easy-coding-standard/config/set/php73-migration.php
@@ -9,6 +9,11 @@ use PhpCsFixer\Fixer\Whitespace\HeredocIndentationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHP_73_MIGRATION is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(HeredocIndentationFixer::class);
     $services->set(TernaryToNullCoalescingFixer::class);

--- a/packages/easy-coding-standard/config/set/phpunit30-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit30-migration-risky.php
@@ -6,6 +6,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitDedicateAssertFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_30_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit32-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit32-migration-risky.php
@@ -7,6 +7,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_32_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit35-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit35-migration-risky.php
@@ -7,6 +7,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_35_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit43-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit43-migration-risky.php
@@ -7,6 +7,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_43_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit48-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit48-migration-risky.php
@@ -8,6 +8,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_48_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit50-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit50-migration-risky.php
@@ -8,6 +8,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_50_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class);
     $services->set(PhpUnitNamespacedFixer::class)

--- a/packages/easy-coding-standard/config/set/phpunit52-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit52-migration-risky.php
@@ -9,6 +9,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_52_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class);
     $services->set(PhpUnitExpectationFixer::class)

--- a/packages/easy-coding-standard/config/set/phpunit54-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit54-migration-risky.php
@@ -10,6 +10,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_54_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class);
     $services->set(PhpUnitExpectationFixer::class)

--- a/packages/easy-coding-standard/config/set/phpunit55-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit55-migration-risky.php
@@ -10,6 +10,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_55_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class);
     $services->set(PhpUnitExpectationFixer::class)

--- a/packages/easy-coding-standard/config/set/phpunit56-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit56-migration-risky.php
@@ -10,6 +10,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_56_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit57-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit57-migration-risky.php
@@ -10,6 +10,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_57_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit60-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit60-migration-risky.php
@@ -10,6 +10,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_60_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/config/set/phpunit75-migration-risky.php
+++ b/packages/easy-coding-standard/config/set/phpunit75-migration-risky.php
@@ -11,6 +11,11 @@ use PhpCsFixer\Fixer\PhpUnit\PhpUnitNoExpectationAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    trigger_error(
+        'ECS set PHPUNIT_75_MIGRATION_RISKY is deprecated. Use more advanced and precise Rector instead (http://github.com/rectorphp/rector)'
+    );
+    sleep(3);
+
     $services = $containerConfigurator->services();
     $services->set(PhpUnitDedicateAssertFixer::class)
         ->call('configure', [[

--- a/packages/easy-coding-standard/src/ValueObject/Set/SetList.php
+++ b/packages/easy-coding-standard/src/ValueObject/Set/SetList.php
@@ -21,36 +21,42 @@ final class SetList
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_70 = __DIR__ . '/../../../config/set/php70.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_56_MIGRATION_RISKY = __DIR__ . '/../../../config/set/php56-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_70_MIGRATION = __DIR__ . '/../../../config/set/php70-migration.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_71_MIGRATION = __DIR__ . '/../../../config/set/php71-migration.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_71_MIGRATION_RISKY = __DIR__ . '/../../../config/set/php71-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_73_MIGRATION = __DIR__ . '/../../../config/set/php73-migration.php';
 
@@ -69,84 +75,98 @@ final class SetList
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_30_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit30-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_32_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit32-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_35_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit35-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_43_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit43-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_48_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit48-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_50_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit50-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_52_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit52-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_54_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit54-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_55_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit55-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_56_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit56-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_57_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit57-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_60_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit60-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHPUNIT_75_MIGRATION_RISKY = __DIR__ . '/../../../config/set/phpunit75-migration-risky.php';
 
     /**
      * @var string
      * @api
+     * @deprecated This set is deprecated and will be removed in ECS 10. Use more reliable Rector for upgrades
      */
     public const PHP_71 = __DIR__ . '/../../../config/set/php71.php';
 


### PR DESCRIPTION
Tokens are proven to be very false positives. Let's deprecate these sets that can cause more harm and make cs focus on coding standards only.

For upgrades, use http://github.com/rectorphp/rector instead