### PR TITLE
[EasyTesting] Use filename as key

### DIFF
--- a/packages/easy-testing/src/DataProvider/StaticFixtureFinder.php
+++ b/packages/easy-testing/src/DataProvider/StaticFixtureFinder.php
@@ -20,7 +20,7 @@ final class StaticFixtureFinder
     {
         $fileInfos = self::findFilesInDirectory($directory, $suffix);
         foreach ($fileInfos as $fileInfo) {
-            yield [new SmartFileInfo($fileInfo->getRealPath())];
+            yield $fileInfo->getFilename() => [new SmartFileInfo($fileInfo->getRealPath())];
         }
     }
 
@@ -28,7 +28,7 @@ final class StaticFixtureFinder
     {
         $fileInfos = self::findFilesInDirectoryExclusively($directory, $suffix);
         foreach ($fileInfos as $fileInfo) {
-            yield [new SmartFileInfo($fileInfo->getRealPath())];
+            yield $fileInfo->getFilename() => [new SmartFileInfo($fileInfo->getRealPath())];
         }
     }
 


### PR DESCRIPTION
## Old

<img width="452" alt="Screenshot 2021-02-12 at 18 24 46@2x" src="https://user-images.githubusercontent.com/104180/107800850-9b508c00-6d5f-11eb-9f5e-5c94aec54819.png">

## New 

<img width="463" alt="Screenshot 2021-02-12 at 18 24 37@2x" src="https://user-images.githubusercontent.com/104180/107800859-a0add680-6d5f-11eb-9a2b-4d7997e4dc9a.png">

Makes it easier to see what test fails and what succeeds :) 
