### PR TITLE
[CodingStandard] Add NewlineServiceDefinitionConfigFixer

### DIFF
--- a/packages/coding-standard/src/DocBlock/UselessDocBlockCleaner.php
+++ b/packages/coding-standard/src/DocBlock/UselessDocBlockCleaner.php
@@ -72,10 +72,10 @@ final class UselessDocBlockCleaner
     }
 
     /**
-     * @param Token[] $reverseTokens
+     * @param Token[] $reversedTokens
      */
     private function cleanClassMethodCommentMimicMethodName(
-        array $reverseTokens,
+        array $reversedTokens,
         int $index,
         string $docContent
     ): string {
@@ -84,7 +84,7 @@ final class UselessDocBlockCleaner
             return $docContent;
         }
 
-        if (! $this->isNextFunction($reverseTokens, $index)) {
+        if (! $this->isNextFunction($reversedTokens, $index)) {
             return $docContent;
         }
 
@@ -96,7 +96,7 @@ final class UselessDocBlockCleaner
         $obviousMethodComment = $matchAnyMethodClass['obvious_method_comment'];
         $obviousMethodComment = $this->removeSpaces($obviousMethodComment);
 
-        $methodNameContent = $reverseTokens[$index + 6]->getContent();
+        $methodNameContent = $reversedTokens[$index + 6]->getContent();
 
         if (strtolower($obviousMethodComment) !== strtolower($methodNameContent)) {
             return $docContent;
@@ -105,12 +105,12 @@ final class UselessDocBlockCleaner
         return Strings::replace($docContent, self::COMMENT_ANY_METHOD_CLASS_REGEX, '');
     }
 
-    private function isNextFunction(array $reverseTokens, int $index): bool
+    private function isNextFunction(array $reversedTokens, int $index): bool
     {
-        if (! isset($reverseTokens[$index + 4])) {
+        if (! isset($reversedTokens[$index + 4])) {
             return false;
         }
-        return $reverseTokens[$index + 4]->getContent() === 'function';
+        return $reversedTokens[$index + 4]->getContent() === 'function';
     }
 
     private function removeSpaces(string $content): string

--- a/packages/coding-standard/src/Fixer/AbstractArrayFixer.php
+++ b/packages/coding-standard/src/Fixer/AbstractArrayFixer.php
@@ -59,8 +59,9 @@ abstract class AbstractArrayFixer extends AbstractSymplifyFixer implements Array
 
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
-        $reverseTokens = $this->reverseTokens($tokens);
-        foreach ($reverseTokens as $index => $token) {
+        $reversedTokens = $this->reverseTokens($tokens);
+
+        foreach ($reversedTokens as $index => $token) {
             if (! $token->isGivenKind(self::ARRAY_OPEN_TOKENS)) {
                 continue;
             }

--- a/packages/coding-standard/src/Fixer/AbstractSymplifyFixer.php
+++ b/packages/coding-standard/src/Fixer/AbstractSymplifyFixer.php
@@ -58,4 +58,24 @@ abstract class AbstractSymplifyFixer implements DefinedFixerInterface
 
         return $fixer->getPriority() + 5;
     }
+
+    protected function getNextMeaningfulToken(Tokens $tokens, int $index): ?Token
+    {
+        $nextMeaninfulTokenPosition = $tokens->getNextMeaningfulToken($index);
+        if ($nextMeaninfulTokenPosition === null) {
+            return null;
+        }
+
+        return $tokens[$nextMeaninfulTokenPosition];
+    }
+
+    protected function getPreviousToken(Tokens $tokens, int $index): ?Token
+    {
+        $previousIndex = $index - 1;
+        if (! isset($tokens[$previousIndex])) {
+            return null;
+        }
+
+        return $tokens[$previousIndex];
+    }
 }

--- a/packages/coding-standard/src/Fixer/Annotation/RemovePHPStormAnnotationFixer.php
+++ b/packages/coding-standard/src/Fixer/Annotation/RemovePHPStormAnnotationFixer.php
@@ -42,8 +42,8 @@ final class RemovePHPStormAnnotationFixer extends AbstractSymplifyFixer implemen
 
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
-        $reverseTokens = $this->reverseTokens($tokens);
-        foreach ($reverseTokens as $index => $token) {
+        $reversedTokens = $this->reverseTokens($tokens);
+        foreach ($reversedTokens as $index => $token) {
             if (! $token->isGivenKind([T_DOC_COMMENT, T_COMMENT])) {
                 continue;
             }

--- a/packages/coding-standard/src/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer.php
+++ b/packages/coding-standard/src/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer.php
@@ -75,13 +75,12 @@ CODE_SAMPLE
 
     private function isNextTokenAlsoArrayOpener(Tokens $tokens, int $index): bool
     {
-        $nextMeaningFullTokenPosition = $tokens->getNextMeaningfulToken($index);
-        if ($nextMeaningFullTokenPosition === null) {
+        $nextToken = $this->getNextMeaningfulToken($tokens, $index);
+        if (! $nextToken instanceof Token) {
             return false;
         }
 
-        $nextMeaningFullToken = $tokens[$nextMeaningFullTokenPosition];
-        return $nextMeaningFullToken->isGivenKind(self::ARRAY_OPEN_TOKENS);
+        return $nextToken->isGivenKind(self::ARRAY_OPEN_TOKENS);
     }
 
     private function handleArrayCloser(Tokens $tokens, int $arrayCloserPosition): void

--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -74,8 +74,8 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
 
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
-        $reverseTokens = $this->reverseTokens($tokens);
-        foreach ($reverseTokens as $index => $token) {
+        $reversedTokens = $this->reverseTokens($tokens);
+        foreach ($reversedTokens as $index => $token) {
             if (! $token->isGivenKind([T_DOC_COMMENT, T_COMMENT])) {
                 continue;
             }

--- a/packages/coding-standard/src/Fixer/Commenting/RemoveUselessDefaultCommentFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/RemoveUselessDefaultCommentFixer.php
@@ -46,14 +46,14 @@ final class RemoveUselessDefaultCommentFixer extends AbstractSymplifyFixer imple
 
     public function fix(SplFileInfo $file, Tokens $tokens): void
     {
-        $reverseTokens = $this->reverseTokens($tokens);
-        foreach ($reverseTokens as $index => $token) {
+        $reversedTokens = $this->reverseTokens($tokens);
+        foreach ($reversedTokens as $index => $token) {
             if (! $token->isGivenKind([T_DOC_COMMENT, T_COMMENT])) {
                 continue;
             }
 
             $cleanedDocContent = $this->uselessDocBlockCleaner->clearDocTokenContent(
-                $reverseTokens,
+                $reversedTokens,
                 $index,
                 $token->getContent()
             );

--- a/packages/coding-standard/src/Fixer/LineLength/LineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/LineLengthFixer.php
@@ -288,10 +288,10 @@ CODE_SAMPLE
     private function isHerenowDoc(Tokens $tokens, BlockInfo $blockInfo): bool
     {
         // heredoc/nowdoc => skip
-        $nextTokenPosition = $tokens->getNextMeaningfulToken($blockInfo->getStart());
-
-        /** @var Token $nextToken */
-        $nextToken = $tokens[$nextTokenPosition];
+        $nextToken = $this->getNextMeaningfulToken($tokens, $blockInfo->getStart());
+        if (! $nextToken instanceof Token) {
+            return false;
+        }
 
         return Strings::contains($nextToken->getContent(), '<<<');
     }

--- a/packages/coding-standard/src/Fixer/Spacing/NewlineServiceDefinitionConfigFixer.php
+++ b/packages/coding-standard/src/Fixer/Spacing/NewlineServiceDefinitionConfigFixer.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\Spacing;
+
+use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\WhitespacesFixerConfig;
+use SplFileInfo;
+use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
+use Symplify\CodingStandard\TokenAnalyzer\SymfonyClosureAnalyzer;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Symplify\CodingStandard\Tests\Fixer\Spacing\NewlineServiceDefinitionConfigFixer\NewlineServiceDefinitionConfigFixerTest
+ */
+final class NewlineServiceDefinitionConfigFixer extends AbstractSymplifyFixer implements DocumentedRuleInterface
+{
+    /**
+     * @var string
+     */
+    private const ERROR_MESSAGE = 'Add newline for a fluent call on service definition in Symfony config';
+
+    /**
+     * @var string
+     */
+    private const FLUENT_METHOD_NAMES = ['call', 'property', 'args', 'arg'];
+
+    /**
+     * @var WhitespacesFixerConfig
+     */
+    private $whitespacesFixerConfig;
+
+    /**
+     * @var SymfonyClosureAnalyzer
+     */
+    private $symfonyClosureAnalyzer;
+
+    public function __construct(
+        WhitespacesFixerConfig $whitespacesFixerConfig,
+        SymfonyClosureAnalyzer $symfonyClosureAnalyzer
+    ) {
+        $this->whitespacesFixerConfig = $whitespacesFixerConfig;
+        $this->symfonyClosureAnalyzer = $symfonyClosureAnalyzer;
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(self::ERROR_MESSAGE, []);
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAllTokenKindsFound([T_RETURN, T_STATIC, T_FUNCTION, T_VARIABLE, T_STRING, T_OBJECT_OPERATOR]);
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        if (! $this->symfonyClosureAnalyzer->isContainerConfiguratorClosure($tokens)) {
+            return;
+        }
+
+        $reversedTokens = $this->reverseTokens($tokens);
+
+        foreach ($reversedTokens as $index => $token) {
+            if (! $token->isGivenKind(T_OBJECT_OPERATOR)) {
+                continue;
+            }
+
+            if (! $this->isNextTokenMethodCallNamed($tokens, $index, self::FLUENT_METHOD_NAMES)) {
+                continue;
+            }
+
+            $previousToken = $this->getPreviousToken($tokens, $index);
+            if (! $previousToken instanceof Token) {
+                continue;
+            }
+
+            if ($previousToken->isWhitespace()) {
+                continue;
+            }
+
+            $newlineAndIndent = $this->whitespacesFixerConfig->getLineEnding() . str_repeat(
+                $this->whitespacesFixerConfig->getIndent(),
+                2
+            );
+
+            $tokens->ensureWhitespaceAtIndex($index, 0, $newlineAndIndent);
+        }
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)->call('configure', [['values']]);
+};
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)
+        ->call('configure', [['values']]);
+};
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function getPriority(): int
+    {
+        return $this->getPriorityBefore(MethodChainingIndentationFixer::class);
+    }
+
+    /**
+     * @param string[] $methodNames
+     */
+    private function isNextTokenMethodCallNamed(Tokens $tokens, int $index, array $methodNames): bool
+    {
+        $nextToken = $this->getNextMeaningfulToken($tokens, $index);
+        if (! $nextToken instanceof Token) {
+            return false;
+        }
+
+        if (! $nextToken->isGivenKind(T_STRING)) {
+            return false;
+        }
+
+        return in_array($nextToken->getContent(), $methodNames, true);
+    }
+}

--- a/packages/coding-standard/src/Fixer/Spacing/StandaloneLinePromotedPropertyFixer.php
+++ b/packages/coding-standard/src/Fixer/Spacing/StandaloneLinePromotedPropertyFixer.php
@@ -118,13 +118,11 @@ CODE_SAMPLE
 
     private function getFunctionName(Tokens $tokens, int $position): ?string
     {
-        $nextPosition = $tokens->getNextMeaningfulToken($position);
-        if (! is_int($nextPosition)) {
+        $nextToken = $this->getNextMeaningfulToken($tokens, $position);
+        if (! $nextToken instanceof Token) {
             return null;
         }
 
-        /** @var Token $nextToken */
-        $nextToken = $tokens[$nextPosition];
         return $nextToken->getContent();
     }
 }

--- a/packages/coding-standard/src/TokenAnalyzer/SymfonyClosureAnalyzer.php
+++ b/packages/coding-standard/src/TokenAnalyzer/SymfonyClosureAnalyzer.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\TokenAnalyzer;
+
+use PhpCsFixer\Tokenizer\Token;
+use PhpCsFixer\Tokenizer\Tokens;
+
+final class SymfonyClosureAnalyzer
+{
+    /**
+     * @var Token[]
+     */
+    private $symfonyClosureContainerConfiguratorFunctionTokens = [];
+
+    public function __construct()
+    {
+        $this->symfonyClosureContainerConfiguratorFunctionTokens = [
+            new Token('('),
+            new Token([T_STRING, 'ContainerConfigurator']),
+            new Token([T_VARIABLE, '$containerConfigurator']),
+            new Token(')'),
+        ];
+    }
+
+    /**
+     * @param Tokens&iterable<Token> $tokens
+     */
+    public function isContainerConfiguratorClosure(Tokens $tokens): bool
+    {
+        foreach ($tokens as $token) {
+            if (! $token->isGivenKind(T_FUNCTION)) {
+                continue;
+            }
+
+            $closureSequence = $tokens->findSequence($this->symfonyClosureContainerConfiguratorFunctionTokens);
+            if ($closureSequence === null) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/many_methods.php.inc
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/many_methods.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)->call('configure', [['values']])->args([])->arg('hey', 'hi');
+};
+
+?>
+-----
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)
+        ->call('configure', [['values']])
+        ->args([])
+        ->arg('hey', 'hi');
+};
+
+?>

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/skip_already_newlined.php.inc
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/skip_already_newlined.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)
+        ->call('configure', [['values']]);
+};

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/skip_not_config_call.php.inc
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/skip_not_config_call.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Spacing\NewlineServiceDefinitionConfigFixer\Fixture;
+
+class SomeClass
+{
+    public static function run()
+    {
+        $someObject = new stdClass();
+        $someObject->call();
+
+        return 100;
+    }
+}

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/wrong.php.inc
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/Fixture/wrong.php.inc
@@ -1,0 +1,24 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)->call('configure', [['values']]);
+};
+
+?>
+-----
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)
+        ->call('configure', [['values']]);
+};
+
+?>

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Spacing\NewlineServiceDefinitionConfigFixer;
+
+use Iterator;
+use Symplify\CodingStandard\Fixer\Spacing\NewlineServiceDefinitionConfigFixer;
+use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
+use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class NewlineServiceDefinitionConfigFixerTest extends AbstractCheckerTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    public function provideData(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+    }
+
+    protected function getCheckerClass(): string
+    {
+        return NewlineServiceDefinitionConfigFixer::class;
+    }
+}

--- a/packages/easy-coding-standard/config/set/common/spaces.php
+++ b/packages/easy-coding-standard/config/set/common/spaces.php
@@ -23,12 +23,15 @@ use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoSpacesAroundOffsetFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Spacing\NewlineServiceDefinitionConfigFixer;
 use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(StandaloneLinePromotedPropertyFixer::class);
+
+    $services->set(NewlineServiceDefinitionConfigFixer::class);
 
     $services->set(MethodChainingIndentationFixer::class);
 

--- a/packages/symfony-php-config/README.md
+++ b/packages/symfony-php-config/README.md
@@ -26,6 +26,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(FuncCallToStaticCallRector::class)
+
         ->call('configure', [[
             FuncCallToStaticCallRector::FUNC_CALLS_TO_STATIC_CALLS => ValueObjectInliner::inline([
                 new FuncCallToStaticCall('dump', 'Tracy\Debugger', 'dump'),


### PR DESCRIPTION
Closes https://github.com/symplify/symplify/issues/2944

```diff
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;

 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

-    $services->set(LineLengthFixer::class)->call('configure', [['values']]);
+    $services->set(LineLengthFixer::class)
+        ->call('configure', [['values']]);
 };
```