### PR TITLE
[TASK] Named fixtures for dataProvider

### DIFF
--- a/packages/easy-testing/src/DataProvider/StaticFixtureFinder.php
+++ b/packages/easy-testing/src/DataProvider/StaticFixtureFinder.php
@@ -20,7 +20,7 @@ final class StaticFixtureFinder
     {
         $fileInfos = self::findFilesInDirectory($directory, $suffix);
         foreach ($fileInfos as $fileInfo) {
-            yield [new SmartFileInfo($fileInfo->getRealPath())];
+            yield $fileInfo->getFilename() => [new SmartFileInfo($fileInfo->getRealPath())];
         }
     }
 
@@ -28,7 +28,7 @@ final class StaticFixtureFinder
     {
         $fileInfos = self::findFilesInDirectoryExclusively($directory, $suffix);
         foreach ($fileInfos as $fileInfo) {
-            yield [new SmartFileInfo($fileInfo->getRealPath())];
+            yield $fileInfo->getFilename() => [new SmartFileInfo($fileInfo->getRealPath())];
         }
     }
 


### PR DESCRIPTION
At the moment the tests are not outputting the name of the file. Would be nice to see the file instead of #0...#11