### PR TITLE
[PHPStanRules] Add RequireStringArgumentInConstructorRule

### DIFF
--- a/packages/phpstan-rules/src/Rules/RequireStringArgumentInConstructorRule.php
+++ b/packages/phpstan-rules/src/Rules/RequireStringArgumentInConstructorRule.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\TypeWithClassName;
+use Symplify\Astral\Naming\SimpleNameResolver;
+use Symplify\PHPStanRules\Exception\ShouldNotHappenException;
+use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Useful for prefixed phar bulid, to keep original references to class un-prefixed
+ *
+ * @see \Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInConstructorRule\RequireStringArgumentInConstructorRuleTest
+ */
+final class RequireStringArgumentInConstructorRule extends AbstractSymplifyRule implements ConfigurableRuleInterface
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Use quoted string in constructor "new %s()" argument on position %d instead of "::class. It prevent scoping of the class in building prefixed package.';
+
+    /**
+     * @var array<string, array<int>>
+     */
+    private $stringArgByType = [];
+
+    /**
+     * @var SimpleNameResolver
+     */
+    private $simpleNameResolver;
+
+    /**
+     * @param array<string, array<int>> $stringArgByType
+     */
+    public function __construct(SimpleNameResolver $simpleNameResolver, array $stringArgByType = [])
+    {
+        $this->stringArgByType = $stringArgByType;
+        $this->simpleNameResolver = $simpleNameResolver;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    /**
+     * @param New_ $node
+     * @return string[]
+     */
+    public function process(Node $node, Scope $scope): array
+    {
+        $errorMessages = [];
+
+        foreach ($this->stringArgByType as $type => $positions) {
+            if (! $this->isNodeVarType($node, $scope, $type)) {
+                continue;
+            }
+
+            foreach ($node->args as $key => $arg) {
+                if ($this->shouldSkipArg($key, $positions, $arg)) {
+                    continue;
+                }
+
+                $errorMessages[] = sprintf(self::ERROR_MESSAGE, $type, $key);
+            }
+        }
+
+        return $errorMessages;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+class AnotherClass
+{
+    public function run()
+    {
+        new SomeClass(YetAnotherClass:class);
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class AnotherClass
+{
+    public function run()
+    {
+        new SomeClass('YetAnotherClass'');
+    }
+}
+CODE_SAMPLE
+                ,
+                [
+                    'stringArgByType' => [
+                        'SomeClass' => [0],
+                    ],
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @param int[] $positions
+     */
+    private function shouldSkipArg(int $key, array $positions, Arg $arg): bool
+    {
+        if (! in_array($key, $positions, true)) {
+            return true;
+        }
+
+        if ($arg->value instanceof String_) {
+            return true;
+        }
+
+        /** @var ClassConstFetch $classConstFetch */
+        $classConstFetch = $arg->value;
+
+        return ! $this->simpleNameResolver->isName($classConstFetch->name, 'class');
+    }
+
+    private function isNodeVarType(New_ $constructCall, Scope $scope, string $desiredType): bool
+    {
+        if (trait_exists($desiredType)) {
+            $message = sprintf(
+                'Do not use trait "%s" as type to match, it breaks the matching. Use specific class that is in this trait',
+                $desiredType
+            );
+
+            throw new ShouldNotHappenException($message);
+        }
+
+        $constructCallType = $scope->getType($constructCall);
+        if (! $constructCallType instanceof TypeWithClassName) {
+            return false;
+        }
+
+        return is_a($constructCallType->getClassName(), $desiredType, true);
+    }
+}

--- a/packages/phpstan-rules/src/Rules/RequireStringArgumentInConstructorRule.php
+++ b/packages/phpstan-rules/src/Rules/RequireStringArgumentInConstructorRule.php
@@ -128,8 +128,10 @@ CODE_SAMPLE
             return true;
         }
 
-        /** @var ClassConstFetch $classConstFetch */
         $classConstFetch = $arg->value;
+        if (! $classConstFetch instanceof ClassConstFetch) {
+            return true;
+        }
 
         return ! $this->simpleNameResolver->isName($classConstFetch->name, 'class');
     }

--- a/packages/phpstan-rules/src/Rules/RequireStringArgumentInConstructorRule.php
+++ b/packages/phpstan-rules/src/Rules/RequireStringArgumentInConstructorRule.php
@@ -33,7 +33,7 @@ final class RequireStringArgumentInConstructorRule extends AbstractSymplifyRule 
     /**
      * @var array<string, array<int>>
      */
-    private $stringArgByType = [];
+    private $stringArgPositionsByType = [];
 
     /**
      * @var SimpleNameResolver
@@ -41,11 +41,11 @@ final class RequireStringArgumentInConstructorRule extends AbstractSymplifyRule 
     private $simpleNameResolver;
 
     /**
-     * @param array<string, array<int>> $stringArgByType
+     * @param array<string, array<int>> $stringArgPositionsByType
      */
-    public function __construct(SimpleNameResolver $simpleNameResolver, array $stringArgByType = [])
+    public function __construct(SimpleNameResolver $simpleNameResolver, array $stringArgPositionsByType = [])
     {
-        $this->stringArgByType = $stringArgByType;
+        $this->stringArgPositionsByType = $stringArgPositionsByType;
         $this->simpleNameResolver = $simpleNameResolver;
     }
 
@@ -65,7 +65,7 @@ final class RequireStringArgumentInConstructorRule extends AbstractSymplifyRule 
     {
         $errorMessages = [];
 
-        foreach ($this->stringArgByType as $type => $positions) {
+        foreach ($this->stringArgPositionsByType as $type => $positions) {
             if (! $this->isNodeVarType($node, $scope, $type)) {
                 continue;
             }
@@ -101,13 +101,13 @@ class AnotherClass
 {
     public function run()
     {
-        new SomeClass('YetAnotherClass'');
+        new SomeClass('YetAnotherClass');
     }
 }
 CODE_SAMPLE
                 ,
                 [
-                    'stringArgByType' => [
+                    'stringArgPositionsByType' => [
                         'SomeClass' => [0],
                     ],
                 ]

--- a/packages/phpstan-rules/src/Rules/RequireStringArgumentInMethodCallRule.php
+++ b/packages/phpstan-rules/src/Rules/RequireStringArgumentInMethodCallRule.php
@@ -35,7 +35,7 @@ final class RequireStringArgumentInMethodCallRule extends AbstractSymplifyRule i
     /**
      * @var array<string, array<string, array<int>>>
      */
-    private $stringArgByMethodByType = [];
+    private $stringArgPositionByMethodByType = [];
 
     /**
      * @var SimpleNameResolver
@@ -43,11 +43,11 @@ final class RequireStringArgumentInMethodCallRule extends AbstractSymplifyRule i
     private $simpleNameResolver;
 
     /**
-     * @param array<string, array<string, array<int>>> $stringArgByMethodByType
+     * @param array<string, array<string, array<int>>> $stringArgPositionByMethodByType
      */
-    public function __construct(SimpleNameResolver $simpleNameResolver, array $stringArgByMethodByType = [])
+    public function __construct(SimpleNameResolver $simpleNameResolver, array $stringArgPositionByMethodByType = [])
     {
-        $this->stringArgByMethodByType = $stringArgByMethodByType;
+        $this->stringArgPositionByMethodByType = $stringArgPositionByMethodByType;
         $this->simpleNameResolver = $simpleNameResolver;
     }
 
@@ -72,7 +72,7 @@ final class RequireStringArgumentInMethodCallRule extends AbstractSymplifyRule i
 
         $errorMessages = [];
 
-        foreach ($this->stringArgByMethodByType as $type => $positionsByMethods) {
+        foreach ($this->stringArgPositionByMethodByType as $type => $positionsByMethods) {
             $positions = $this->matchPositions($node, $scope, $type, $positionsByMethods, $methodCallName);
             if ($positions === null) {
                 continue;
@@ -115,7 +115,7 @@ class AnotherClass
 CODE_SAMPLE
                 ,
                 [
-                    'stringArgByMethodByType' => [
+                    'stringArgPositionByMethodByType' => [
                         'SomeClass' => [
                             'someMethod' => [0],
                         ],

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/SkipWithConstant.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/SkipWithConstant.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString;
+use Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AnotherClassWithConstant;
+
+final class SkipWithConstant
+{
+    public function run(): void
+    {
+        new AlwaysCallMeWithString(0, AnotherClassWithConstant::CONSTANT_NAME);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/SkipWithString.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/SkipWithString.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString;
+
+final class SkipWithString
+{
+    public function run(): void
+    {
+        new AlwaysCallMeWithString(0, 'type');
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/SkipWithVariable.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/SkipWithVariable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString;
+
+final class SkipWithVariable
+{
+    public function run(): void
+    {
+        $value = 'someType';
+
+        new AlwaysCallMeWithString(0, $value);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/WithClassConstant.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Fixture/WithClassConstant.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString;
+use Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AnotherClassWithConstant;
+
+final class WithClassConstant
+{
+    public function run(): void
+    {
+        new AlwaysCallMeWithString(0, AnotherClassWithConstant::class);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/RequireStringArgumentInConstructorRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/RequireStringArgumentInConstructorRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInConstructorRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Rules\RequireStringArgumentInConstructorRule;
+
+final class RequireStringArgumentInConstructorRuleTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    /**
+     * @return Iterator<mixed>
+     */
+    public function provideData(): Iterator
+    {
+        $errorMessage = sprintf(RequireStringArgumentInConstructorRule::ERROR_MESSAGE, 'Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString', 1);
+        yield [__DIR__ . '/Fixture/WithClassConstant.php', [[$errorMessage, 14]]];
+
+        yield [__DIR__ . '/Fixture/SkipWithConstant.php', []];
+        yield [__DIR__ . '/Fixture/SkipWithString.php', []];
+        yield [__DIR__ . '/Fixture/SkipWithVariable.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(
+            RequireStringArgumentInConstructorRule::class,
+            __DIR__ . '/config/configured_rule.neon'
+        );
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Source/AlwaysCallMeWithString.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Source/AlwaysCallMeWithString.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source;
+
+final class AlwaysCallMeWithString
+{
+    public function __construct($object, $type)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Source/AnotherClassWithConstant.php
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/Source/AnotherClassWithConstant.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source;
+
+final class AnotherClassWithConstant
+{
+    public const CONSTANT_NAME = 'constant_value';
+}

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/config/configured_rule.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireStringArgumentInConstructorRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            stringArgByType:
+                Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString: [1]

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInConstructorRule/config/configured_rule.neon
@@ -6,5 +6,5 @@ services:
         class: Symplify\PHPStanRules\Rules\RequireStringArgumentInConstructorRule
         tags: [phpstan.rules.rule]
         arguments:
-            stringArgByType:
+            stringArgPositionsByType:
                 Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString: [1]

--- a/packages/phpstan-rules/tests/Rules/RequireStringArgumentInMethodCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireStringArgumentInMethodCallRule/config/configured_rule.neon
@@ -6,6 +6,6 @@ services:
         class: Symplify\PHPStanRules\Rules\RequireStringArgumentInMethodCallRule
         tags: [phpstan.rules.rule]
         arguments:
-            stringArgByMethodByType:
+            stringArgPositionByMethodByType:
                 Symplify\PHPStanRules\Tests\Rules\RequireStringArgumentInMethodCallRule\Source\AlwaysCallMeWithString:
                     callMe: [1]


### PR DESCRIPTION
This can be used in Rector to prevent issues with prefixing.

See https://github.com/rectorphp/rector/issues/5596 and https://github.com/rectorphp/rector/pull/5597