### PR TITLE
[RuleDocGenerator] Ensure trim $badCode and $goodCode in AbstractCodeSample

### DIFF
--- a/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerVersionManipulator.php
+++ b/packages/monorepo-builder/packages/testing/src/ComposerJson/ComposerVersionManipulator.php
@@ -10,6 +10,9 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 final class ComposerVersionManipulator
 {
+    /**
+     * @var string
+     */
     private const COMPOSER_BRANCH_PREFIX = 'dev-';
 
     /**

--- a/packages/phpstan-rules/src/Rules/CheckTypehintCallerTypeRule.php
+++ b/packages/phpstan-rules/src/Rules/CheckTypehintCallerTypeRule.php
@@ -154,7 +154,7 @@ CODE_SAMPLE
             }
 
             $paramErrorMessage = $this->validateParam($param, $position, $argType);
-            if ($paramErrorMessage === null) {
+            if (! $paramErrorMessage instanceof RuleError) {
                 continue;
             }
 

--- a/packages/rule-doc-generator/src/DirectoryToMarkdownPrinter.php
+++ b/packages/rule-doc-generator/src/DirectoryToMarkdownPrinter.php
@@ -63,7 +63,7 @@ final class DirectoryToMarkdownPrinter
         $this->symfonyStyle->note($message);
 
         $classes = array_map(
-            function (RuleClassWithFilePath $rule) {
+            function (RuleClassWithFilePath $rule): string {
                 return $rule->getClass();
             },
             $documentedRuleClasses

--- a/packages/rule-doc-generator/src/ValueObject/AbstractCodeSample.php
+++ b/packages/rule-doc-generator/src/ValueObject/AbstractCodeSample.php
@@ -21,6 +21,9 @@ abstract class AbstractCodeSample implements CodeSampleInterface
 
     public function __construct(string $badCode, string $goodCode)
     {
+        $badCode = trim($badCode);
+        $goodCode = trim($goodCode);
+
         if ($badCode === '') {
             throw new ShouldNotHappenException('Bad sample good code cannot be empty');
         }

--- a/packages/rule-doc-generator/tests/DirectoryToMarkdownPrinter/Expected/rector/rector_categorized.md
+++ b/packages/rule-doc-generator/tests/DirectoryToMarkdownPrinter/Expected/rector/rector_categorized.md
@@ -1,10 +1,10 @@
-# 1 Rules Overview
+# 2 Rules Overview
 
 <br>
 
 ## Categories
 
-- [Big Category](#big-category) (1)
+- [Big Category](#big-category) (2)
 
 <br>
 
@@ -15,6 +15,19 @@
 Some change
 
 - class: [`Symplify\RuleDocGenerator\Tests\DirectoryToMarkdownPrinter\Fixture\Rector\Standard\SomeRector`](Fixture/Rector/Standard/SomeRector.php)
+
+```diff
+-before
++after
+```
+
+<br>
+
+### SomeWhiteSpaceCodeSampleRector
+
+Some change
+
+- class: [`Symplify\RuleDocGenerator\Tests\DirectoryToMarkdownPrinter\Fixture\Rector\Standard\SomeWhiteSpaceCodeSampleRector`](Fixture/Rector/Standard/SomeWhiteSpaceCodeSampleRector.php)
 
 ```diff
 -before

--- a/packages/rule-doc-generator/tests/DirectoryToMarkdownPrinter/Expected/rector/rector_content.md
+++ b/packages/rule-doc-generator/tests/DirectoryToMarkdownPrinter/Expected/rector/rector_content.md
@@ -1,10 +1,23 @@
-# 1 Rules Overview
+# 2 Rules Overview
 
 ## SomeRector
 
 Some change
 
 - class: [`Symplify\RuleDocGenerator\Tests\DirectoryToMarkdownPrinter\Fixture\Rector\Standard\SomeRector`](Fixture/Rector/Standard/SomeRector.php)
+
+```diff
+-before
++after
+```
+
+<br>
+
+## SomeWhiteSpaceCodeSampleRector
+
+Some change
+
+- class: [`Symplify\RuleDocGenerator\Tests\DirectoryToMarkdownPrinter\Fixture\Rector\Standard\SomeWhiteSpaceCodeSampleRector`](Fixture/Rector/Standard/SomeWhiteSpaceCodeSampleRector.php)
 
 ```diff
 -before

--- a/packages/rule-doc-generator/tests/DirectoryToMarkdownPrinter/Fixture/Rector/Standard/SomeWhiteSpaceCodeSampleRector.php
+++ b/packages/rule-doc-generator/tests/DirectoryToMarkdownPrinter/Fixture/Rector/Standard/SomeWhiteSpaceCodeSampleRector.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Symplify\RuleDocGenerator\Tests\DirectoryToMarkdownPrinter\Fixture\Rector\Standard;
+
+use Rector\Core\Contract\Rector\RectorInterface;
+use Rector\Core\RectorDefinition\RectorDefinition;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class SomeWhiteSpaceCodeSampleRector implements RectorInterface, DocumentedRuleInterface
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Some change', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+before
+
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+after
+
+CODE_SAMPLE
+            )
+        ]);
+    }
+}


### PR DESCRIPTION
To ensure same code with different whitespace not marked as different.