### PR TITLE
feat(git): Add GitCommits

### DIFF
--- a/packages/git-wrapper/src/GitCommit.php
+++ b/packages/git-wrapper/src/GitCommit.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\GitWrapper;
+
+use DateTime;
+use DateTimeImmutable;
+use Symplify\GitWrapper\Exception\GitException;
+
+final class GitCommit
+{
+    /**
+     * @var string
+     */
+    private $hash;
+
+    /**
+     * @var string
+     */
+    private $author;
+
+    /**
+     * @var DateTimeImmutable
+     */
+    private $authorDate;
+
+    /**
+     * @var string
+     */
+    private $committer;
+
+    /**
+     * @var DateTimeImmutable
+     */
+    private $committerDate;
+
+    /**
+     * @var string
+     */
+    private $subject;
+
+    /**
+     * @var string
+     */
+    private $body;
+
+    public function __construct(
+        string $hash,
+        string $author,
+        string $authorDate,
+        string $committer,
+        string $committerDate,
+        string $subject,
+        string $body
+    ) {
+        $this->hash = $hash;
+        $this->author = $author;
+        $parsed = DateTimeImmutable::createFromFormat(DateTime::ISO8601, $authorDate);
+
+        if (! $parsed) {
+            throw new GitException('Could not parse author date.');
+        }
+
+        $this->authorDate = $parsed;
+        $this->committer = $committer;
+
+        $parsed = DateTimeImmutable::createFromFormat(DateTime::ISO8601, $committerDate);
+
+        if (! $parsed) {
+            throw new GitException('Could not parse commiter date.');
+        }
+
+        $this->committerDate = $parsed;
+        $this->subject = $subject;
+        $this->body = $body;
+    }
+
+    public function getHash(): string
+    {
+        return $this->hash;
+    }
+
+    public function getAuthor(): string
+    {
+        return $this->author;
+    }
+
+    public function getAuthorDate(): DateTimeImmutable
+    {
+        return $this->authorDate;
+    }
+
+    public function getCommitter(): string
+    {
+        return $this->committer;
+    }
+
+    public function getCommitterDate(): DateTimeImmutable
+    {
+        return $this->committerDate;
+    }
+
+    public function getSubject(): string
+    {
+        return $this->subject;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+}

--- a/packages/git-wrapper/src/GitCommit.php
+++ b/packages/git-wrapper/src/GitCommit.php
@@ -45,35 +45,28 @@ final class GitCommit
      */
     private $body;
 
-    public function __construct(
-        string $hash,
-        string $author,
-        string $authorDate,
-        string $committer,
-        string $committerDate,
-        string $subject,
-        string $body
-    ) {
-        $this->hash = $hash;
-        $this->author = $author;
-        $parsed = DateTimeImmutable::createFromFormat(DateTime::ISO8601, $authorDate);
+    public function __construct(array $data)
+    {
+        $this->hash = $data['hash'];
+        $this->author = $data['author'];
+        $parsed = DateTimeImmutable::createFromFormat(DateTime::ISO8601, $data['authorDate']);
 
         if (! $parsed) {
             throw new GitException('Could not parse author date.');
         }
 
         $this->authorDate = $parsed;
-        $this->committer = $committer;
+        $this->committer = $data['committer'];
 
-        $parsed = DateTimeImmutable::createFromFormat(DateTime::ISO8601, $committerDate);
+        $parsed = DateTimeImmutable::createFromFormat(DateTime::ISO8601, $data['committerDate']);
 
         if (! $parsed) {
             throw new GitException('Could not parse commiter date.');
         }
 
         $this->committerDate = $parsed;
-        $this->subject = $subject;
-        $this->body = $body;
+        $this->subject = $data['subject'];
+        $this->body = $data['body'];
     }
 
     public function getHash(): string

--- a/packages/git-wrapper/src/GitCommits.php
+++ b/packages/git-wrapper/src/GitCommits.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\GitWrapper;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Nette\Utils\Strings;
+use Symplify\GitWrapper\ValueObject\Regex;
+
+/**
+ * Class that parses and returnes an array of commits.
+ */
+final class GitCommits implements IteratorAggregate
+{
+    /**
+     * @var GitWorkingCopy
+     */
+    private $gitWorkingCopy;
+
+    public function __construct(GitWorkingCopy $gitWorkingCopy)
+    {
+        $this->gitWorkingCopy = clone $gitWorkingCopy;
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        $commits = $this->all();
+        return new ArrayIterator($commits);
+    }
+
+    /**
+     * @api
+     * @return string[]
+     */
+    public function all(): array
+    {
+        return $this->fetchCommits();
+    }
+
+    /**
+     * Fetches the commits via the `git log` command.
+     *
+     * @api
+     * @return string[]
+     */
+    public function fetchCommits(): array
+    {
+        $output = $this->gitWorkingCopy->log([
+                'format=%H' => '',
+            ]);
+
+        return Strings::split(trim($output), Regex::NEWLINE_REGEX);
+    }
+}

--- a/packages/git-wrapper/src/GitCommits.php
+++ b/packages/git-wrapper/src/GitCommits.php
@@ -7,6 +7,7 @@ namespace Symplify\GitWrapper;
 use ArrayIterator;
 use IteratorAggregate;
 use Nette\Utils\Strings;
+use Symplify\GitWrapper\ValueObject\CommandName;
 use Symplify\GitWrapper\ValueObject\Regex;
 
 /**
@@ -30,12 +31,13 @@ final class GitCommits implements IteratorAggregate
     public function getIterator(): ArrayIterator
     {
         $commits = $this->all();
+
         return new ArrayIterator($commits);
     }
 
     /**
-     * @api
      * @return string[]
+     * @api
      */
     public function all(): array
     {
@@ -45,8 +47,8 @@ final class GitCommits implements IteratorAggregate
     /**
      * Fetches the commits via the `git log` command.
      *
-     * @api
      * @return string[]
+     * @api
      */
     public function fetchCommits(): array
     {
@@ -55,5 +57,81 @@ final class GitCommits implements IteratorAggregate
         ]);
 
         return Strings::split(trim($output), Regex::NEWLINE_REGEX);
+    }
+
+    /**
+     * Fetches a range of commits via the `git rev-list` command.
+     *
+     * @return string[]
+     * @api
+     */
+    public function fetchRange(string $first, string $second): array
+    {
+        $output = $this->gitWorkingCopy->run(
+            CommandName::REV_LIST,
+            [
+                $first . '...' . $second,
+                [
+                    'boundary' => true,
+                    'reverse' => true,
+                ],
+            ]
+        );
+
+        return array_map([$this, 'parseCommit'], Strings::split(trim($output), Regex::NEWLINE_REGEX));
+    }
+
+    public function get(string $hash): GitCommit
+    {
+        $formatLines = [
+            'Hash: %H',
+            'Author: %an <%ae>',
+            'AuthorDate: %aI',
+            'Committer: %cn <%ce>',
+            'CommitterDate: %cI',
+            'Subject: %s',
+            'Body: %b',
+        ];
+
+        $format = implode('%n', $formatLines);
+
+        $output = $this->gitWorkingCopy->show($hash, [
+            'format=' . $format => '',
+            'no-patch' => true,
+        ]);
+
+        return $this->parseShowOutput($output);
+    }
+
+    private function parseShowOutput(string $output): GitCommit
+    {
+        /** @var string[] $lines */
+        $lines = Strings::split(trim($output), Regex::NEWLINE_REGEX);
+        $items = [];
+
+        $captureBody = false;
+
+        foreach ($lines as $line) {
+            if (! $captureBody) {
+                $split = Strings::split($line, '/:/');
+                $key = array_shift($split);
+                $value = trim((implode(':', $split)));
+
+                if ($key === 'Body') {
+                    $captureBody = true;
+                }
+
+                $items[Strings::firstLower($key)] = $value;
+            } else {
+                $items['body'] .= "\n" . $line;
+            }
+        }
+
+        return new GitCommit(...$items);
+    }
+
+    private function parseCommit(string $commit): string
+    {
+        return ltrim($commit, '-');
     }
 }

--- a/packages/git-wrapper/src/GitCommits.php
+++ b/packages/git-wrapper/src/GitCommits.php
@@ -51,8 +51,8 @@ final class GitCommits implements IteratorAggregate
     public function fetchCommits(): array
     {
         $output = $this->gitWorkingCopy->log([
-                'format=%H' => '',
-            ]);
+            'format=%H' => '',
+        ]);
 
         return Strings::split(trim($output), Regex::NEWLINE_REGEX);
     }

--- a/packages/git-wrapper/src/GitCommits.php
+++ b/packages/git-wrapper/src/GitCommits.php
@@ -127,7 +127,7 @@ final class GitCommits implements IteratorAggregate
             }
         }
 
-        return new GitCommit(...$items);
+        return new GitCommit($items);
     }
 
     private function parseCommit(string $commit): string

--- a/packages/git-wrapper/src/GitCommits.php
+++ b/packages/git-wrapper/src/GitCommits.php
@@ -24,6 +24,9 @@ final class GitCommits implements IteratorAggregate
         $this->gitWorkingCopy = clone $gitWorkingCopy;
     }
 
+    /**
+     * @return ArrayIterator<string>
+     */
     public function getIterator(): ArrayIterator
     {
         $commits = $this->all();

--- a/packages/git-wrapper/src/GitWorkingCopy.php
+++ b/packages/git-wrapper/src/GitWorkingCopy.php
@@ -691,6 +691,15 @@ final class GitWorkingCopy
         return new GitTags($this);
     }
 
+    /**
+     * @api
+     * Returns a GitCommits object that contains information about the commits of the current branch.
+     */
+    public function commits(): GitCommits
+    {
+        return new GitCommits($this);
+    }
+
     private function ensureAddRemoteArgsAreValid(string $name, string $url): void
     {
         if ($name === '') {

--- a/packages/git-wrapper/src/ValueObject/CommandName.php
+++ b/packages/git-wrapper/src/ValueObject/CommandName.php
@@ -145,4 +145,9 @@ final class CommandName
      * @var string
      */
     public const MERGE_BASE = 'merge-base';
+
+    /**
+     * @var string
+     */
+    public const REV_LIST = 'rev-list';
 }

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -10,6 +10,7 @@ use OndraM\CiDetector\CiDetector;
 use Symfony\Component\Process\Process;
 use Symplify\GitWrapper\Exception\GitException;
 use Symplify\GitWrapper\GitBranches;
+use Symplify\GitWrapper\GitCommits;
 use Symplify\GitWrapper\GitWorkingCopy;
 use Symplify\GitWrapper\Tests\EventSubscriber\Source\TestGitOutputEventSubscriber;
 use Symplify\GitWrapper\Tests\Source\StreamSuppressFilter;
@@ -848,6 +849,29 @@ CODE_SAMPLE;
 
         $resolveRemoveUrl = $git->getRemoteUrl($remote, $operation);
         $this->assertSame('file://' . $expectedRemoteUrl, $resolveRemoveUrl);
+    }
+
+    public function testCommits(): void
+    {
+        $git = $this->getWorkingCopy();
+        $gitCommits = $git->commits();
+
+        $this->assertInstanceOf(GitCommits::class, $gitCommits);
+
+        $this->assertCount(1, $gitCommits);
+
+        // Add another commit
+        $this->smartFileSystem->dumpFile(self::WORKING_DIR . '/commit.txt', "created\n");
+
+        $this->assertTrue($git->hasChanges());
+
+        $git->add('commit.txt');
+        $git->commit([
+            'm' => 'Committed testing branch.',
+            'a' => true,
+        ]);
+
+        $this->assertCount(2, $gitCommits);
     }
 
     /**


### PR DESCRIPTION
I am currently working on a library and cli that validates commit messages. I am using the git wrapper to get the commits and commit messages. This is the first step to support access to commits.

In another project I already have the command to get only a range of commits. This could be useful in PR checks to get all commits between `GITHUB_BASE_REF` and s`GITHUB_HEAD_REF`, it is not feature-ready at the moment. So I'll start with this base on which I can add more features.

