### PR TITLE
[SnifferFixerToECSConverter] improve PHP-CS-Fixer path detection. Fixes #3089

### DIFF
--- a/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
+++ b/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
@@ -24,10 +24,18 @@ final class FixerClassProvider
 
         $robotLoader = new RobotLoader();
 
-        if (defined('SYMPLIFY_MONOREPO')) {
-            $robotLoader->addDirectory(__DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src');
-        } else {
-            $robotLoader->addDirectory(__DIR__ . '/../../../../friendsofphp/php-cs-fixer/src');
+        $possiblePhpCsFixerPaths = [
+            // after split package
+            __DIR__ . '/../../../../friendsofphp/php-cs-fixer/src',
+            // monorepo
+            __DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src',
+        ];
+
+        foreach ($possiblePhpCsFixerPaths as $possiblePhpCsFixerPath) {
+            if (file_exists($possiblePhpCsFixerPath)) {
+                $robotLoader->addDirectory($possiblePhpCsFixerPath);
+                break;
+            }
         }
 
         $robotLoader->acceptFiles = ['*Fixer.php'];

--- a/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
+++ b/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
@@ -23,7 +23,20 @@ final class FixerClassProvider
         }
 
         $robotLoader = new RobotLoader();
-        $robotLoader->addDirectory(__DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src');
+
+        $possiblePhpCsFixerPaths = [
+            // after split package
+            __DIR__ . '/../../../../friendsofphp/php-cs-fixer/src',
+            // monorepo
+            __DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src',
+        ];
+
+        foreach ($possiblePhpCsFixerPaths as $possiblePhpCsFixerPath) {
+            if (file_exists($possiblePhpCsFixerPath)) {
+                $robotLoader->addDirectory($possiblePhpCsFixerPath);
+                break;
+            }
+        }
 
         $robotLoader->acceptFiles = ['*Fixer.php'];
         $robotLoader->rebuild();

--- a/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
+++ b/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
@@ -11,6 +11,16 @@ final class FixerClassProvider
     /**
      * @var string[]
      */
+    private const POSSIBLE_PHP_CS_FIXER_PATHS = [
+        // after split package
+        __DIR__ . '/../../../../friendsofphp/php-cs-fixer/src',
+        // monorepo
+        __DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src',
+    ];
+
+    /**
+     * @var string[]
+     */
     private $fixerClasses = [];
 
     /**
@@ -24,14 +34,7 @@ final class FixerClassProvider
 
         $robotLoader = new RobotLoader();
 
-        $possiblePhpCsFixerPaths = [
-            // after split package
-            __DIR__ . '/../../../../friendsofphp/php-cs-fixer/src',
-            // monorepo
-            __DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src',
-        ];
-
-        foreach ($possiblePhpCsFixerPaths as $possiblePhpCsFixerPath) {
+        foreach (self::POSSIBLE_PHP_CS_FIXER_PATHS as $possiblePhpCsFixerPath) {
             if (file_exists($possiblePhpCsFixerPath)) {
                 $robotLoader->addDirectory($possiblePhpCsFixerPath);
                 break;

--- a/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
+++ b/packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
@@ -24,18 +24,10 @@ final class FixerClassProvider
 
         $robotLoader = new RobotLoader();
 
-        $possiblePhpCsFixerPaths = [
-            // after split package
-            __DIR__ . '/../../../../friendsofphp/php-cs-fixer/src',
-            // monorepo
-            __DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src',
-        ];
-
-        foreach ($possiblePhpCsFixerPaths as $possiblePhpCsFixerPath) {
-            if (file_exists($possiblePhpCsFixerPath)) {
-                $robotLoader->addDirectory($possiblePhpCsFixerPath);
-                break;
-            }
+        if (defined('SYMPLIFY_MONOREPO')) {
+            $robotLoader->addDirectory(__DIR__ . '/../../../../vendor/friendsofphp/php-cs-fixer/src');
+        } else {
+            $robotLoader->addDirectory(__DIR__ . '/../../../../friendsofphp/php-cs-fixer/src');
         }
 
         $robotLoader->acceptFiles = ['*Fixer.php'];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -204,6 +204,11 @@ parameters:
         - '#The path "/another\-one\.php" was not found#'
 
         -
+            message: '#The path "/\.\./\.\./\.\./\.\./friendsofphp/php\-cs\-fixer/src" was not found#'
+            paths:
+                 - packages/sniffer-fixer-to-ecs-converter/src/RobotLoader/FixerClassProvider.php
+
+        -
             message: '#Do not use factory/method call in constructor\. Put factory in config and get service with dependency injection#'
             paths:
                 - packages/easy-coding-standard/src/Set/EasyCodingStandardSetProvider.php # 23


### PR DESCRIPTION
Improves PHP-CS-Fixer path detection by avoiding the `vendor` directory name, as it is configurable in `composer.json`.