### PR TITLE
[SimplePhpDocParser] Add PhpDocNodeTraverser

### DIFF
--- a/packages/rule-doc-generator/tests/Text/KeywordHighlighterTest.php
+++ b/packages/rule-doc-generator/tests/Text/KeywordHighlighterTest.php
@@ -36,7 +36,10 @@ final class KeywordHighlighterTest extends AbstractKernelTestCase
         yield ['some @var text', 'some `@var` text'];
         yield ['@param @var text', '`@param` `@var` text'];
         yield ['some @var and @param text', 'some `@var` and `@param` text'];
-        yield ['Split multiple inline assigns to each own lines default value, to prevent undefined array issues', 'Split multiple inline assigns to each own lines default value, to prevent undefined array issues'];
+        yield [
+            'Split multiple inline assigns to each own lines default value, to prevent undefined array issues',
+            'Split multiple inline assigns to each own lines default value, to prevent undefined array issues',
+        ];
         yield [
             'autowire(), autoconfigure(), and public() are required in config service',
             '`autowire()`, `autoconfigure()`, and `public()` are required in config service',

--- a/packages/simple-php-doc-parser/config/config.php
+++ b/packages/simple-php-doc-parser/config/config.php
@@ -17,7 +17,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autoconfigure();
 
     $services->load('Symplify\SimplePhpDocParser\\', __DIR__ . '/../src')
-        ->exclude([__DIR__ . '/../src/Bundle']);
+        ->exclude([
+            __DIR__ . '/../src/Bundle',
+            __DIR__ . '/../src/PhpDocNodeVisitor/CallablePhpDocNodeVisitor.php',
+        ]);
 
     $services->set(PhpDocParser::class);
     $services->set(Lexer::class);

--- a/packages/simple-php-doc-parser/src/Contract/PhpDocNodeVisitorInterface.php
+++ b/packages/simple-php-doc-parser/src/Contract/PhpDocNodeVisitorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SimplePhpDocParser\Contract;
+
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+
+/**
+ * Inspired by https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/NodeVisitor.php
+ */
+interface PhpDocNodeVisitorInterface
+{
+    public function beforeTraverse(PhpDocNode $phpDocNode): void;
+
+    public function enterNode(Node $node): ?Node;
+
+    public function leaveNode(Node $node): void;
+
+    public function afterTraverse(PhpDocNode $phpDocNode): void;
+}

--- a/packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
@@ -26,12 +26,39 @@ use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use Symplify\SimplePhpDocParser\Contract\PhpDocNodeVisitorInterface;
 
 /**
+ * Mimics
+ * https://github.com/nikic/PHP-Parser/blob/4abdcde5f16269959a834e4e58ea0ba0938ab133/lib/PhpParser/NodeTraverser.php
+ *
  * @see \Symplify\SimplePhpDocParser\Tests\SimplePhpDocNodeTraverser\PhpDocNodeTraverserTest
  */
 final class PhpDocNodeTraverser
 {
+    /**
+     * @var PhpDocNodeVisitorInterface[]
+     */
+    private $phpDocNodeVisitors = [];
+
+    public function addPhpDocNodeVisitor(PhpDocNodeVisitorInterface $phpDocNodeVisitor): void
+    {
+        $this->phpDocNodeVisitors[] = $phpDocNodeVisitor;
+    }
+
+    public function traverse(PhpDocNode $phpDocNode): void
+    {
+        foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+            $phpDocNodeVisitor->beforeTraverse($phpDocNode);
+        }
+
+        $phpDocNode = $this->traverseNode($phpDocNode);
+
+        foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+            $phpDocNodeVisitor->afterTraverse($phpDocNode);
+        }
+    }
+
     public function traverseWithCallable(Node $node, string $docContent, callable $callable): Node
     {
         if ($node instanceof PhpDocNode) {
@@ -181,5 +208,67 @@ final class PhpDocNodeTraverser
         foreach ($arrayShapeNode->items as $key => $itemNode) {
             $arrayShapeNode->items[$key] = $this->traverseTypeNode($itemNode, $docContent, $callable);
         }
+    }
+
+    /**
+     * @template TNode as Node
+     * @param TNode $node
+     * @return TNode
+     */
+    private function traverseNode(Node $node): Node
+    {
+        $subNodes = get_object_vars($node);
+
+        foreach ($subNodes as &$subNode) {
+            if (\is_array($subNode)) {
+                $subNode = $this->traverseArray($subNode);
+            } elseif ($subNode instanceof Node) {
+                foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+                    $return = $phpDocNodeVisitor->enterNode($subNode);
+                    if ($return instanceof Node) {
+                        $subNode = $return;
+                    }
+                }
+
+                $subNode = $this->traverseNode($subNode);
+
+                foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+                    $phpDocNodeVisitor->leaveNode($subNode);
+                }
+            }
+        }
+
+        return $node;
+    }
+
+    /**
+     * @param array<Node|mixed> $nodes
+     * @return array<Node|mixed>
+     */
+    private function traverseArray(array $nodes): array
+    {
+        foreach ($nodes as $key => $node) {
+            // can be string or something else
+            if (! $node instanceof Node) {
+                continue;
+            }
+
+            foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+                $return = $phpDocNodeVisitor->enterNode($node);
+                if ($return instanceof Node) {
+                    $node = $return;
+                }
+            }
+
+            $node = $this->traverseNode($node);
+
+            foreach ($this->phpDocNodeVisitors as $phpDocNodeVisitor) {
+                $phpDocNodeVisitor->leaveNode($node);
+            }
+
+            $nodes[$key] = $node;
+        }
+
+        return $nodes;
     }
 }

--- a/packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
@@ -5,28 +5,9 @@ declare(strict_types=1);
 namespace Symplify\SimplePhpDocParser;
 
 use PHPStan\PhpDocParser\Ast\Node;
-use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\MethodTagValueParameterNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocChildNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PropertyTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\ThrowsTagValueNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
-use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
-use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
-use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\CallableTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
-use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
 use Symplify\SimplePhpDocParser\Contract\PhpDocNodeVisitorInterface;
+use Symplify\SimplePhpDocParser\PhpDocNodeVisitor\CallablePhpDocNodeVisitor;
 
 /**
  * Mimics
@@ -59,155 +40,13 @@ final class PhpDocNodeTraverser
         }
     }
 
-    public function traverseWithCallable(Node $node, string $docContent, callable $callable): Node
+    public function traverseWithCallable(PhpDocNode $phpDocNode, string $docContent, callable $callable): PhpDocNode
     {
-        if ($node instanceof PhpDocNode) {
-            $this->traversePhpDocNode($node, $docContent, $callable);
-            return $node;
-        }
+        $callableNodeVisitor = new CallablePhpDocNodeVisitor($callable, $docContent);
+        $this->addPhpDocNodeVisitor($callableNodeVisitor);
 
-        if ($this->isValueNodeWithType($node)) {
-            /** @var ParamTagValueNode|VarTagValueNode|ReturnTagValueNode|GenericTypeNode $node */
-            if ($node->type !== null) {
-                $node->type = $this->traverseTypeNode($node->type, $docContent, $callable);
-            }
-
-            return $callable($node, $docContent);
-        }
-
-        if ($node instanceof MethodTagValueNode) {
-            return $this->traverseMethodTagValueNode($node, $docContent, $callable);
-        }
-
-        if ($node instanceof TypeNode) {
-            return $this->traverseTypeNode($node, $docContent, $callable);
-        }
-
-        return $callable($node, $docContent);
-    }
-
-    private function isValueNodeWithType(Node $node): bool
-    {
-        return $node instanceof PropertyTagValueNode ||
-            $node instanceof ReturnTagValueNode ||
-            $node instanceof ParamTagValueNode ||
-            $node instanceof VarTagValueNode ||
-            $node instanceof ThrowsTagValueNode ||
-            $node instanceof MethodTagValueParameterNode;
-    }
-
-    private function traverseTypeNode(TypeNode $typeNode, string $docContent, callable $callable): TypeNode
-    {
-        $typeNode = $callable($typeNode, $docContent);
-
-        if ($typeNode instanceof ArrayTypeNode || $typeNode instanceof NullableTypeNode || $typeNode instanceof GenericTypeNode) {
-            $typeNode->type = $this->traverseTypeNode($typeNode->type, $docContent, $callable);
-        }
-
-        if ($typeNode instanceof CallableTypeNode) {
-            $typeNode->returnType = $this->traverseTypeNode($typeNode->returnType, $docContent, $callable);
-            return $typeNode;
-        }
-
-        if ($typeNode instanceof ArrayShapeNode) {
-            $this->traverseArrayShapeNode($typeNode, $docContent, $callable);
-            return $typeNode;
-        }
-
-        if ($typeNode instanceof ArrayShapeItemNode) {
-            $typeNode->valueType = $this->traverseTypeNode($typeNode->valueType, $docContent, $callable);
-            return $typeNode;
-        }
-
-        if ($typeNode instanceof GenericTypeNode) {
-            $this->traverseGenericTypeNode($typeNode, $docContent, $callable);
-            return $typeNode;
-        }
-
-        if ($typeNode instanceof UnionTypeNode || $typeNode instanceof IntersectionTypeNode) {
-            $this->traverseUnionIntersectionType($typeNode, $docContent, $callable);
-            return $typeNode;
-        }
-
-        return $typeNode;
-    }
-
-    private function traverseMethodTagValueNode(
-        MethodTagValueNode $methodTagValueNode,
-        string $docContent,
-        callable $callable
-    ): MethodTagValueNode {
-        if ($methodTagValueNode->returnType !== null) {
-            $methodTagValueNode->returnType = $this->traverseTypeNode(
-                $methodTagValueNode->returnType,
-                $docContent,
-                $callable
-            );
-        }
-
-        foreach ($methodTagValueNode->parameters as $key => $methodTagValueParameterNode) {
-            /** @var MethodTagValueParameterNode $methodTagValueParameterNode */
-            $methodTagValueParameterNode = $this->traverseWithCallable(
-                $methodTagValueParameterNode,
-                $docContent,
-                $callable
-            );
-
-            $methodTagValueNode->parameters[$key] = $methodTagValueParameterNode;
-        }
-
-        return $callable($methodTagValueNode, $docContent);
-    }
-
-    private function traversePhpDocNode(PhpDocNode $phpDocNode, string $docContent, callable $callable): void
-    {
-        foreach ($phpDocNode->children as $key => $phpDocChildNode) {
-            /** @var PhpDocChildNode $phpDocChildNode */
-            $phpDocChildNode = $this->traverseWithCallable($phpDocChildNode, $docContent, $callable);
-            $phpDocNode->children[$key] = $phpDocChildNode;
-
-            if ($phpDocChildNode instanceof PhpDocTextNode) {
-                continue;
-            }
-
-            if (! $phpDocChildNode instanceof PhpDocTagNode) {
-                continue;
-            }
-
-            /** @var PhpDocTagValueNode $traversedValue */
-            $traversedValue = $this->traverseWithCallable($phpDocChildNode->value, $docContent, $callable);
-            $phpDocChildNode->value = $traversedValue;
-        }
-    }
-
-    private function traverseGenericTypeNode(
-        GenericTypeNode $genericTypeNode,
-        string $docContent,
-        callable $callable
-    ): void {
-        foreach ($genericTypeNode->genericTypes as $key => $genericType) {
-            $genericTypeNode->genericTypes[$key] = $this->traverseTypeNode($genericType, $docContent, $callable);
-        }
-    }
-
-    /**
-     * @param UnionTypeNode|IntersectionTypeNode $node
-     */
-    private function traverseUnionIntersectionType(Node $node, string $docContent, callable $callable): void
-    {
-        foreach ($node->types as $key => $subTypeNode) {
-            $node->types[$key] = $this->traverseTypeNode($subTypeNode, $docContent, $callable);
-        }
-    }
-
-    private function traverseArrayShapeNode(
-        ArrayShapeNode $arrayShapeNode,
-        string $docContent,
-        callable $callable
-    ): void {
-        foreach ($arrayShapeNode->items as $key => $itemNode) {
-            $arrayShapeNode->items[$key] = $this->traverseTypeNode($itemNode, $docContent, $callable);
-        }
+        $this->traverse($phpDocNode);
+        return $phpDocNode;
     }
 
     /**

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/AbstractPhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/AbstractPhpDocNodeVisitor.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SimplePhpDocParser\PhpDocNodeVisitor;
+
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use Symplify\SimplePhpDocParser\Contract\PhpDocNodeVisitorInterface;
+
+abstract class AbstractPhpDocNodeVisitor implements PhpDocNodeVisitorInterface
+{
+    public function beforeTraverse(PhpDocNode $phpDocNode): void
+    {
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        return null;
+    }
+
+    public function leaveNode(Node $node): void
+    {
+    }
+
+    public function afterTraverse(PhpDocNode $phpDocNode): void
+    {
+    }
+}

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/AbstractPhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/AbstractPhpDocNodeVisitor.php
@@ -8,6 +8,9 @@ use PHPStan\PhpDocParser\Ast\Node;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use Symplify\SimplePhpDocParser\Contract\PhpDocNodeVisitorInterface;
 
+/**
+ * Inspired by https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/NodeVisitorAbstract.php
+ */
 abstract class AbstractPhpDocNodeVisitor implements PhpDocNodeVisitorInterface
 {
     public function beforeTraverse(PhpDocNode $phpDocNode): void

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CallablePhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CallablePhpDocNodeVisitor.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SimplePhpDocParser\PhpDocNodeVisitor;
+
+use PHPStan\PhpDocParser\Ast\Node;
+
+final class CallablePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
+{
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @var string|null
+     */
+    private $docContent;
+
+    public function __construct(callable $callable, ?string $docContent = null)
+    {
+        $this->callable = $callable;
+        $this->docContent = $docContent;
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        $callable = $this->callable;
+        return $callable($node, $this->docContent);
+    }
+}

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitor.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SimplePhpDocParser\PhpDocNodeVisitor;
+
+use PHPStan\PhpDocParser\Ast\Node;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use Symplify\SimplePhpDocParser\ValueObject\PhpDocAttributeKey;
+
+/**
+ * Mimics https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/NodeVisitor/ParentConnectingVisitor.php
+ *
+ * @see \Symplify\SimplePhpDocParser\Tests\PhpDocNodeVisitor\ParentConnectingPhpDocNodeVisitorTest
+ */
+final class ParentConnectingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
+{
+    /**
+     * @var Node[]
+     */
+    private $stack = [];
+
+    public function beforeTraverse(PhpDocNode $phpDocNode): void
+    {
+        $this->stack = [];
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if ($this->stack !== []) {
+            $parentNode = $this->stack[count($this->stack) - 1];
+            $node->setAttribute(PhpDocAttributeKey::PARENT, $parentNode);
+        }
+
+        $this->stack[] = $node;
+
+        return $node;
+    }
+
+    public function leaveNode(Node $node): void
+    {
+        array_pop($this->stack);
+    }
+}

--- a/packages/simple-php-doc-parser/src/ValueObject/PhpDocAttributeKey.php
+++ b/packages/simple-php-doc-parser/src/ValueObject/PhpDocAttributeKey.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SimplePhpDocParser\ValueObject;
+
+final class PhpDocAttributeKey
+{
+    /**
+     * @var string
+     */
+    public const PARENT = 'parent';
+}

--- a/packages/simple-php-doc-parser/tests/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitorTest.php
+++ b/packages/simple-php-doc-parser/tests/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SimplePhpDocParser\Tests\PhpDocNodeVisitor;
+
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use Symplify\SimplePhpDocParser\PhpDocNodeTraverser;
+use Symplify\SimplePhpDocParser\PhpDocNodeVisitor\ParentConnectingPhpDocNodeVisitor;
+use Symplify\SimplePhpDocParser\Tests\HttpKernel\SimplePhpDocParserKernel;
+use Symplify\SimplePhpDocParser\ValueObject\PhpDocAttributeKey;
+
+final class ParentConnectingPhpDocNodeVisitorTest extends AbstractKernelTestCase
+{
+    /**
+     * @var PhpDocNodeTraverser
+     */
+    private $phpDocNodeTraverser;
+
+    /**
+     * @var ParentConnectingPhpDocNodeVisitor
+     */
+    private $parentConnectingPhpDocNodeVisitor;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(SimplePhpDocParserKernel::class);
+
+        $this->phpDocNodeTraverser = $this->getService(PhpDocNodeTraverser::class);
+        $this->parentConnectingPhpDocNodeVisitor = $this->getService(ParentConnectingPhpDocNodeVisitor::class);
+    }
+
+    public function test(): void
+    {
+        $this->phpDocNodeTraverser->addPhpDocNodeVisitor($this->parentConnectingPhpDocNodeVisitor);
+
+        $phpDocNode = $this->createPhpDocNode();
+
+        $this->phpDocNodeTraverser->traverse($phpDocNode);
+
+        $phpDocChildNode = $phpDocNode->children[0];
+        $this->assertInstanceOf(PhpDocTagNode::class, $phpDocChildNode);
+
+        /** @var PhpDocTagNode $phpDocChildNode */
+        $returnTagValueNode = $phpDocChildNode->value;
+
+        $this->assertInstanceOf(ReturnTagValueNode::class, $returnTagValueNode);
+
+        /** @var ReturnTagValueNode $returnTagValueNode */
+        $returnParent = $returnTagValueNode->getAttribute(PhpDocAttributeKey::PARENT);
+        $this->assertSame($phpDocChildNode, $returnParent);
+
+        $returnTypeParent = $returnTagValueNode->type->getAttribute(PhpDocAttributeKey::PARENT);
+        $this->assertSame($returnTagValueNode, $returnTypeParent);
+    }
+
+    private function createPhpDocNode(): PhpDocNode
+    {
+        $returnTagValueNode = new ReturnTagValueNode(new IdentifierTypeNode('string'), '');
+
+        return new PhpDocNode([
+            new PhpDocTagNode('@return', $returnTagValueNode),
+            new PhpDocTextNode('some text'),
+        ]);
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -536,4 +536,10 @@ parameters:
 
         -
             message: '#Do not inherit from abstract class, better use composition#'
-            path: packages/simple-php-doc-parser/src/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitor.php
+            paths:
+                 - packages/simple-php-doc-parser/src/PhpDocNodeVisitor/*PhpDocNodeVisitor.php
+
+        -
+            message: '#Parameter "docContent" cannot be nullable#'
+            paths:
+                 - packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CallablePhpDocNodeVisitor.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -516,3 +516,24 @@ parameters:
             message: '#Class cognitive complexity is \d+, keep it under 25#'
             paths:
                 - packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
+
+        # node traverser magic
+        -
+            message: '#Use explicit return value over magic &reference#'
+            path: packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+
+        -
+            message: '#Cognitive complexity for "Symplify\\SimplePhpDocParser\\PhpDocNodeTraverser\:\:traverseNode\(\)" is 12, keep it under 8#'
+            path: packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+
+        -
+            message: '#Class cognitive complexity is 43, keep it under 25#'
+            path: packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+
+        -
+            message: '#Use void instead of modify and return self object#'
+            path: packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+
+        -
+            message: '#Do not inherit from abstract class, better use composition#'
+            path: packages/simple-php-doc-parser/src/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitor.php


### PR DESCRIPTION
What if we could get anywhere in php doc block and do any change like with php-parser? 

```diff
 /**
- * @param OldNode|string $value
+ * @param NewNode|string $value
- * @return OldNode 
+ * @return NewNode
  */
```