### PR TITLE
Default behavior changed to *append* patches

### DIFF
--- a/packages/vendor-patches/src/Composer/ComposerPatchesConfigurationUpdater.php
+++ b/packages/vendor-patches/src/Composer/ComposerPatchesConfigurationUpdater.php
@@ -43,13 +43,18 @@ final class ComposerPatchesConfigurationUpdater
 
         // remove any patches that have been deleted from disk
         foreach ($patches as $package=>$paths) {
-            $patches[$package] = array_filter(array_unique($paths), function($path) {
-                return file_exists(getcwd() . '/' . $path);
-            });
+            $new_paths = [];
+            foreach ($paths as $path) {
+                if (file_exists(getcwd() . '/' . $path)) {
+                    $new_paths[$path] = $path;
+                }
+            }
+            $patches[$package] = array_values($new_paths);
         }
 
         // update the composer.json file
-        $composerJson->setExtra(array_merge($extraSection, ['patches'=>$patches]));
+        $extra = array_merge($extraSection, ['patches'=>$patches]);
+        $composerJson->setExtra($extra);
         $this->jsonFileManager->printComposerJsonToFilePath($composerJson, $composerJsonFilePath);
     }
 }


### PR DESCRIPTION
The default behavior up to now was to scan the `vendor/` folder, look for `*.old` files, and to create a patch for each of these files. This list of patches would then be the new patches that would appear in the `composer.json` file. 

That sounds reasonable, but has the unfortunate side effect that if you ever do a re-install of the `vendor/` folder, you will lose all the `*.old` files, and then the NEXT time you run `vendor/bin/vendor-patches generate` it will REMOVE the patches you already had and REPLACE them with the new patches it found, even though the actual patches themselves are still present in the `patches/` folder.

I think that's unreasonable and unexpected behavior.

In my case it actually caused an error on a live production system.

So, I've changed the behavior to APPEND any new patches to the existing set of patches, and to only REMOVE patches if the referenced file in the `patches/` folder has been deleted.