### PR TITLE
Fixing running test ecs prefixed on merge

### DIFF
--- a/.github/workflows/test_ecs_prefixed.yaml
+++ b/.github/workflows/test_ecs_prefixed.yaml
@@ -14,16 +14,15 @@ jobs:
     tests_ecs_prefixed:
         runs-on: ubuntu-latest
         steps:
-            -
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: 7.3
-                    coverage: none
+            - name: Checkout tools repo
+              uses: actions/checkout@v2
+              with:
+                repository: symplify/easy-coding-standard-prefixed
+                path: easy-coding-standard-prefixed
 
-            -   run: |
-                  composer config minimum-stability dev
-                  composer config prefer-stable true  
-                  composer require symplify/easy-coding-standard-prefixed:dev-main --ansi
-                   
+            - uses: shivammathur/setup-php@v2
+              with:
+                php-version: 7.3
+                coverage: none
 
             -   run: vendor/bin/ecs list --ansi

--- a/.github/workflows/test_ecs_prefixed.yaml
+++ b/.github/workflows/test_ecs_prefixed.yaml
@@ -25,4 +25,4 @@ jobs:
                 php-version: 7.3
                 coverage: none
 
-            -   run: vendor/bin/ecs list --ansi
+            - run: vendor/bin/ecs list --ansi

--- a/.github/workflows/test_ecs_prefixed.yaml
+++ b/.github/workflows/test_ecs_prefixed.yaml
@@ -14,15 +14,15 @@ jobs:
     tests_ecs_prefixed:
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout tools repo
-              uses: actions/checkout@v2
-              with:
-                repository: symplify/easy-coding-standard-prefixed
-                path: easy-coding-standard-prefixed
+            -   name: Checkout tools repo
+                uses: actions/checkout@v2
+                with:
+                    repository: symplify/easy-coding-standard-prefixed
+                    path: easy-coding-standard-prefixed
 
-            - uses: shivammathur/setup-php@v2
-              with:
-                php-version: 7.3
-                coverage: none
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.3
+                    coverage: none
 
-            - run: vendor/bin/ecs list --ansi
+            -   run: vendor/bin/ecs list --ansi


### PR DESCRIPTION
On merge:

- clone latest `symplify/easy-coding-standard-prefixed` dev-main branch
- run test immediately