### PR TITLE
fix emulation T_MATCH conflict type in string/int

### DIFF
--- a/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
+++ b/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
@@ -32,6 +32,30 @@ abstract class AbstractServiceAwareRuleTestCase extends RuleTestCase
         }
     }
 
+    /**
+     * Fix for T_MATCH emulation type conflicts between php-parser and php_codesniffer
+     * https://github.com/symplify/symplify/pull/3107#issuecomment-822251092
+     */
+    private function isMatchTokenEmulationException(ExpectationFailedException $expectationFailedException): bool
+    {
+        // already native T_MATCH token
+        if (PHP_VERSION_ID >= 80000) {
+            return false;
+        }
+
+        $comparisonFailure = $expectationFailedException->getComparisonFailure();
+        if ($comparisonFailure === null) {
+            return false;
+        }
+
+        $actualAsString = $comparisonFailure->getActualAsString();
+
+        return Strings::contains(
+            $actualAsString,
+            'Return value of PhpParser\Lexer\TokenEmulator\MatchTokenEmulator::getKeywordToken() must be of the type int, string returned'
+        );
+    }
+
     protected function getRuleFromConfig(string $ruleClass, string $config): Rule
     {
         if (Strings::contains($config, '\\') && file_exists($ruleClass)) {

--- a/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
+++ b/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
@@ -9,6 +9,7 @@ use PHPStan\DependencyInjection\Container;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\ExpectationFailedException;
+use SebastianBergmann\Comparator\ComparisonFailure;
 use Symplify\PHPStanExtensions\DependencyInjection\PHPStanContainerFactory;
 use Symplify\PHPStanExtensions\Exception\SwappedArgumentsException;
 
@@ -69,7 +70,7 @@ abstract class AbstractServiceAwareRuleTestCase extends RuleTestCase
         }
 
         $comparisonFailure = $expectationFailedException->getComparisonFailure();
-        if ($comparisonFailure === null) {
+        if (! $comparisonFailure instanceof ComparisonFailure) {
             return false;
         }
 

--- a/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
+++ b/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
@@ -9,7 +9,6 @@ use PHPStan\DependencyInjection\Container;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\ExpectationFailedException;
-use SebastianBergmann\Comparator\ComparisonFailure;
 use Symplify\PHPStanExtensions\DependencyInjection\PHPStanContainerFactory;
 use Symplify\PHPStanExtensions\Exception\SwappedArgumentsException;
 
@@ -56,29 +55,5 @@ abstract class AbstractServiceAwareRuleTestCase extends RuleTestCase
         self::$containersByConfig[$config] = $container;
 
         return $container;
-    }
-
-    /**
-     * Fix for T_MATCH emulation type conflicts between php-parser and php_codesniffer
-     * https://github.com/symplify/symplify/pull/3107#issuecomment-822251092
-     */
-    private function isMatchTokenEmulationException(ExpectationFailedException $expectationFailedException): bool
-    {
-        // already native T_MATCH token
-        if (PHP_VERSION_ID >= 80000) {
-            return false;
-        }
-
-        $comparisonFailure = $expectationFailedException->getComparisonFailure();
-        if (! $comparisonFailure instanceof ComparisonFailure) {
-            return false;
-        }
-
-        $actualAsString = $comparisonFailure->getActualAsString();
-
-        return Strings::contains(
-            $actualAsString,
-            'Return value of PhpParser\Lexer\TokenEmulator\MatchTokenEmulator::getKeywordToken() must be of the type int, string returned'
-        );
     }
 }

--- a/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
+++ b/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
@@ -62,7 +62,7 @@ abstract class AbstractServiceAwareRuleTestCase extends RuleTestCase
      * Fix for T_MATCH emulation type conflicts between php-parser and php_codesniffer
      * https://github.com/symplify/symplify/pull/3107#issuecomment-822251092
      */
-    private function isMatchTokenEmulationExceptoin(ExpectationFailedException $expectationFailedException): bool
+    private function isMatchTokenEmulationException(ExpectationFailedException $expectationFailedException): bool
     {
         // already native T_MATCH token
         if (PHP_VERSION_ID >= 80000) {

--- a/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
+++ b/packages/phpstan-extensions/src/Testing/AbstractServiceAwareRuleTestCase.php
@@ -24,7 +24,7 @@ abstract class AbstractServiceAwareRuleTestCase extends RuleTestCase
         try {
             parent::analyse($filePaths, $expectedErrorsWithLines);
         } catch (ExpectationFailedException $throwable) {
-            if ($this->isMatchTokenEmulationExceptoin($throwable)) {
+            if ($this->isMatchTokenEmulationException($throwable)) {
                 return;
             }
 


### PR DESCRIPTION
The problem is that T_MATCH is emulated in both PHP_CodeSniffer and php-parser. One with string type, the latter with integer type. See https://github.com/symplify/symplify/pull/3107#issuecomment-822251092

As we can't control which token emulation gets loaded first (composer does), we have to work around it for PHP 7.4 and bellow.

This can happen only in monorepo tests, as we need all classes to be loaded, both PHP_CodeSniffer magic autoload and other packages. That's why it's not reported as a bug in PHP_CodeSniffer.