### PR TITLE
[EasyCodingStandardTester] Add missing dependency

### DIFF
--- a/packages/easy-coding-standard-tester/composer.json
+++ b/packages/easy-coding-standard-tester/composer.json
@@ -9,7 +9,8 @@
         "symplify/skipper": "^9.3",
         "symplify/package-builder": "^9.3",
         "symplify/easy-testing": "^9.3",
-        "symplify/smart-file-system": "^9.3"
+        "symplify/smart-file-system": "^9.3",
+        "symplify/php-config-printer": "^9.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
```
Error : Class 'Symplify\PhpConfigPrinter\HttpKernel\PhpConfigPrinterKernel' not found
 /app/vendor/symplify/package-builder/src/Testing/AbstractKernelTestCase.php:104
```