### PR TITLE
[PHPStanRules] Make NoNestedFuncCallRule work for nested expressions

### DIFF
--- a/packages/phpstan-rules/src/Rules/NoNestedFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/NoNestedFuncCallRule.php
@@ -6,6 +6,7 @@ namespace Symplify\PHPStanRules\Rules;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use Symplify\Astral\Naming\SimpleNameResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -31,9 +32,15 @@ final class NoNestedFuncCallRule extends AbstractSymplifyRule
      */
     private $simpleNameResolver;
 
-    public function __construct(SimpleNameResolver $simpleNameResolver)
+    /**
+     * @var NodeFinder
+     */
+    private $nodeFinder;
+
+    public function __construct(SimpleNameResolver $simpleNameResolver, NodeFinder $nodeFinder)
     {
         $this->simpleNameResolver = $simpleNameResolver;
+        $this->nodeFinder = $nodeFinder;
     }
 
     /**
@@ -51,17 +58,14 @@ final class NoNestedFuncCallRule extends AbstractSymplifyRule
     public function process(Node $node, Scope $scope): array
     {
         foreach ($node->args as $arg) {
-            if (! $arg->value instanceof FuncCall) {
-                continue;
+            $nestedFuncCalls = $this->nodeFinder->findInstanceOf($arg, FuncCall::class);
+            foreach ($nestedFuncCalls as $nestedFuncCall) {
+                if ($this->simpleNameResolver->isNames($nestedFuncCall, self::ALLOWED_FUNC_NAMES)) {
+                    continue;
+                }
+
+                return [self::ERROR_MESSAGE];
             }
-
-            $funcCall = $arg->value;
-
-            if ($this->simpleNameResolver->isNames($funcCall, self::ALLOWED_FUNC_NAMES)) {
-                continue;
-            }
-
-            return [self::ERROR_MESSAGE];
         }
 
         return [];

--- a/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/Fixture/NestedArrayFuncCall.php
+++ b/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/Fixture/NestedArrayFuncCall.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoNestedFuncCallRule\Fixture;
+
+final class NestedArrayFuncCall
+{
+    public function run(array $expectationMocks)
+    {
+        return array_map(static function (ExpectationMock $expectationMock): Arg {
+            $arrayItems = array_map(static function (?Expr $expr): ArrayItem {
+                return new ArrayItem($expr ?: new ConstFetch(new Name('null')));
+            }, $expectationMock->getWithArguments());
+            return new Arg(new Array_($arrayItems));
+        }, $expectationMocks);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/NoNestedFuncCallRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/NoNestedFuncCallRuleTest.php
@@ -25,6 +25,7 @@ final class NoNestedFuncCallRuleTest extends AbstractServiceAwareRuleTestCase
         yield [__DIR__ . '/Fixture/SkipNonNested.php', []];
         yield [__DIR__ . '/Fixture/SkipCount.php', []];
         yield [__DIR__ . '/Fixture/NestedFuncCall.php', [[NoNestedFuncCallRule::ERROR_MESSAGE, 11]]];
+        yield [__DIR__ . '/Fixture/NestedArrayFuncCall.php', [[NoNestedFuncCallRule::ERROR_MESSAGE, 11]]];
     }
 
     protected function getRule(): Rule


### PR DESCRIPTION
Closes https://github.com/symplify/symplify/issues/3068