### PR TITLE
[ECS] Move from getCheckerClass() to provideConfig()

### DIFF
--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNewlineInNestedAnnotationFixer/DoctrineAnnotationNewlineInNestedAnnotationFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNewlineInNestedAnnotationFixer/DoctrineAnnotationNewlineInNestedAnnotationFixerTest.php
@@ -27,7 +27,7 @@ final class DoctrineAnnotationNewlineInNestedAnnotationFixerTest extends Abstrac
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNewlineInNestedAnnotationFixer/DoctrineAnnotationNewlineInNestedAnnotationFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNewlineInNestedAnnotationFixer/DoctrineAnnotationNewlineInNestedAnnotationFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNewlineInNestedAnnotationFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNewlineInNestedAnnotationFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class DoctrineAnnotationNewlineInNestedAnnotationFixerTest extends Abstrac
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return DoctrineAnnotationNewlineInNestedAnnotationFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNewlineInNestedAnnotationFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNewlineInNestedAnnotationFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNewlineInNestedAnnotationFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DoctrineAnnotationNewlineInNestedAnnotationFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/RemovePHPStormAnnotationFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/RemovePHPStormAnnotationFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Annotation\RemovePHPStormAnnotationFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Annotation\RemovePHPStormAnnotationFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class RemovePHPStormAnnotationFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return RemovePHPStormAnnotationFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/RemovePHPStormAnnotationFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/RemovePHPStormAnnotationFixerTest.php
@@ -27,7 +27,7 @@ final class RemovePHPStormAnnotationFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Annotation\RemovePHPStormAnnotationFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemovePHPStormAnnotationFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/ArrayListItemNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/ArrayListItemNewlineFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class ArrayListItemNewlineFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return ArrayListItemNewlineFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/ArrayListItemNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/ArrayListItemNewlineFixerTest.php
@@ -27,7 +27,7 @@ final class ArrayListItemNewlineFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayListItemNewlineFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ArrayListItemNewlineFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/ArrayOpenerAndCloserNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/ArrayOpenerAndCloserNewlineFixerTest.php
@@ -27,7 +27,7 @@ final class ArrayOpenerAndCloserNewlineFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/ArrayOpenerAndCloserNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/ArrayOpenerAndCloserNewlineFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class ArrayOpenerAndCloserNewlineFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return ArrayOpenerAndCloserNewlineFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\ArrayNotation\ArrayOpenerAndCloserNewlineFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ArrayOpenerAndCloserNewlineFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/Php80Test.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/Php80Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -29,8 +28,8 @@ final class Php80Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp80');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return StandaloneLineInMultilineArrayFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/Php80Test.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/Php80Test.php
@@ -28,7 +28,7 @@ final class Php80Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp80');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class StandaloneLineInMultilineArrayFixerTest extends AbstractCheckerTestC
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return StandaloneLineInMultilineArrayFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTest.php
@@ -27,7 +27,7 @@ final class StandaloneLineInMultilineArrayFixerTest extends AbstractCheckerTestC
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(StandaloneLineInMultilineArrayFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,8 +30,8 @@ final class ParamReturnAndVarTagMalformsFixerTest extends AbstractCheckerTestCas
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return ParamReturnAndVarTagMalformsFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
@@ -30,7 +30,7 @@ final class ParamReturnAndVarTagMalformsFixerTest extends AbstractCheckerTestCas
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Php74Test.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Php74Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -32,8 +31,8 @@ final class Php74Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp74');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return ParamReturnAndVarTagMalformsFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Php74Test.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Php74Test.php
@@ -31,7 +31,7 @@ final class Php74Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp74');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(ParamReturnAndVarTagMalformsFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveCommentedCodeFixer/RemoveCommentedCodeFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveCommentedCodeFixer/RemoveCommentedCodeFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveCommentedCodeFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Commenting\RemoveCommentedCodeFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class RemoveCommentedCodeFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return RemoveCommentedCodeFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveCommentedCodeFixer/RemoveCommentedCodeFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveCommentedCodeFixer/RemoveCommentedCodeFixerTest.php
@@ -27,7 +27,7 @@ final class RemoveCommentedCodeFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveCommentedCodeFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveCommentedCodeFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Commenting\RemoveCommentedCodeFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveCommentedCodeFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/RemoveUselessDefaultCommentFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/RemoveUselessDefaultCommentFixerTest.php
@@ -27,7 +27,7 @@ final class RemoveUselessDefaultCommentFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/RemoveUselessDefaultCommentFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/RemoveUselessDefaultCommentFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDefaultCommentFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDefaultCommentFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class RemoveUselessDefaultCommentFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return RemoveUselessDefaultCommentFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Commenting\RemoveUselessDefaultCommentFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(RemoveUselessDefaultCommentFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\DocBlockLineLengthFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\DocBlockLineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,18 +27,8 @@ final class DocBlockLineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return DocBlockLineLengthFixer::class;
-    }
-
-    /**
-     * @return array<string, int|bool>
-     */
-    protected function getCheckerConfiguration(): array
-    {
-        return [
-            DocBlockLineLengthFixer::LINE_LENGTH => 40,
-        ];
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
@@ -27,7 +27,7 @@ final class DocBlockLineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\DocBlockLineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DocBlockLineLengthFixer::class)
+        ->call('configure', [[
+            DocBlockLineLengthFixer::LINE_LENGTH => 40,
+        ]]);
+};

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ArrayLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ArrayLineLengthFixerTest.php
@@ -27,7 +27,7 @@ final class ArrayLineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureArray');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ArrayLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ArrayLineLengthFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class ArrayLineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureArray');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return LineLengthFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ConfiguredLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ConfiguredLineLengthFixerTest.php
@@ -27,7 +27,7 @@ final class ConfiguredLineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureConfigured');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/custom_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ConfiguredLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ConfiguredLineLengthFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,20 +27,8 @@ final class ConfiguredLineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureConfigured');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return LineLengthFixer::class;
-    }
-
-    /**
-     * @return array<string, int|bool>
-     */
-    protected function getCheckerConfiguration(): array
-    {
-        return [
-            LineLengthFixer::LINE_LENGTH => 100,
-            LineLengthFixer::BREAK_LONG_LINES => true,
-            LineLengthFixer::INLINE_SHORT_LINES => false,
-        ];
+        return __DIR__ . '/config/custom_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/LineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/LineLengthFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class LineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return LineLengthFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/LineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/LineLengthFixerTest.php
@@ -27,7 +27,7 @@ final class LineLengthFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Php80Test.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Php80Test.php
@@ -30,7 +30,7 @@ final class Php80Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp80');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Php80Test.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Php80Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,8 +30,8 @@ final class Php80Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp80');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return LineLengthFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/config/custom_rule.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/config/custom_rule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class)
+        ->call('configure', [[
+            LineLengthFixer::LINE_LENGTH => 100,
+            LineLengthFixer::BREAK_LONG_LINES => true,
+            LineLengthFixer::INLINE_SHORT_LINES => false,
+        ]]);
+};

--- a/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/Php73Test.php
+++ b/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/Php73Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Naming\StandardizeHereNowDocKeywordFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Naming\StandardizeHereNowDocKeywordFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,8 +30,8 @@ final class Php73Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp73');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return StandardizeHereNowDocKeywordFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/Php73Test.php
+++ b/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/Php73Test.php
@@ -30,7 +30,7 @@ final class Php73Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp73');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/StandardizeHereNowDocKeywordFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/StandardizeHereNowDocKeywordFixerTest.php
@@ -27,7 +27,7 @@ final class StandardizeHereNowDocKeywordFixerTest extends AbstractCheckerTestCas
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/StandardizeHereNowDocKeywordFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/StandardizeHereNowDocKeywordFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Naming\StandardizeHereNowDocKeywordFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Naming\StandardizeHereNowDocKeywordFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class StandardizeHereNowDocKeywordFixerTest extends AbstractCheckerTestCas
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return StandardizeHereNowDocKeywordFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Naming\StandardizeHereNowDocKeywordFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(StandardizeHereNowDocKeywordFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/MethodChainingNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/MethodChainingNewlineFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Spacing\MethodChainingNewlineFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Spacing\MethodChainingNewlineFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class MethodChainingNewlineFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return MethodChainingNewlineFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/MethodChainingNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/MethodChainingNewlineFixerTest.php
@@ -27,7 +27,7 @@ final class MethodChainingNewlineFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Spacing\MethodChainingNewlineFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(MethodChainingNewlineFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
@@ -27,7 +27,7 @@ final class NewlineServiceDefinitionConfigFixerTest extends AbstractCheckerTestC
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Spacing\NewlineServiceDefinitionConfigFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Spacing\NewlineServiceDefinitionConfigFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class NewlineServiceDefinitionConfigFixerTest extends AbstractCheckerTestC
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return NewlineServiceDefinitionConfigFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Spacing\NewlineServiceDefinitionConfigFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(NewlineServiceDefinitionConfigFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/SpaceAfterCommaHereNowDocFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/SpaceAfterCommaHereNowDocFixerTest.php
@@ -30,7 +30,7 @@ final class SpaceAfterCommaHereNowDocFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/SpaceAfterCommaHereNowDocFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/SpaceAfterCommaHereNowDocFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,8 +30,8 @@ final class SpaceAfterCommaHereNowDocFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return SpaceAfterCommaHereNowDocFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Spacing\SpaceAfterCommaHereNowDocFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(SpaceAfterCommaHereNowDocFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/StandaloneLinePromotedPropertyFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/StandaloneLinePromotedPropertyFixerTest.php
@@ -30,7 +30,7 @@ final class StandaloneLinePromotedPropertyFixerTest extends AbstractCheckerTestC
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/StandaloneLinePromotedPropertyFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/StandaloneLinePromotedPropertyFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,8 +30,8 @@ final class StandaloneLinePromotedPropertyFixerTest extends AbstractCheckerTestC
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return StandaloneLinePromotedPropertyFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(StandaloneLinePromotedPropertyFixer::class);
+};

--- a/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
@@ -27,7 +27,7 @@ final class BlankLineAfterStrictTypesFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/configured_rule.php';
     }

--- a/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -28,8 +27,8 @@ final class BlankLineAfterStrictTypesFixerTest extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return BlankLineAfterStrictTypesFixer::class;
+        return __DIR__ . '/config/configured_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Strict\BlankLineAfterStrictTypesFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(BlankLineAfterStrictTypesFixer::class);
+};

--- a/packages/coding-standard/tests/Issues/InlineArrayTest.php
+++ b/packages/coding-standard/tests/Issues/InlineArrayTest.php
@@ -27,7 +27,7 @@ final class InlineArrayTest extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/skip_already_inlined.php.inc')];
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/config_inline_long_array.php';
     }

--- a/packages/coding-standard/tests/Issues/Issue896Test.php
+++ b/packages/coding-standard/tests/Issues/Issue896Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Issues;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -27,8 +26,8 @@ final class Issue896Test extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/correct896.php.inc')];
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return LineLengthFixer::class;
+        return __DIR__ . '/config/line_lenght_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Issues/Issue896Test.php
+++ b/packages/coding-standard/tests/Issues/Issue896Test.php
@@ -26,7 +26,7 @@ final class Issue896Test extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/correct896.php.inc')];
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/line_lenght_rule.php';
     }

--- a/packages/coding-standard/tests/Issues/Issue973Test.php
+++ b/packages/coding-standard/tests/Issues/Issue973Test.php
@@ -26,7 +26,7 @@ final class Issue973Test extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/correct973.php.inc')];
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/line_lenght_rule.php';
     }

--- a/packages/coding-standard/tests/Issues/Issue973Test.php
+++ b/packages/coding-standard/tests/Issues/Issue973Test.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\CodingStandard\Tests\Issues;
 
 use Iterator;
-use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandardTester\Testing\AbstractCheckerTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -27,8 +26,8 @@ final class Issue973Test extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/correct973.php.inc')];
     }
 
-    protected function getCheckerClass(): string
+    protected function provideConfig(): string
     {
-        return LineLengthFixer::class;
+        return __DIR__ . '/config/line_lenght_rule.php';
     }
 }

--- a/packages/coding-standard/tests/Issues/config/line_lenght_rule.php
+++ b/packages/coding-standard/tests/Issues/config/line_lenght_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(LineLengthFixer::class);
+};

--- a/packages/easy-coding-standard-tester/composer.json
+++ b/packages/easy-coding-standard-tester/composer.json
@@ -6,11 +6,9 @@
         "php": ">=7.3",
         "phpunit/phpunit": "^9.5",
         "symplify/easy-coding-standard": "^9.3",
-        "symplify/skipper": "^9.3",
         "symplify/package-builder": "^9.3",
         "symplify/easy-testing": "^9.3",
-        "symplify/smart-file-system": "^9.3",
-        "symplify/php-config-printer": "^9.3"
+        "symplify/smart-file-system": "^9.3"
     },
     "autoload": {
         "psr-4": {

--- a/packages/easy-coding-standard-tester/src/Contract/ConfigAwareInterface.php
+++ b/packages/easy-coding-standard-tester/src/Contract/ConfigAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandardTester\Contract;
+
+interface ConfigAwareInterface
+{
+    public function provideConfig(): string;
+}

--- a/packages/easy-coding-standard-tester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/easy-coding-standard-tester/src/Testing/AbstractCheckerTestCase.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandardTester\Testing;
 
-use Nette\Utils\Json;
-use Nette\Utils\Strings;
 use Symplify\EasyCodingStandard\Configuration\Exception\NoCheckersLoadedException;
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffResultFactory;
@@ -14,11 +12,8 @@ use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
 use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
 use Symplify\EasyTesting\StaticFixtureSplitter;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
-use Symplify\PhpConfigPrinter\HttpKernel\PhpConfigPrinterKernel;
-use Symplify\PhpConfigPrinter\YamlToPhpConverter;
 use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\SmartFileInfo;
-use Symplify\SmartFileSystem\SmartFileSystem;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
@@ -30,11 +25,6 @@ abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
         __DIR__ . '/../../../../../vendor/squizlabs/php_codesniffer/autoload.php',
         __DIR__ . '/../../../../vendor/squizlabs/php_codesniffer/autoload.php',
     ];
-
-    /**
-     * @var YamlToPhpConverter|null
-     */
-    private static $yamlToPhpConverter;
 
     /**
      * @var FixerFileProcessor
@@ -88,64 +78,14 @@ abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
         );
     }
 
-    /**
-     * @deprecated Use provideConfig() only instead
-     */
-    protected function getCheckerClass(): string
-    {
-        // to be implemented
-        return '';
-    }
-
     protected function provideConfig(): string
     {
-        // use local if not overloaded
-        if ($this->getCheckerClass() !== '') {
-            $hash = $this->createConfigHash();
-            $configFileTempPath = sys_get_temp_dir() . '/ecs_temp_tests/config_' . $hash . '.php';
-
-            // cache for 2nd run, similar to original config one
-            if (file_exists($configFileTempPath)) {
-                return $configFileTempPath;
-            }
-
-            $servicesConfiguration = [
-                'services' => [
-                    '_defaults' => [
-                        // for tests
-                        'public' => true,
-                        'autowire' => true,
-                    ],
-                    $this->getCheckerClass() => $this->getCheckerConfiguration() ?: null,
-                ],
-            ];
-
-            $yamlToPhpConverter = $this->getYamlToPhpConverter();
-            $phpConfigContent = $yamlToPhpConverter->convertYamlArray($servicesConfiguration);
-
-            $smartFileSystem = new SmartFileSystem();
-            $smartFileSystem->dumpFile($configFileTempPath, $phpConfigContent);
-
-            return $configFileTempPath;
-        }
-
         // to be implemented
         return '';
-    }
-
-    /**
-     * @return mixed[]
-     */
-    protected function getCheckerConfiguration(): ?array
-    {
-        // to be implemented
-        return null;
     }
 
     /**
      * File should stay the same and contain 0 errors
-     *
-     * @todo resolve their combination with PSR-12
      */
     protected function doTestCorrectFileInfo(SmartFileInfo $fileInfo): void
     {
@@ -227,15 +167,6 @@ abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
         }
     }
 
-    private function createConfigHash(): string
-    {
-        return Strings::substring(
-            md5($this->getCheckerClass() . Json::encode($this->getCheckerConfiguration())),
-            0,
-            10
-        );
-    }
-
     private function ensureSomeCheckersAreRegistered(): void
     {
         $totalCheckersLoaded = count($this->sniffFileProcessor->getCheckers())
@@ -270,17 +201,5 @@ abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
         $fileSystemGuard->ensureFileExists($config, static::class);
 
         return [$config];
-    }
-
-    private function getYamlToPhpConverter(): YamlToPhpConverter
-    {
-        if (self::$yamlToPhpConverter !== null) {
-            return self::$yamlToPhpConverter;
-        }
-
-        $this->bootKernel(PhpConfigPrinterKernel::class);
-        self::$yamlToPhpConverter = $this->getService(YamlToPhpConverter::class);
-
-        return self::$yamlToPhpConverter;
     }
 }

--- a/packages/easy-coding-standard-tester/src/Testing/AbstractCheckerTestCase.php
+++ b/packages/easy-coding-standard-tester/src/Testing/AbstractCheckerTestCase.php
@@ -10,13 +10,14 @@ use Symplify\EasyCodingStandard\Error\ErrorAndDiffResultFactory;
 use Symplify\EasyCodingStandard\FixerRunner\Application\FixerFileProcessor;
 use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
 use Symplify\EasyCodingStandard\SniffRunner\Application\SniffFileProcessor;
+use Symplify\EasyCodingStandardTester\Contract\ConfigAwareInterface;
 use Symplify\EasyTesting\StaticFixtureSplitter;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
-abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
+abstract class AbstractCheckerTestCase extends AbstractKernelTestCase implements ConfigAwareInterface
 {
     /**
      * @var string[]
@@ -76,12 +77,6 @@ abstract class AbstractCheckerTestCase extends AbstractKernelTestCase
             $inputFileInfoAndExpectedFileInfo->getExpectedFileInfoRealPath(),
             $fileInfo
         );
-    }
-
-    protected function provideConfig(): string
-    {
-        // to be implemented
-        return '';
     }
 
     /**

--- a/packages/easy-coding-standard/tests/Issues/Issue1024Test.php
+++ b/packages/easy-coding-standard/tests/Issues/Issue1024Test.php
@@ -32,7 +32,7 @@ final class Issue1024Test extends AbstractCheckerTestCase
         ];
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/config1024.php';
     }

--- a/packages/easy-coding-standard/tests/Issues/Issue3113Test.php
+++ b/packages/easy-coding-standard/tests/Issues/Issue3113Test.php
@@ -29,7 +29,7 @@ final class Issue3113Test extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/fixture3113.php.inc')];
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/config3113.php';
     }

--- a/packages/easy-coding-standard/tests/Issues/Issue777Test.php
+++ b/packages/easy-coding-standard/tests/Issues/Issue777Test.php
@@ -29,7 +29,7 @@ final class Issue777Test extends AbstractCheckerTestCase
         yield [new SmartFileInfo(__DIR__ . '/Fixture/fixture777.php.inc')];
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/config/config777.php';
     }

--- a/packages/easy-coding-standard/tests/Set/Psr12/Psr12Test.php
+++ b/packages/easy-coding-standard/tests/Set/Psr12/Psr12Test.php
@@ -27,7 +27,7 @@ final class Psr12Test extends AbstractCheckerTestCase
         return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture');
     }
 
-    protected function provideConfig(): string
+    public function provideConfig(): string
     {
         return __DIR__ . '/../../../config/set/psr12.php';
     }


### PR DESCRIPTION
Closes https://github.com/symplify/symplify/issues/3147

Update your fixer tests ↓

## Before

```php
protected function getCheckerClass(): string
{
	return LineLenghtFixer::class;
}

```

## After

```php
protected function provideConfig(): string
{
    return __DIR__ . '/config/line_lenght_rule.php';
}
```

```php
// line_length_rule.php
use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
use Symplify\EasyCodingStandard\ValueObject\Set\SetList;

return static function (ContainerConfigurator $containerConfigurator): void {
	$services = $containerConfigurator->services();
	$services->set(LineLenghtFixer::class);
};
```