### PR TITLE
[ECS] Fix upgrade error when jean85/pretty-package-versions is locked to version greater than 2.0

### DIFF
--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -10,7 +10,7 @@
         "composer/package-versions-deprecated": "^1.8",
         "composer/xdebug-handler": "^1.4",
         "friendsofphp/php-cs-fixer": "^2.18.5",
-        "jean85/pretty-package-versions": "^2.0.1",
+        "jean85/pretty-package-versions": "^1.6|^2.0.1",
         "nette/utils": "^3.2",
         "nette/robot-loader": "^3.3",
         "ocramius/package-versions": "^1.4",

--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -7,6 +7,7 @@
     ],
     "require": {
         "php": ">=7.3",
+        "composer/package-versions-deprecated": "^1.8",
         "composer/xdebug-handler": "^1.4",
         "friendsofphp/php-cs-fixer": "^2.18.5",
         "jean85/pretty-package-versions": "^2.0.1",

--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.3",
         "composer/xdebug-handler": "^1.4",
         "friendsofphp/php-cs-fixer": "^2.18.5",
-        "jean85/pretty-package-versions": "^1.6|^2.0.1",
+        "jean85/pretty-package-versions": "^2.0.1",
         "nette/utils": "^3.2",
         "nette/robot-loader": "^3.3",
         "ocramius/package-versions": "^1.4",


### PR DESCRIPTION
Fixes #3133

This issue only happens when jean85/pretty-package-versions is locked to version greater than 2.0 before require or update symplify/easy-coding-standard.