### PR TITLE
[ECS] return error exit status code in JsonOutputFormatter if there are diffs

### DIFF
--- a/packages/easy-coding-standard/src/Console/Output/JsonOutputFormatter.php
+++ b/packages/easy-coding-standard/src/Console/Output/JsonOutputFormatter.php
@@ -41,7 +41,9 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         $this->easyCodingStandardStyle->writeln($json);
 
         $errorCount = $errorAndDiffResult->getErrorCount();
-        return $errorCount === 0 ? ShellCode::SUCCESS : ShellCode::ERROR;
+        $diffCount = $errorAndDiffResult->getFileDiffsCount();
+
+        return $errorCount + $diffCount === 0 ? ShellCode::SUCCESS : ShellCode::ERROR;
     }
 
     public function getName(): string

--- a/packages/easy-coding-standard/tests/Console/Output/JsonOutputFormatterTest.php
+++ b/packages/easy-coding-standard/tests/Console/Output/JsonOutputFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandard\Tests\Console\Output;
 
+use Symplify\PackageBuilder\Console\ShellCode;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\Console\Output\JsonOutputFormatter;
@@ -51,5 +52,18 @@ final class JsonOutputFormatterTest extends AbstractKernelTestCase
 
         $jsonContent = $this->jsonOutputFormatter->createJsonContent($errorAndDiffResult);
         $this->assertStringMatchesFormatFile(__DIR__ . '/Fixture/expected_json_output.json', $jsonContent . PHP_EOL);
+    }
+
+    public function testErrorExitStatusIfThereAreDiffs(): void
+    {
+        $randomFileInfo = new SmartFileInfo(__DIR__ . '/Source/RandomFile.php');
+
+        $this->errorAndDiffCollector->addDiffForFileInfo($randomFileInfo, 'some diff', [LineLengthFixer::class]);
+        $this->errorAndDiffCollector->addDiffForFileInfo($randomFileInfo, 'some other diff', [LineLengthFixer::class]);
+
+        $errorAndDiffResult = $this->errorAndDiffResultFactory->create();
+        $status = $this->jsonOutputFormatter->report($errorAndDiffResult, 1);
+
+        $this->assertEquals(ShellCode::ERROR, $status);
     }
 }


### PR DESCRIPTION
When executing ECS with `--output-format=json` flag, if there are no unfixable errors, it returns 0 exit code (success) even if there are diffs. It should take diffs into account when determining what exit status to return.