### PR TITLE
[Autowire] remove @noRector on ParameterSkipper const

### DIFF
--- a/packages/autowire-array-parameter/src/Skipper/ParameterSkipper.php
+++ b/packages/autowire-array-parameter/src/Skipper/ParameterSkipper.php
@@ -15,7 +15,6 @@ final class ParameterSkipper
      * Classes that create circular dependencies
      *
      * @var string[]
-     * @noRector
      */
     private const DEFAULT_EXCLUDED_FATAL_CLASSES = [
         'Symfony\Component\Form\FormExtensionInterface',

--- a/packages/symfony-php-config/src/ValueObjectInliner.php
+++ b/packages/symfony-php-config/src/ValueObjectInliner.php
@@ -37,7 +37,8 @@ final class ValueObjectInliner
 
     /**
      * @param object|object[] $object
-     * @return InlineServiceConfigurator|\RectorPrefix20210514\Symfony\Component\DependencyInjection\Loader\Configurator\InlineServiceConfigurator[]
+     * @return InlineServiceConfigurator|InlineServiceConfigurator[]
+     * @noRector \Rector\TypeDeclaration\Rector\ClassMethod\AddArrayReturnDocTypeRector
      */
     public static function inline($object)
     {

--- a/packages/symfony-php-config/src/ValueObjectInliner.php
+++ b/packages/symfony-php-config/src/ValueObjectInliner.php
@@ -37,7 +37,7 @@ final class ValueObjectInliner
 
     /**
      * @param object|object[] $object
-     * @return InlineServiceConfigurator|InlineServiceConfigurator[]
+     * @return InlineServiceConfigurator|\RectorPrefix20210514\Symfony\Component\DependencyInjection\Loader\Configurator\InlineServiceConfigurator[]
      */
     public static function inline($object)
     {


### PR DESCRIPTION
This patch to make it downgrade-able to php 7.0 compatible code at https://github.com/rectorphp/rector-src/pull/50