### PR TITLE
Move EasyCodingStandardTester to EasyCodingStandard

### DIFF
--- a/packages/easy-coding-standard/src/Testing/Contract/ConfigAwareInterface.php
+++ b/packages/easy-coding-standard/src/Testing/Contract/ConfigAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Testing\Contract;
+
+interface ConfigAwareInterface
+{
+    public function provideConfig(): string;
+}

--- a/packages/easy-coding-standard/src/Testing/Exception/ShouldNotHappenException.php
+++ b/packages/easy-coding-standard/src/Testing/Exception/ShouldNotHappenException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Testing\Exception;
+
+use Exception;
+
+final class ShouldNotHappenException extends Exception
+{
+}

--- a/packages/easy-coding-standard/src/Testing/Test/AbstractCheckerTestCase.php
+++ b/packages/easy-coding-standard/src/Testing/Test/AbstractCheckerTestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\EasyCodingStandardTester\Testing;
+namespace Symplify\EasyCodingStandard\Testing\Test;
 
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffResultFactory;
@@ -16,17 +16,14 @@ use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-/**
- * @deprecated Use Symplify\EasyCodingStandard\Testing\Test\AbstractCheckerTestCase instead.
- */
 abstract class AbstractCheckerTestCase extends AbstractKernelTestCase implements ConfigAwareInterface
 {
     /**
      * @var string[]
      */
     private const POSSIBLE_CODE_SNIFFER_AUTOLOAD_PATHS = [
+        __DIR__ . '/../../../../../../vendor/squizlabs/php_codesniffer/autoload.php',
         __DIR__ . '/../../../../../vendor/squizlabs/php_codesniffer/autoload.php',
-        __DIR__ . '/../../../../vendor/squizlabs/php_codesniffer/autoload.php',
     ];
 
     /**


### PR DESCRIPTION
Closes #3204

Here is a draft. I simply duplicated the classes from EasyCodingStandardTester under `Symplify\EasyCodingStandard\Testing\`. I hope this is what you meant... if not let me know...

Also added a deprecation for the original class.

Finally I added an extra `../` to the paths since the class is now one level deeper in the directory structure.

Should I do anything else to deprecate the original package?

----

However this won't help with my second issue with failing PHPStan:

```
Module/Core/PhpCsFixer/ImmutableObjectHasConstructorFixer.php:20
 ↳ Class PhpCsFixer\AbstractFixer not found.
```

How should I handle that? :thinking: 