### PR TITLE
Move EasyCodingStandardTester to EasyCodingStandard

### DIFF
--- a/packages/easy-coding-standard/build/target-repository/composer.json
+++ b/packages/easy-coding-standard/build/target-repository/composer.json
@@ -13,10 +13,6 @@
     "bin": [
         "bin/ecs"
     ],
-    "replace": {
-        "squizlabs/php_codesniffer": "^3.6",
-        "friendsofphp/php-cs-fixer": "^3.0"
-    },
     "conflict": {
         "squizlabs/php_codesniffer": "<3.6",
         "friendsofphp/php-cs-fixer": "<3.0"

--- a/packages/easy-coding-standard/src/Testing/Contract/ConfigAwareInterface.php
+++ b/packages/easy-coding-standard/src/Testing/Contract/ConfigAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Testing\Contract;
+
+interface ConfigAwareInterface
+{
+    public function provideConfig(): string;
+}

--- a/packages/easy-coding-standard/src/Testing/Exception/ShouldNotHappenException.php
+++ b/packages/easy-coding-standard/src/Testing/Exception/ShouldNotHappenException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Testing\Exception;
+
+use Exception;
+
+final class ShouldNotHappenException extends Exception
+{
+}

--- a/packages/easy-coding-standard/src/Testing/Test/AbstractCheckerTestCase.php
+++ b/packages/easy-coding-standard/src/Testing/Test/AbstractCheckerTestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\EasyCodingStandardTester\Testing;
+namespace Symplify\EasyCodingStandard\Testing\Test;
 
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffCollector;
 use Symplify\EasyCodingStandard\Error\ErrorAndDiffResultFactory;
@@ -16,17 +16,14 @@ use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\SmartFileSystem\FileSystemGuard;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-/**
- * @deprecated Use Symplify\EasyCodingStandard\Testing\Test\AbstractCheckerTestCase instead.
- */
 abstract class AbstractCheckerTestCase extends AbstractKernelTestCase implements ConfigAwareInterface
 {
     /**
      * @var string[]
      */
     private const POSSIBLE_CODE_SNIFFER_AUTOLOAD_PATHS = [
+        __DIR__ . '/../../../../../../vendor/squizlabs/php_codesniffer/autoload.php',
         __DIR__ . '/../../../../../vendor/squizlabs/php_codesniffer/autoload.php',
-        __DIR__ . '/../../../../vendor/squizlabs/php_codesniffer/autoload.php',
     ];
 
     /**


### PR DESCRIPTION
Replaces #3208.

I noticed you added some preload in #3210. Is this related to my issues in some way? I tried v9.3.12 but it didn't change anything for me. So I removed the package replace from ECS's composer.json which should help solving the phpstan issue. Though tbh with that change moving the classes from ECST to ECS isn't really necessary... I think we maybe should just drop the replace.