### PR TITLE
[ECS] Add release-based version constants

### DIFF
--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -15,6 +15,7 @@
         "symfony/console": "^4.4|^5.2",
         "symfony/config": "^4.4|^5.2",
         "symfony/http-kernel": "^4.4|^5.2",
+        "symfony/process": "^4.4|^5.2",
         "symfony/dependency-injection": "^5.2",
         "symfony/finder": "^4.4|^5.2",
         "symplify/coding-standard": "^9.4",

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Nette\Utils\Strings;
+use Symplify\EasyCodingStandard\Application\VersionResolver;
 
 require __DIR__ . '/vendor/autoload.php';
 
@@ -107,6 +108,20 @@ return [
             }
 
             return $content;
+        },
+
+        // add static versions constant values
+        function (string $filePath, string $prefix, string $content): string {
+            if (! Strings::endsWith($filePath, 'src/Application/VersionResolver.php')) {
+                return $content;
+            }
+
+            $releaseDateTime = VersionResolver::resolverReleaseDateTime();
+
+            return strtr($content, [
+                '@package_version@' => VersionResolver::resolvePackageVersion(),
+                '@release_date@' => $releaseDateTime->format('Y-m-d H:i:s'),
+            ]);
         },
     ],
 ];

--- a/packages/easy-coding-standard/src/Application/VersionResolver.php
+++ b/packages/easy-coding-standard/src/Application/VersionResolver.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Application;
+
+use DateTime;
+use DateTimeInterface;
+use Symfony\Component\Process\Process;
+use Symplify\EasyCodingStandard\Exception\VersionException;
+use Symplify\PackageBuilder\Console\ShellCode;
+
+/**
+ * Inspired by https://github.com/composer/composer/blob/master/src/Composer/Composer.php See
+ * https://github.com/composer/composer/blob/6587715d0f8cae0cd39073b3bc5f018d0e6b84fe/src/Composer/Compiler.php#L208
+ */
+final class VersionResolver
+{
+    /**
+     * @var string
+     */
+    public const PACKAGE_VERSION = '@package_version@';
+
+    /**
+     * @var string
+     */
+    public const RELEASE_DATE = '@release_date@';
+
+    public static function resolvePackageVersion(): string
+    {
+        $process = new Process(['git', 'log', '--pretty="%H"', '-n1', 'HEAD'], __DIR__);
+        if ($process->run() !== ShellCode::SUCCESS) {
+            throw new VersionException(
+                'You must ensure to run compile from composer git repository clone and that git binary is available.'
+            );
+        }
+        return trim($process->getOutput());
+    }
+
+    public static function resolverReleaseDateTime(): DateTimeInterface
+    {
+        $process = new Process(['git', 'log', '-n1', '--pretty=%ci', 'HEAD'], __DIR__);
+        if ($process->run() !== ShellCode::SUCCESS) {
+            throw new VersionException(
+                'You must ensure to run compile from composer git repository clone and that git binary is available.'
+            );
+        }
+
+        return new DateTime(trim($process->getOutput()));
+    }
+}

--- a/packages/easy-coding-standard/src/Application/VersionResolver.php
+++ b/packages/easy-coding-standard/src/Application/VersionResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\Application;
 
 use DateTime;
-use DateTimeInterface;
 use Symfony\Component\Process\Process;
 use Symplify\EasyCodingStandard\Exception\VersionException;
 use Symplify\PackageBuilder\Console\ShellCode;
@@ -37,7 +36,7 @@ final class VersionResolver
         return trim($process->getOutput());
     }
 
-    public static function resolverReleaseDateTime(): DateTimeInterface
+    public static function resolverReleaseDateTime(): DateTime
     {
         $process = new Process(['git', 'log', '-n1', '--pretty=%ci', 'HEAD'], __DIR__);
         if ($process->run() !== ShellCode::SUCCESS) {

--- a/packages/easy-coding-standard/src/Console/EasyCodingStandardConsoleApplication.php
+++ b/packages/easy-coding-standard/src/Console/EasyCodingStandardConsoleApplication.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\Console;
 
 use Composer\XdebugHandler\XdebugHandler;
-use Nette\Utils\Strings;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symplify\EasyCodingStandard\Application\VersionResolver;
 use Symplify\EasyCodingStandard\Console\Command\CheckCommand;
 use Symplify\EasyCodingStandard\Console\Output\ConsoleOutputFormatter;
 use Symplify\EasyCodingStandard\ValueObject\Option;
@@ -24,9 +24,7 @@ final class EasyCodingStandardConsoleApplication extends Application
      */
     public function __construct(array $commands)
     {
-        $version = $this->resolveEasyCodingStandardVersion();
-
-        parent::__construct('EasyCodingStandard', $version);
+        parent::__construct('EasyCodingStandard', VersionResolver::PACKAGE_VERSION);
 
         // @see https://tomasvotruba.com/blog/2020/10/26/the-bullet-proof-symfony-command-naming/
         $commandNaming = new CommandNaming();
@@ -97,32 +95,5 @@ final class EasyCodingStandardConsoleApplication extends Application
             InputOption::VALUE_NONE,
             'Run in debug mode (alias for "-vvv")'
         ));
-    }
-
-    private function resolveEasyCodingStandardVersion(): string
-    {
-        // load packages' scoped installed versions class
-        if (file_exists(__DIR__ . '/../../vendor/composer/InstalledVersions.php')) {
-            require_once __DIR__ . '/../../vendor/composer/InstalledVersions.php';
-        }
-
-        $installedRawData = \Composer\InstalledVersions::getRawData();
-        $ecsPackageData = isset($installedRawData['versions']['symplify/easy-coding-standard']) ? $installedRawData['versions']['symplify/easy-coding-standard'] : null;
-        if ($ecsPackageData === null) {
-            return 'Unknown';
-        }
-        if (isset($ecsPackageData['replaced'])) {
-            return 'replaced@' . $ecsPackageData['replaced'][0];
-        }
-
-        if ($ecsPackageData['version'] === 'dev-main') {
-            if ($ecsPackageData['reference'] !== null) {
-                return 'dev-main@' . Strings::substring($ecsPackageData['reference'], 0, 7);
-            }
-
-            return $ecsPackageData['aliases'][0] ?? 'dev-main';
-        }
-
-        return $ecsPackageData['version'];
     }
 }

--- a/packages/easy-coding-standard/src/Exception/VersionException.php
+++ b/packages/easy-coding-standard/src/Exception/VersionException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Exception;
+
+use Exception;
+
+final class VersionException extends Exception
+{
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -557,3 +557,8 @@ parameters:
         -
             message:  '#Use "Symplify\\SmartFileSystem\\SmartFileSystem\:\:dumpFile\(\)" static call over "file_put_contents\(\)" func call#'
             path: packages/easy-coding-standard/build/build-preload.php
+
+        # this class is used by scoper, so better use less external deps
+        -
+            message: '#Instead of "DateTime" class/interface use "Nette\\Utils\\DateTime"#'
+            path: packages/easy-coding-standard/src/Application/VersionResolver.php


### PR DESCRIPTION
This will prevent bugs with dependency on composer installed hardcoded class with packagist-based versions. Inspired by solution directory from composer versioning itself :+1: 

Inspired in https://github.com/rectorphp/rector-src/commit/e2bd8de3480bc10b518a1713987cbbbf24b54a6b