### PR TITLE
[PHPStanRules] Add NoVoidGetterMethodRule

### DIFF
--- a/packages/amnesia/src/ValueObject/Symfony/ServiceTag.php
+++ b/packages/amnesia/src/ValueObject/Symfony/ServiceTag.php
@@ -194,5 +194,4 @@ final class ServiceTag
      * @var string
      */
     public const VALIDATOR_INITIALIZER = 'validator.initializer';
-
 }

--- a/packages/astral/src/NodeFinder/SimpleNodeFinder.php
+++ b/packages/astral/src/NodeFinder/SimpleNodeFinder.php
@@ -38,6 +38,21 @@ final class SimpleNodeFinder
     }
 
     /**
+     * @template T of Node
+     * @param array<class-string<T>> $nodeClasses
+     */
+    public function hasByTypes(Node $node, array $nodeClasses): bool
+    {
+        foreach ($nodeClasses as $nodeClass) {
+            if ($this->findByType($node, $nodeClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * @see https://phpstan.org/blog/generics-in-php-using-phpdocs for template
      *
      * @template T of Node

--- a/packages/phpstan-rules/config/naming-rules.neon
+++ b/packages/phpstan-rules/config/naming-rules.neon
@@ -1,5 +1,9 @@
 services:
     -
+        class: Symplify\PHPStanRules\Rules\NoVoidGetterMethodRule
+        tags: [phpstan.rules.rule]
+
+    -
         class: Symplify\PHPStanRules\Rules\SuffixInterfaceRule
         tags: [phpstan.rules.rule]
 

--- a/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
+++ b/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\FunctionLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use Symplify\Astral\Naming\SimpleNameResolver;
+use Symplify\Astral\NodeFinder\SimpleNodeFinder;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\NoVoidGetterMethodRuleTest
+ */
+final class NoVoidGetterMethodRule extends AbstractSymplifyRule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Getter method must return somethign, not void';
+
+    /**
+     * @var SimpleNameResolver
+     */
+    private $simpleNameResolver;
+
+    /**
+     * @var SimpleNodeFinder
+     */
+    private $simpleNodeFinder;
+
+    public function __construct(SimpleNameResolver $simpleNameResolver, SimpleNodeFinder $simpleNodeFinder)
+    {
+        $this->simpleNameResolver = $simpleNameResolver;
+        $this->simpleNodeFinder = $simpleNodeFinder;
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class, Function_::class];
+    }
+
+    /**
+     * @param ClassMethod|Function_ $node
+     * @return string[]
+     */
+    public function process(Node $node, Scope $scope): array
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return [];
+        }
+
+        if (! $classReflection->isClass()) {
+            return [];
+        }
+
+        if (! $this->simpleNameResolver->isName($node, 'get*')) {
+            return [];
+        }
+
+        if (! $this->isVoidReturnFunctionLike($node)) {
+            return [];
+        }
+
+        return [self::ERROR_MESSAGE];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function getData(): void
+    {
+    }
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+final class SomeClass
+{
+    public function getData(): array
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function isVoidReturnFunctionLike(FunctionLike $functionLike): bool
+    {
+        if ($this->hasVoidReturnType($functionLike)) {
+            return true;
+        }
+
+        return ! $this->simpleNodeFinder->hasByTypes($functionLike, [
+            Return_::class,
+            Yield_::class,
+            // possibly unneded contract override
+            Throw_::class,
+            Node\Stmt\Throw_::class,
+        ]);
+    }
+
+    /**
+     * @param ClassMethod|Function_ $functionLike
+     */
+    private function hasVoidReturnType(FunctionLike $functionLike): bool
+    {
+        if ($functionLike->returnType === null) {
+            return false;
+        }
+
+        return $this->simpleNameResolver->isName($functionLike->returnType, 'void');
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipGetterWithReturn.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipGetterWithReturn.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+final class SkipGetterWithReturn
+{
+    public function get()
+    {
+        return 1000;
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipIfElseReturn.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipIfElseReturn.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+final class SkipIfElseReturn
+{
+    public function get()
+    {
+        if (mt_rand(0, 1)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipInterfaceContractGetter.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipInterfaceContractGetter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+interface SkipInterfaceContractGetter
+{
+    public function getName(): string;
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipNoThrows.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipNoThrows.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+use InvalidArgumentException;
+
+final class SkipNoThrows
+{
+    public function get(): int
+    {
+        // not supported
+        throw new InvalidArgumentException();
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipSetter.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipSetter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+final class SkipSetter
+{
+    public function set(): void
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipYielder.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipYielder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+use Iterator;
+
+final class SkipYielder
+{
+    public function get(): Iterator
+    {
+        yield [200];
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SomeGetterVoid.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SomeGetterVoid.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+final class SomeGetterVoid
+{
+    public function get(): void
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SomeGetterWithNoReturn.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SomeGetterWithNoReturn.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+final class SomeGetterWithNoReturn
+{
+    public function getSomeValues()
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/NoVoidGetterMethodRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/NoVoidGetterMethodRuleTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Rules\NoVoidGetterMethodRule;
+
+/**
+ * @extends AbstractServiceAwareRuleTestCase<NoVoidGetterMethodRule>
+ */
+final class NoVoidGetterMethodRuleTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @param array<string|int> $expectedErrorsWithLines
+     */
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SomeGetterVoid.php', [[NoVoidGetterMethodRule::ERROR_MESSAGE, 9]]];
+        yield [__DIR__ . '/Fixture/SomeGetterWithNoReturn.php', [[NoVoidGetterMethodRule::ERROR_MESSAGE, 9]]];
+
+        yield [__DIR__ . '/Fixture/SkipIfElseReturn.php', []];
+        yield [__DIR__ . '/Fixture/SkipGetterWithReturn.php', []];
+        yield [__DIR__ . '/Fixture/SkipSetter.php', []];
+        yield [__DIR__ . '/Fixture/SkipYielder.php', []];
+        yield [__DIR__ . '/Fixture/SkipInterfaceContractGetter.php', []];
+        yield [__DIR__ . '/Fixture/SkipNoThrows.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(
+            NoVoidGetterMethodRule::class,
+            __DIR__ . '/../../../config/symplify-rules.neon'
+        );
+    }
+}


### PR DESCRIPTION
Closes https://github.com/symplify/symplify/issues/3237

Getter-named methods must return some value:

```php
final class SomeClass
{
    public function getData(): void
    {
    }
}
```

# :x: 