### PR TITLE
[Dir] Always use realpath() on sys_get_temp_dir()

### DIFF
--- a/packages/autowire-array-parameter/tests/HttpKernel/AutowireArrayParameterHttpKernel.php
+++ b/packages/autowire-array-parameter/tests/HttpKernel/AutowireArrayParameterHttpKernel.php
@@ -34,12 +34,12 @@ final class AutowireArrayParameterHttpKernel extends Kernel implements ExtraConf
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/autowire_array_parameter_test';
+        return realpath(sys_get_temp_dir()) . '/autowire_array_parameter_test';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/autowire_array_parameter_test_log';
+        return realpath(sys_get_temp_dir()) . '/autowire_array_parameter_test_log';
     }
 
     /**

--- a/packages/coding-standard/tests/HttpKernel/SymplifyCodingStandardKernel.php
+++ b/packages/coding-standard/tests/HttpKernel/SymplifyCodingStandardKernel.php
@@ -18,12 +18,12 @@ final class SymplifyCodingStandardKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/symplify_coding_standard';
+        return realpath(sys_get_temp_dir()) . '/symplify_coding_standard';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/symplify_coding_standard_log';
+        return realpath(sys_get_temp_dir()) . '/symplify_coding_standard_log';
     }
 
     /**

--- a/packages/composer-json-manipulator/tests/ComposerJsonSchemaValidation/ComposerJsonSchemaValidationTest.php
+++ b/packages/composer-json-manipulator/tests/ComposerJsonSchemaValidation/ComposerJsonSchemaValidationTest.php
@@ -33,7 +33,7 @@ final class ComposerJsonSchemaValidationTest extends AbstractKernelTestCase
     public function testCheckEmptyKeysAreRemoved(): void
     {
         $sourceJsonPath = __DIR__ . '/Source/symfony-website_skeleton-composer.json';
-        $targetJsonPath = sys_get_temp_dir() . '/composer_json_manipulator_test_schema_validation.json';
+        $targetJsonPath = realpath(sys_get_temp_dir()) . '/composer_json_manipulator_test_schema_validation.json';
 
         $sourceJson = $this->jsonFileManager->loadFromFilePath($sourceJsonPath);
         $this->smartFileSystem->dumpFile($targetJsonPath, $this->jsonFileManager->encodeJsonToFileContent($sourceJson));

--- a/packages/config-transformer/src/ConfigLoader.php
+++ b/packages/config-transformer/src/ConfigLoader.php
@@ -70,7 +70,7 @@ final class ConfigLoader
         if (in_array($smartFileInfo->getSuffix(), [Format::YML, Format::YAML], true)) {
             $content = Strings::replace($content, self::PHP_CONST_REGEX, '!php/const ');
             if ($content !== $smartFileInfo->getContents()) {
-                $fileRealPath = sys_get_temp_dir() . '/_migrify_config_tranformer_clean_yaml/' . $smartFileInfo->getFilename();
+                $fileRealPath = realpath(sys_get_temp_dir()) . '/_migrify_config_tranformer_clean_yaml/' . $smartFileInfo->getFilename();
                 $this->smartFileSystem->dumpFile($fileRealPath, $content);
             }
 

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php
@@ -68,7 +68,7 @@ abstract class AbstractConfigFormatConverterTest extends AbstractKernelTestCase
 
     protected function doTestYamlContentIsLoadable(string $yamlContent): void
     {
-        $localFile = sys_get_temp_dir() . '/_migrify_temporary_yaml/some_file.yaml';
+        $localFile = realpath(sys_get_temp_dir()) . '/_migrify_temporary_yaml/some_file.yaml';
         $this->smartFileSystem->dumpFile($localFile, $yamlContent);
 
         $containerBuilder = new ContainerBuilder();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/XmlToPhp/XmlToPhpTest.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/XmlToPhp/XmlToPhpTest.php
@@ -18,7 +18,7 @@ final class XmlToPhpTest extends AbstractConfigFormatConverterTest
     {
         $this->smartFileSystem->copy(
             __DIR__ . '/Source/some.xml',
-            sys_get_temp_dir() . '/_temp_fixture_easy_testing/some.xml'
+            realpath(sys_get_temp_dir()) . '/_temp_fixture_easy_testing/some.xml'
         );
 
         $this->doTestOutput($fixtureFileInfo, 'xml', 'php');

--- a/packages/console-package-builder/tests/HttpKernel/ConsolePackageBuilderKernel.php
+++ b/packages/console-package-builder/tests/HttpKernel/ConsolePackageBuilderKernel.php
@@ -42,11 +42,11 @@ final class ConsolePackageBuilderKernel extends Kernel implements ExtraConfigAwa
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/console_package_builder';
+        return realpath(sys_get_temp_dir()) . '/console_package_builder';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/console_package_builder_log';
+        return realpath(sys_get_temp_dir()) . '/console_package_builder_log';
     }
 }

--- a/packages/easy-coding-standard/README.md
+++ b/packages/easy-coding-standard/README.md
@@ -116,7 +116,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::FILE_EXTENSIONS, ['php', 'phpt']);
 
     // configure cache paths & namespace - useful for Gitlab CI caching, where getcwd() produces always different path
-    // [default: sys_get_temp_dir() . '/_changed_files_detector_tests']
+    // [default: realpath(sys_get_temp_dir()) . '/_changed_files_detector_tests']
     $parameters->set(Option::CACHE_DIRECTORY, '.ecs_cache');
 
     // [default: \Nette\Utils\Strings::webalize(getcwd())']

--- a/packages/easy-coding-standard/build/target-repository/README.md
+++ b/packages/easy-coding-standard/build/target-repository/README.md
@@ -116,7 +116,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::FILE_EXTENSIONS, ['php', 'phpt']);
 
     // configure cache paths & namespace - useful for Gitlab CI caching, where getcwd() produces always different path
-    // [default: sys_get_temp_dir() . '/_changed_files_detector_tests']
+    // [default: realpath(sys_get_temp_dir()) . '/_changed_files_detector_tests']
     $parameters->set(Option::CACHE_DIRECTORY, '.ecs_cache');
 
     // [default: \Nette\Utils\Strings::webalize(getcwd())']

--- a/packages/easy-coding-standard/config/config.php
+++ b/packages/easy-coding-standard/config/config.php
@@ -13,7 +13,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set(Option::INDENTATION, Option::INDENTATION_SPACES);
     $parameters->set(Option::LINE_ENDING, PHP_EOL);
-    $parameters->set(Option::CACHE_DIRECTORY, sys_get_temp_dir() . '/_changed_files_detector%env(TEST_SUFFIX)%');
+    $parameters->set(Option::CACHE_DIRECTORY, realpath(sys_get_temp_dir()) . '/_changed_files_detector%env(TEST_SUFFIX)%');
     $parameters->set(Option::CACHE_NAMESPACE, Strings::webalize(getcwd()));
     $parameters->set(Option::PATHS, []);
     $parameters->set(Option::SETS, []);

--- a/packages/easy-coding-standard/packages/SnippetFormatter/Formatter/SnippetFormatter.php
+++ b/packages/easy-coding-standard/packages/SnippetFormatter/Formatter/SnippetFormatter.php
@@ -173,7 +173,7 @@ final class SnippetFormatter
         $key = md5($content);
         $fileName = sprintf('php-code-%s.php', $key);
 
-        return sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'ecs_temp' . DIRECTORY_SEPARATOR . $fileName;
+        return realpath(sys_get_temp_dir()) . DIRECTORY_SEPARATOR . 'ecs_temp' . DIRECTORY_SEPARATOR . $fileName;
     }
 
     private function removeOpeningTag(string $fileContent): string

--- a/packages/easy-testing/src/StaticFixtureSplitter.php
+++ b/packages/easy-testing/src/StaticFixtureSplitter.php
@@ -60,7 +60,7 @@ final class StaticFixtureSplitter
             return self::$customTemporaryPath;
         }
 
-        return sys_get_temp_dir() . '/_temp_fixture_easy_testing';
+        return realpath(sys_get_temp_dir()) . '/_temp_fixture_easy_testing';
     }
 
     public static function createTemporaryFileInfo(

--- a/packages/monorepo-builder/packages-tests/Testing/ComposerJson/ComposerJsonSymlinkerTest.php
+++ b/packages/monorepo-builder/packages-tests/Testing/ComposerJson/ComposerJsonSymlinkerTest.php
@@ -6,7 +6,6 @@ namespace Symplify\MonorepoBuilder\Tests\Testing\ComposerJson;
 
 use Iterator;
 use Nette\Utils\Json;
-use Symplify\ComposerJsonManipulator\FileSystem\JsonFileManager;
 use Symplify\MonorepoBuilder\HttpKernel\MonorepoBuilderKernel;
 use Symplify\MonorepoBuilder\Testing\ComposerJson\ComposerJsonSymlinker;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
@@ -19,16 +18,9 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
      */
     private $composerJsonSymlinker;
 
-    /**
-     * @var JsonFileManager
-     */
-    private $jsonFileManager;
-
     protected function setUp(): void
     {
         $this->bootKernel(MonorepoBuilderKernel::class);
-
-        $this->jsonFileManager = $this->getService(JsonFileManager::class);
         $this->composerJsonSymlinker = $this->getService(ComposerJsonSymlinker::class);
     }
 

--- a/packages/monorepo-builder/packages-tests/Testing/ComposerJson/ComposerJsonSymlinkerTest.php
+++ b/packages/monorepo-builder/packages-tests/Testing/ComposerJson/ComposerJsonSymlinkerTest.php
@@ -44,8 +44,6 @@ final class ComposerJsonSymlinkerTest extends AbstractKernelTestCase
         $mainComposerJson = new SmartFileInfo(__DIR__ . '/composer.json');
         $packageFileInfo = new SmartFileInfo($packagePath);
 
-        $packageComposerJson = $this->jsonFileManager->loadFromFileInfo($packageFileInfo);
-
         $packageComposerJson = $this->composerJsonSymlinker->decoratePackageComposerJsonWithPackageSymlinks(
             $packageFileInfo,
             [$packageName],

--- a/packages/phpstan-extensions/src/DependencyInjection/PHPStanContainerFactory.php
+++ b/packages/phpstan-extensions/src/DependencyInjection/PHPStanContainerFactory.php
@@ -16,7 +16,7 @@ final class PHPStanContainerFactory
     {
         $containerFactory = new ContainerFactory(getcwd());
         // random for tests cache invalidation in case the container changes
-        $tempDirectory = sys_get_temp_dir() . '/_symplify_phpstan_tests/id_' . random_int(0, 1000);
+        $tempDirectory = realpath(sys_get_temp_dir()) . '/_symplify_phpstan_tests/id_' . random_int(0, 1000);
 
         return $containerFactory->create($tempDirectory, $configs, [], []);
     }

--- a/packages/phpstan-rules/packages/cognitive-complexity/tests/AstCognitiveComplexityAnalyzer/AstCognitiveComplexityAnalyzerTest.php
+++ b/packages/phpstan-rules/packages/cognitive-complexity/tests/AstCognitiveComplexityAnalyzer/AstCognitiveComplexityAnalyzerTest.php
@@ -29,7 +29,7 @@ final class AstCognitiveComplexityAnalyzerTest extends TestCase
     {
         $phpstanContainerFactory = new ContainerFactory(getcwd());
 
-        $tempFile = sys_get_temp_dir() . '/_symplify_cogntive_complexity_test';
+        $tempFile = realpath(sys_get_temp_dir()) . '/_symplify_cogntive_complexity_test';
         $container = $phpstanContainerFactory->create($tempFile, [__DIR__ . '/config/configured_service.neon'], []);
 
         $this->astCognitiveComplexityAnalyzer = $container->getByType(AstCognitiveComplexityAnalyzer::class);

--- a/packages/phpstan-rules/src/Rules/NoFuncCallInMethodCallRule.php
+++ b/packages/phpstan-rules/src/Rules/NoFuncCallInMethodCallRule.php
@@ -27,7 +27,7 @@ final class NoFuncCallInMethodCallRule extends AbstractSymplifyRule
     /**
      * @var string[]
      */
-    private const ALLOWED_FUNC_CALL_NAMES = ['getcwd', 'sys_get_temp_dir'];
+    private const ALLOWED_FUNC_CALL_NAMES = ['getcwd', 'sys_get_temp_dir', 'realpath'];
 
     /**
      * @return array<class-string<Node>>

--- a/packages/phpstan-rules/src/Rules/NoNestedFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/NoNestedFuncCallRule.php
@@ -37,6 +37,7 @@ final class NoNestedFuncCallRule extends AbstractSymplifyRule
         'is_file',
         'file_exists',
         'in_array',
+        'sys_get_temp_dir',
     ];
 
     /**

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipRealpath.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/Fixture/SkipRealpath.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoFuncCallInMethodCallRule\Fixture;
+
+final class SkipRealpath
+{
+    public function run()
+    {
+        $this->container = $containerFactory->create(realpath(sys_get_temp_dir()), $existingAdditionalConfigFiles, []);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/NoFuncCallInMethodCallRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/NoFuncCallInMethodCallRuleTest.php
@@ -30,6 +30,7 @@ final class NoFuncCallInMethodCallRuleTest extends AbstractServiceAwareRuleTestC
 
         yield [__DIR__ . '/Fixture/SkipGetCwd.php', []];
         yield [__DIR__ . '/Fixture/SkipNamespacedFunction.php', []];
+        yield [__DIR__ . '/Fixture/SkipRealpath.php', []];
     }
 
     protected function getRule(): Rule

--- a/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/Fixture/SkipSysGetTempDir.php
+++ b/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/Fixture/SkipSysGetTempDir.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoNestedFuncCallRule\Fixture;
+
+final class SkipSysGetTempDir
+{
+    public function run()
+    {
+        $this->container = $containerFactory->create(realpath(sys_get_temp_dir()), $existingAdditionalConfigFiles, []);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/NoNestedFuncCallRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/NoNestedFuncCallRuleTest.php
@@ -31,6 +31,7 @@ final class NoNestedFuncCallRuleTest extends AbstractServiceAwareRuleTestCase
 
         yield [__DIR__ . '/Fixture/SkipNonNested.php', []];
         yield [__DIR__ . '/Fixture/SkipCount.php', []];
+        yield [__DIR__ . '/Fixture/SkipSysGetTempDir.php', []];
     }
 
     protected function getRule(): Rule

--- a/packages/psr4-switcher/src/RobotLoader/PhpClassLoader.php
+++ b/packages/psr4-switcher/src/RobotLoader/PhpClassLoader.php
@@ -16,7 +16,7 @@ final class PhpClassLoader
     {
         $robotLoader = new RobotLoader();
         $robotLoader->addDirectory(...$directories);
-        $robotLoader->setTempDirectory(sys_get_temp_dir() . '/migrify_psr4_switcher');
+        $robotLoader->setTempDirectory(realpath(sys_get_temp_dir()) . '/migrify_psr4_switcher');
         $robotLoader->rebuild();
 
         return $robotLoader->getIndexedClasses();

--- a/packages/rule-doc-generator/src/Finder/ClassByTypeFinder.php
+++ b/packages/rule-doc-generator/src/Finder/ClassByTypeFinder.php
@@ -18,7 +18,7 @@ final class ClassByTypeFinder
     public function findByType(string $workingDirectory, array $directories, string $type): array
     {
         $robotLoader = new RobotLoader();
-        $robotLoader->setTempDirectory(sys_get_temp_dir() . '/robot_loader_temp');
+        $robotLoader->setTempDirectory(realpath(sys_get_temp_dir()) . '/robot_loader_temp');
         $robotLoader->addDirectory(...$directories);
         $robotLoader->ignoreDirs[] = '*tests*';
         $robotLoader->ignoreDirs[] = '*Fixture*';

--- a/packages/symfony-static-dumper/tests/test_project/src/HttpKernel/TestSymfonyStaticDumperKernel.php
+++ b/packages/symfony-static-dumper/tests/test_project/src/HttpKernel/TestSymfonyStaticDumperKernel.php
@@ -34,12 +34,12 @@ final class TestSymfonyStaticDumperKernel extends Kernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/test_symfony_static_dumper_kernel_cache';
+        return realpath(sys_get_temp_dir()) . '/test_symfony_static_dumper_kernel_cache';
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/test_symfony_static_dumper_kernel_log';
+        return realpath(sys_get_temp_dir()) . '/test_symfony_static_dumper_kernel_log';
     }
 
     protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void

--- a/packages/symplify-kernel/src/HttpKernel/AbstractSymplifyKernel.php
+++ b/packages/symplify-kernel/src/HttpKernel/AbstractSymplifyKernel.php
@@ -21,12 +21,12 @@ abstract class AbstractSymplifyKernel extends Kernel implements ExtraConfigAware
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/' . $this->getUniqueKernelHash();
+        return realpath(sys_get_temp_dir()) . '/' . $this->getUniqueKernelHash();
     }
 
     public function getLogDir(): string
     {
-        return sys_get_temp_dir() . '/' . $this->getUniqueKernelHash() . '_log';
+        return realpath(sys_get_temp_dir()) . '/' . $this->getUniqueKernelHash() . '_log';
     }
 
     /**


### PR DESCRIPTION
To handle different result on MacOS which /private/var pointed to '/var` like the following:

```
--- Expected
+++ Actual
@@ @@
-'/var/folders/dv/m3gvpzh94t59l94qz3w2dgfr0000gn/T/_temp_fixture_easy_testing/SomeClassTranslation.php'
+'/private/var/folders/dv/m3gvpzh94t59l94qz3w2dgfr0000gn/T/_temp_fixture_easy_testing/SomeClassTranslation.php'
```

like described in https://github.com/rectorphp/rector-src/pull/127