### PR TITLE
[ECS] Whitelist ContainerConfigurator on scoper config

### DIFF
--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -25,6 +25,9 @@ $timestamp = (new DateTime('now'))->format('Ymd');
 return [
     'prefix' => 'ECSPrefix' . $timestamp,
     'files-whitelist' => [
+        // part of public interface of configs.php
+        'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
+
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',

--- a/packages/phpstan-rules/src/Rules/ForbiddenArrayWithStringKeysRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenArrayWithStringKeysRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
+use JsonSerializable;
 use Nette\Utils\Strings;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
@@ -203,7 +204,7 @@ CODE_SAMPLE
         // allow for array
         if ($this->reflectionProvider->hasClass($className)) {
             $classReflection = $this->reflectionProvider->getClass($className);
-            if ($classReflection->implementsInterface('JsonSerializable')) {
+            if ($classReflection->implementsInterface(JsonSerializable::class)) {
                 return true;
             }
         }


### PR DESCRIPTION
Handle error:

```bash
 [ERROR] Class                                                                  
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator' not found 
```

The `Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator` need to be registered to whitelist.

Ref: 

https://github.com/rectorphp/rector-src/blob/8151fd8cb11ae8a545043ef5e32cdff53bf8551e/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php#L13-L14