### PR TITLE
ParamReturnAndVarTagMalformsFixer: added support for psalm/phpstan prefixed phpdocs

### DIFF
--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -41,7 +41,7 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
 
     /**
      * @var string
-     * @see https://regex101.com/r/8iqNuR/1
+     * @see https://regex101.com/r/Nlxkd9/1
      */
     private const TYPE_ANNOTATION_REGEX = '#@(psalm-|phpstan-)?(param|return|var)#';
 

--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -43,7 +43,7 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
      * @var string
      * @see https://regex101.com/r/8iqNuR/1
      */
-    private const TYPE_ANNOTATION_REGEX = '#@(param|return|var)#';
+    private const TYPE_ANNOTATION_REGEX = '#@(psalm-|phpstan-)?(param|return|var)#';
 
     /**
      * @param MalformWorkerInterface[] $malformWorkers

--- a/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/InlineVarMalformWorker.php
+++ b/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/InlineVarMalformWorker.php
@@ -13,9 +13,9 @@ final class InlineVarMalformWorker implements MalformWorkerInterface
 {
     /**
      * @var string
-     * @see https://regex101.com/r/8OuO60/1
+     * @see https://regex101.com/r/cj95e6/1
      */
-    private const SINGLE_ASTERISK_START_REGEX = '#^/\*(\n?\s+@var)#';
+    private const SINGLE_ASTERISK_START_REGEX = '#^/\*(\n?\s+@(?:psalm-|phpstan-)?var)#';
 
     /**
      * @param Tokens<Token> $tokens

--- a/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/InlineVariableDocBlockMalformWorker.php
+++ b/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/InlineVariableDocBlockMalformWorker.php
@@ -16,7 +16,7 @@ final class InlineVariableDocBlockMalformWorker implements MalformWorkerInterfac
      * @var string
      * @see https://regex101.com/r/GkyV1C/1
      */
-    private const SINGLE_ASTERISK_START_REGEX = '#^/\*\s+\*(\s+@var)#';
+    private const SINGLE_ASTERISK_START_REGEX = '#^/\*\s+\*(\s+@(?:psalm-|phpstan-)?var)#';
 
     /**
      * @var string

--- a/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/MissingVarNameMalformWorker.php
+++ b/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/MissingVarNameMalformWorker.php
@@ -13,9 +13,9 @@ final class MissingVarNameMalformWorker implements MalformWorkerInterface
 {
     /**
      * @var string
-     * @see https://regex101.com/r/QtWnWv/3
+     * @see https://regex101.com/r/s1UkZs/1
      */
-    private const VAR_WITHOUT_NAME_REGEX = '#^(?<open>\/\*\* @var )(?<type>[\\\\\w\|]+)(?<close>\s+\*\/)$#';
+    private const VAR_WITHOUT_NAME_REGEX = '#^(?<open>\/\*\* @(?:psalm-|phpstan-)?var )(?<type>[\\\\\w\|-|]+)(?<close>\s+\*\/)$#';
 
     /**
      * @param Tokens<Token> $tokens

--- a/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/SuperfluousReturnNameMalformWorker.php
+++ b/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/SuperfluousReturnNameMalformWorker.php
@@ -14,9 +14,9 @@ final class SuperfluousReturnNameMalformWorker implements MalformWorkerInterface
 {
     /**
      * @var string
-     * @see https://regex101.com/r/26Wy7Y/1
+     * @see https://regex101.com/r/4qyd2j/1
      */
-    private const RETURN_VARIABLE_NAME_REGEX = '#(?<tag>@return)(?<type>\s+[|\\\\\w]+)?(\s+)(?<' . self::VARIABLE_NAME_PART . '>\$[\w]+)#';
+    private const RETURN_VARIABLE_NAME_REGEX = '#(?<tag>@(?:psalm-|phpstan-)?return)(?<type>\s+[|\\\\\w]+)?(\s+)(?<' . self::VARIABLE_NAME_PART . '>\$[\w]+)#';
 
     /**
      * @var string[]

--- a/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/SuperfluousVarNameMalformWorker.php
+++ b/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/SuperfluousVarNameMalformWorker.php
@@ -20,9 +20,9 @@ final class SuperfluousVarNameMalformWorker implements MalformWorkerInterface
 
     /**
      * @var string
-     * @see https://regex101.com/r/8LCnOl/1
+     * @see https://regex101.com/r/6XuSGV/1
      */
-    private const VAR_VARIABLE_NAME_REGEX = '#(?<tag>@var)(?<type>\s+[|\\\\\w]+)?(\s+)(?<propertyName>\$[\w]+)#';
+    private const VAR_VARIABLE_NAME_REGEX = '#(?<tag>@(?:psalm-|phpstan-)?var)(?<type>\s+[|\\\\\w]+)?(\s+)(?<propertyName>\$[\w]+)#';
 
     /**
      * @param Tokens<Token> $tokens

--- a/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/SwitchedTypeAndNameMalformWorker.php
+++ b/packages/coding-standard/src/TokenRunner/DocBlock/MalformWorker/SwitchedTypeAndNameMalformWorker.php
@@ -16,7 +16,7 @@ final class SwitchedTypeAndNameMalformWorker implements MalformWorkerInterface
      * @var string
      * @see https://regex101.com/r/4us32A/1
      */
-    private const NAME_THEN_TYPE_REGEX = '#@(param|var)(\s+)(?<name>\$\w+)(\s+)(?<type>[|\\\\\w\[\]]+)#';
+    private const NAME_THEN_TYPE_REGEX = '#@((?:psalm-|phpstan-)?(?:param|var))(\s+)(?<name>\$\w+)(\s+)(?<type>[|\\\\\w\[\]]+)#';
 
     /**
      * @param Tokens<Token> $tokens

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/inlined_var_above.php.inc
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/inlined_var_above.php.inc
@@ -4,6 +4,10 @@ function someFunction()
 {
     /** @var int */
     $value = 1000;
+    /** @phpstan-var int */
+    $value1 = 1000;
+    /** @psalm-var int */
+    $value2 = 1000;
 }
 
 ?>
@@ -14,6 +18,10 @@ function someFunction()
 {
     /** @var int $value */
     $value = 1000;
+    /** @phpstan-var int $value1 */
+    $value1 = 1000;
+    /** @psalm-var int $value2 */
+    $value2 = 1000;
 }
 
 ?>

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong5.php.inc
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong5.php.inc
@@ -3,6 +3,9 @@
 /* @var int $variable */
 $variable = 5;
 
+/* @phpstan-var list<array{0: string}> $variable */
+$variable = array(array('hello'));
+
 /** @var $variable int */
 $variable = 5;
 
@@ -22,6 +25,9 @@ $variable = 5;
 
 /** @var int $variable */
 $variable = 5;
+
+/** @phpstan-var list<array{0: string}> $variable */
+$variable = array(array('hello'));
 
 /** @var int $variable */
 $variable = 5;

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong5.php.inc
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong5.php.inc
@@ -19,6 +19,11 @@ $variable = 5;
  */
 $variable = 5;
 
+/*
+ * @phpstan-var $variable int
+ */
+$variable = 5;
+
 ?>
 -----
 <?php
@@ -36,6 +41,9 @@ $variable = 5;
 $variable = 5;
 
 /** @var int $variable */
+$variable = 5;
+
+/** @phpstan-var int $variable */
 $variable = 5;
 
 ?>

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong7.php.inc
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong7.php.inc
@@ -8,6 +8,13 @@ function function1(): int
 }
 
 /**
+ * @phpstan-return int $value
+ */
+function function1(): int
+{
+}
+
+/**
  * @return int $value This is the value
  */
 function function2(): int
@@ -48,6 +55,13 @@ function returnValuesDescription()
 
 /**
  * @return int
+ */
+function function1(): int
+{
+}
+
+/**
+ * @phpstan-return int
  */
 function function1(): int
 {

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong8.php.inc
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/wrong8.php.inc
@@ -8,6 +8,11 @@ class SomeClass
     private $property;
 
     /**
+     * @phpstan-var string $prefixedProperty
+     */
+    private $prefixedProperty;
+
+    /**
      * @var $anotherProperty \PhpMyAdmin\SqlParser\Statements\CreateStatement
      */
     private $anotherProperty;
@@ -31,6 +36,11 @@ class SomeClass
      * @var string
      */
     private $property;
+
+    /**
+     * @phpstan-var string
+     */
+    private $prefixedProperty;
 
     /**
      * @var \PhpMyAdmin\SqlParser\Statements\CreateStatement


### PR DESCRIPTION
closes https://github.com/symplify/symplify/issues/3295