### PR TITLE
PreventDuplicateClassMethodRule: fix minimum line count example in docs

### DIFF
--- a/packages/phpstan-rules/src/Rules/PreventDuplicateClassMethodRule.php
+++ b/packages/phpstan-rules/src/Rules/PreventDuplicateClassMethodRule.php
@@ -133,7 +133,7 @@ class SomeClass
 CODE_SAMPLE
         ,
                 [
-                    'minimumLineCount' => 1,
+                    'minimumLineCount' => 3,
                 ]
             ),
         ]);


### PR DESCRIPTION
when using this rule as suggested in the docs, you run into strange errors. propagate a better default in the docs, so people like me don't fall into this trap

before this PR:

![grafik](https://user-images.githubusercontent.com/120441/122873821-88b01a00-d332-11eb-83ba-fc212858a2d5.png)


closes https://github.com/symplify/symplify/issues/3259