### PR TITLE
[PhpConfigPrinter] Suppress errors when resolving deprecated constants

### DIFF
--- a/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
@@ -44,7 +44,8 @@ final class ConstantNodeFactory
         $definedConstants = get_defined_constants();
 
         foreach (array_keys($definedConstants) as $constantName) {
-            if ($value !== constant($constantName)) {
+            $constantValue = $this->getConstantValueIgnoringDeprecationWarnings($constantName);
+            if ($value !== $constantValue) {
                 continue;
             }
 
@@ -59,5 +60,16 @@ final class ConstantNodeFactory
         }
 
         return null;
+    }
+
+    private function getConstantValueIgnoringDeprecationWarnings(string $constant) : mixed
+    {
+        $previousLevel = error_reporting(E_ALL & ~E_DEPRECATED);
+
+        $value = constant($constant);
+
+        error_reporting($previousLevel);
+
+        return $value;
     }
 }

--- a/packages/php-config-printer/tests/NodeFactory/ConstantNodeFactoryTest.php
+++ b/packages/php-config-printer/tests/NodeFactory/ConstantNodeFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PhpConfigPrinter\Tests\NodeFactory;
+
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\TestCase;
+use Symplify\ConfigTransformer\Provider\YamlContentProvider;
+use Symplify\PhpConfigPrinter\NodeFactory\ConstantNodeFactory;
+
+final class ConstantNodeFactoryTest extends TestCase
+{
+    private ConstantNodeFactory $constantNodeFactory;
+    private YamlContentProvider $yamlContentProvider;
+
+    protected function setUp() : void
+    {
+        $this->yamlContentProvider = new YamlContentProvider();
+        $this->constantNodeFactory = new ConstantNodeFactory($this->yamlContentProvider);
+    }
+
+    public function testThatDeprecatedPHPConstantExists() : void
+    {
+        $previousLevel = error_reporting(E_ALL & ~E_DEPRECATED);
+
+        $value = constant('PGSQL_LIBPQ_VERSION_STR');
+
+        $this->assertNotEmpty($value);
+
+        error_reporting($previousLevel);
+    }
+
+    public function testConstantFetchNode() : void
+    {
+        $this->yamlContentProvider->setContent(
+            <<<YAML
+            services:
+                My\Service:
+                    arguments:
+                        - !php/const PHP_VERSION
+            YAML
+        );
+
+        $previousLevel = error_reporting(E_ALL);
+
+        $result = $this->constantNodeFactory->createConstantIfValue(PHP_VERSION);
+
+        $this->assertEquals($result, new ConstFetch(new Name('PHP_VERSION')));
+
+        error_reporting($previousLevel);
+    }
+}


### PR DESCRIPTION
When running PHP 8 with `pdo_pgsql` installed a lot of deprecations are reported:

```
Deprecated: Constant PGSQL_LIBPQ_VERSION_STR is deprecated in /Volumes/CS/www/website/vendor/symplify/php-config-printer/src/NodeFactory/ConstantNodeFactory.php on line 52
PHP Deprecated:  Constant PGSQL_LIBPQ_VERSION_STR is deprecated in /Volumes/CS/www/website/vendor/symplify/php-config-printer/src/NodeFactory/ConstantNodeFactory.php on line 52
```