### PR TITLE
[PhpConfigTransformer] Support service `bind` (same as `arguments`)

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/FixtureSymfony51/services_bind.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/FixtureSymfony51/services_bind.yaml
@@ -1,0 +1,20 @@
+services:
+    App\Controller\SomeController:
+        bind:
+            $config: '@some.service.config'
+            $endpoint: '@some.service.endpoint'
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set('App\Controller\SomeController')
+        ->bind('$config', service('some.service.config'))
+        ->bind('$endpoint', service('some.service.endpoint'));
+};

--- a/packages/php-config-printer/src/ServiceOptionConverter/BindAutowireAutoconfigureServiceOptionKeyYamlToPhpFactory.php
+++ b/packages/php-config-printer/src/ServiceOptionConverter/BindAutowireAutoconfigureServiceOptionKeyYamlToPhpFactory.php
@@ -7,14 +7,18 @@ namespace Symplify\PhpConfigPrinter\ServiceOptionConverter;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use Symplify\PhpConfigPrinter\Contract\Converter\ServiceOptionsKeyYamlToPhpFactoryInterface;
+use Symplify\PhpConfigPrinter\NodeFactory\ArgsNodeFactory;
 use Symplify\PhpConfigPrinter\NodeFactory\CommonNodeFactory;
+use Symplify\PhpConfigPrinter\ServiceOptionAnalyzer\ServiceOptionAnalyzer;
 use Symplify\PhpConfigPrinter\ValueObject\YamlKey;
 use Symplify\PhpConfigPrinter\ValueObject\YamlServiceKey;
 
 final class BindAutowireAutoconfigureServiceOptionKeyYamlToPhpFactory implements ServiceOptionsKeyYamlToPhpFactoryInterface
 {
     public function __construct(
-        private CommonNodeFactory $commonNodeFactory
+        private CommonNodeFactory $commonNodeFactory,
+        private ArgsNodeFactory $argsNodeFactory,
+        private ServiceOptionAnalyzer $serviceOptionAnalyzer
     ) {
     }
 
@@ -25,9 +29,22 @@ final class BindAutowireAutoconfigureServiceOptionKeyYamlToPhpFactory implements
             $method = 'share';
         }
 
-        $methodCall = new MethodCall($methodCall, $method);
         if ($yaml === false) {
+            $methodCall = new MethodCall($methodCall, $method);
             $methodCall->args[] = new Arg($this->commonNodeFactory->createFalse());
+
+            return $methodCall;
+        }
+
+        if (! $this->serviceOptionAnalyzer->hasNamedArguments($yaml)) {
+            $args = $this->argsNodeFactory->createFromValuesAndWrapInArray($yaml);
+            return new MethodCall($methodCall, 'bind', $args);
+        }
+
+        foreach ($yaml as $key => $value) {
+            $args = $this->argsNodeFactory->createFromValues([$key, $value], false, true);
+
+            $methodCall = new MethodCall($methodCall, 'bind', $args);
         }
 
         return $methodCall;


### PR DESCRIPTION
Before, it would only add an empty `bind()` call.