### PR TITLE
[PhpConfigPrinter] Properly import function calls

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/XmlToPhp/Fixture/some.xml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/XmlToPhp/Fixture/some.xml
@@ -24,8 +24,8 @@
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\MimeTypes;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/reference.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/reference.yaml
@@ -12,10 +12,10 @@ services:
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\ExistingClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\ThirdFakeClass;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_arguments.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_arguments.yaml
@@ -29,11 +29,11 @@ services:
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\expr;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\ThirdFakeClass;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\expr;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_calls.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_calls.yaml
@@ -14,8 +14,8 @@ services:
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_configurator.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_configurator.yaml
@@ -10,9 +10,9 @@ services:
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_factory.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_factory.yaml
@@ -16,9 +16,9 @@ services:
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\ref;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();

--- a/packages/php-config-printer/config/config.php
+++ b/packages/php-config-printer/config/config.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PhpParser\BuilderFactory;
 use PhpParser\NodeFinder;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Yaml\Parser;
@@ -20,11 +21,17 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autoconfigure();
 
     $services->load('Symplify\PhpConfigPrinter\\', __DIR__ . '/../src')
-        ->exclude([__DIR__ . '/../src/HttpKernel', __DIR__ . '/../src/Dummy', __DIR__ . '/../src/Bundle']);
+        ->exclude([
+            __DIR__ . '/../src/HttpKernel',
+            __DIR__ . '/../src/Dummy',
+            __DIR__ . '/../src/Bundle',
+            __DIR__ . '/../src/ValueObject/FullyQualifiedImport.php',
+        ]);
 
     $services->set(NodeFinder::class);
     $services->set(Parser::class);
     $services->set(BuilderFactory::class);
+    $services->set(ParentConnectingVisitor::class);
 
     $services->set(ParameterProvider::class)
         ->args([service(ContainerInterface::class)]);

--- a/packages/php-config-printer/src/Sorter/FullyQualifiedImportSorter.php
+++ b/packages/php-config-printer/src/Sorter/FullyQualifiedImportSorter.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PhpConfigPrinter\Sorter;
+
+use Symplify\PhpConfigPrinter\ValueObject\FullyQualifiedImport;
+use Symplify\PhpConfigPrinter\ValueObject\ImportType;
+
+final class FullyQualifiedImportSorter
+{
+    /**
+     * @var array<string, int>
+     */
+    private const TYPE_ORDER = [
+        ImportType::CLASS_TYPE => 0,
+        ImportType::CONSTANT_TYPE => 1,
+        ImportType::FUNCTION_TYPE => 2,
+    ];
+
+    /**
+     * @param FullyQualifiedImport[] $imports
+     *
+     * @return FullyQualifiedImport[]
+     */
+    public function sortImports(array $imports): array
+    {
+        $sortByFullQualifiedCallback = static fn ($left, $right): int => strcmp(
+            $left->getFullyQualified(),
+            $right->getFullyQualified()
+        );
+        usort($imports, $sortByFullQualifiedCallback);
+
+        $sortByTypeCallback = static fn ($left, $right): int => self::TYPE_ORDER[$left->getType()] <=> self::TYPE_ORDER[$right->getType()];
+        usort($imports, $sortByTypeCallback);
+
+        return $imports;
+    }
+}

--- a/packages/php-config-printer/src/ValueObject/AttributeKey.php
+++ b/packages/php-config-printer/src/ValueObject/AttributeKey.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PhpConfigPrinter\ValueObject;
+
+final class AttributeKey
+{
+    /**
+     * Convention key name in php-parser and PHPStan for parent node
+     *
+     * @var string
+     */
+    public const PARENT = 'parent';
+}

--- a/packages/php-config-printer/src/ValueObject/FullyQualifiedImport.php
+++ b/packages/php-config-printer/src/ValueObject/FullyQualifiedImport.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PhpConfigPrinter\ValueObject;
+
+final class FullyQualifiedImport
+{
+    public function __construct(
+        private string $type,
+        private string $fullyQualified,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        return $this->fullyQualified;
+    }
+
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+
+    public function getFullyQualified(): string
+    {
+        return $this->fullyQualified;
+    }
+}

--- a/packages/php-config-printer/src/ValueObject/ImportType.php
+++ b/packages/php-config-printer/src/ValueObject/ImportType.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PhpConfigPrinter\ValueObject;
+
+/**
+ * @enum
+ */
+final class ImportType
+{
+    /**
+     * @var string
+     */
+    public const CLASS_TYPE = 'normal';
+
+    /**
+     * @var string
+     */
+    public const FUNCTION_TYPE = 'function';
+
+    /**
+     * @var string
+     */
+    public const CONSTANT_TYPE = 'constant';
+}


### PR DESCRIPTION
I noticed that the `service` function would not be imported in my setup.

It would be imported as:
```php
use Symfony\Component\DependencyInjection\Loader\Configurator\service;
```
instead of
```php
use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
```

I checked the code, and it turns out that it's a bit naive. It has a special rule
for when the function is called `ref` (the old `service` function). In other cases
it imports it as function when the function exists.

Instead of doing this, why not use the nodes to know the context of the import?

The `ImportFullyQualifiedNamesNodeVisitor` keeps track of the context in where it finds a
`FullyQualified` node. When the `FullyQualified` node is used inside a `FuncCall` expression
it will import the FQCN as function.

@TomasVotruba What do you you think of this approach? 
Do you think it would be better if the `ImportFullyQualifiedNamesNodeTraverser` is split into: `ImportFullyQualifiedClassNamesNodeTraverser` and `ImportFullyQualifiedFunctionNamesNodeTraverser`?
And the same for `ImportFullyQualifiedNamesNodeVisitor` > `ImportFullyQualifiedClassNamesNodeVisitor` and `ImportFullyQualifiedFunctionNamesNodeVisitor`.