### PR TITLE
[PhpConfigPrinter] Keep original key when converting alias

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_alias.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_alias.yaml
@@ -3,6 +3,8 @@ services:
 
     Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass $variable: '@App\Fake\Class'
 
+    doctrine.dbal.read_connection: '@doctrine.dbal.read1_connection'
+
     fake.simple_class_two:
         public: false
         alias: Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass
@@ -22,6 +24,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->alias(FakeClass::class, 'fake.simple_class');
 
     $services->alias(SecondFakeClass::class . ' $variable', 'App\Fake\Class');
+
+    $services->alias('doctrine.dbal.read_connection', 'doctrine.dbal.read1_connection');
 
     $services->alias('fake.simple_class_two', SecondFakeClass::class)
         ->private()

--- a/packages/php-config-printer/src/CaseConverter/AliasCaseConverter.php
+++ b/packages/php-config-printer/src/CaseConverter/AliasCaseConverter.php
@@ -62,7 +62,7 @@ final class AliasCaseConverter implements CaseConverterInterface
         }
 
         if (is_string($values) && $values[0] === '@') {
-            $args = $this->argsNodeFactory->createFromValues([$values], true);
+            $args = $this->argsNodeFactory->createFromValues([$key, $values], true);
             $methodCall = new MethodCall($servicesVariable, MethodName::ALIAS, $args);
             return new Expression($methodCall);
         }


### PR DESCRIPTION
Before, it would convert:
```yaml
services:
    doctrine.dbal.read_connection: '@doctrine.dbal.read1_connection'
```
to this:
```php
    $services->alias('doctrine.dbal.read1_connection');
```
instead of
```php
    $services->alias('doctrine.dbal.read_connection', 'doctrine.dbal.read1_connection');
```