### PR TITLE
ForbiddenFuncCallRule: add support for additional custom errors

### DIFF
--- a/packages/phpstan-rules/config/services/services.neon
+++ b/packages/phpstan-rules/config/services/services.neon
@@ -91,6 +91,8 @@ services:
     - Symplify\PHPStanRules\TypeResolver\NullableTypeResolver
     - Symplify\PHPStanRules\NodeAnalyzer\AttributeFinder
 
+    - Symplify\PHPStanRules\Forbidden\ForbiddenCallable
+
     # regex
     - Symplify\PHPStanRules\NodeAnalyzer\RegexFuncCallAnalyzer
     - Symplify\PHPStanRules\NodeAnalyzer\RegexStaticCallAnalyzer

--- a/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
+++ b/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
@@ -33,4 +33,61 @@ final class ForbiddenCallable {
         }
         return sprintf($errorMessage, $funcName);
     }
+
+    /**
+     * @param string[]|array<string, string>|list<array<string, string>> $forbiddenFunctions
+     *
+     * @return array<string, string|null> forbidden functions as keys, optional additional messages as values
+     */
+    public function normalizeConfig($forbiddenFunctions): array {
+        $forbidden = [];
+        foreach($forbiddenFunctions as $key => $value) {
+            if (is_int($key)) {
+                if (is_array($value)) {
+                    /**
+                     * config-format:
+                     *
+                     * forbiddenFunctions:
+                     * - 'extract': 'you shouldn"t use this dynamic things'
+                     * - 'dump': 'seems you missed some debugging function'
+                     */
+
+                    $aKey = array_key_first($value);
+                    $aVal = $value[$aKey];
+
+                    if ($aVal === '') {
+                        $forbidden[$aKey] = null;
+                    } else {
+                        $forbidden[$aKey] = $aVal;
+                    }
+                } else {
+                    /**
+                     * config-format:
+                     *
+                     * forbiddenFunctions:
+                     * - 'extract'
+                     * - 'dump'
+                     */
+
+                    $forbidden[$value] = null;
+                }
+            } elseif (is_string($key)) {
+                /**
+                 * config-format:
+                 *
+                 * forbiddenFunctions:
+                 *   'extract': 'you shouldn"t use this dynamic things'
+                 *   'dump': 'seems you missed some debugging function'
+                 */
+
+                if ($value === '') {
+                    $forbidden[$key] = null;
+                } else {
+                    $forbidden[$key] = $value;
+                }
+            }
+        }
+
+        return $forbidden;
+    }
 }

--- a/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
+++ b/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
@@ -42,6 +42,9 @@ final class ForbiddenCallable {
     public function normalizeConfig($forbiddenFunctions): array {
         $forbidden = [];
         foreach($forbiddenFunctions as $key => $value) {
+            $funcName = null;
+            $additionalMessage = null;
+
             if (is_int($key)) {
                 if (is_array($value)) {
                     /**
@@ -52,14 +55,8 @@ final class ForbiddenCallable {
                      * - 'dump': 'seems you missed some debugging function'
                      */
 
-                    $aKey = array_key_first($value);
-                    $aVal = $value[$aKey];
-
-                    if ($aVal === '') {
-                        $forbidden[$aKey] = null;
-                    } else {
-                        $forbidden[$aKey] = $aVal;
-                    }
+                    $funcName = array_key_first($value);
+                    $additionalMessage = $value[$funcName];
                 } else {
                     /**
                      * config-format:
@@ -69,7 +66,8 @@ final class ForbiddenCallable {
                      * - 'dump'
                      */
 
-                    $forbidden[$value] = null;
+                    $funcName = $value;
+                    $additionalMessage = null;
                 }
             } elseif (is_string($key)) {
                 /**
@@ -80,11 +78,18 @@ final class ForbiddenCallable {
                  *   'dump': 'seems you missed some debugging function'
                  */
 
-                if ($value === '') {
-                    $forbidden[$key] = null;
-                } else {
-                    $forbidden[$key] = $value;
-                }
+                $funcName = $key;
+                $additionalMessage = $value;
+            }
+
+            if ($funcName === null) {
+                continue;
+            }
+
+            if ($additionalMessage === '') {
+                $forbidden[$funcName] = null;
+            } else {
+                $forbidden[$funcName] = $additionalMessage;
             }
         }
 

--- a/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
+++ b/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Forbidden;
+
+use Symplify\PackageBuilder\Matcher\ArrayStringAndFnMatcher;
+
+final class ForbiddenCallable {
+    /**
+     * @param string[]|array<string, string> $forbiddenFunctions
+     */
+    public function __construct(
+        private ArrayStringAndFnMatcher $arrayStringAndFnMatcher,
+        private array $forbiddenFunctions
+   ) {
+   }
+
+    public function formatError(string $errorMessage, string $funcName): string {
+        foreach($this->getForbiddenFunctionsWithMessages() as $forbiddenFunction => $additionalMessage) {
+            if (!$additionalMessage) {
+                continue;
+            }
+
+            if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFunction])) {
+                continue;
+            }
+
+            return sprintf($errorMessage .': '. $additionalMessage, $funcName);
+        }
+        return sprintf($errorMessage, $funcName);
+    }
+}

--- a/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
+++ b/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
@@ -15,7 +15,7 @@ final class ForbiddenCallable {
     /**
      * @param string $errorMessage
      * @param string $funcName
-     * @return array<string, string|null> $forbiddenFunctions
+     * @param array<string, string|null> $forbiddenFunctions
      *
      * @return string
      */

--- a/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
+++ b/packages/phpstan-rules/src/Forbidden/ForbiddenCallable.php
@@ -7,17 +7,20 @@ namespace Symplify\PHPStanRules\Forbidden;
 use Symplify\PackageBuilder\Matcher\ArrayStringAndFnMatcher;
 
 final class ForbiddenCallable {
-    /**
-     * @param string[]|array<string, string> $forbiddenFunctions
-     */
-    public function __construct(
-        private ArrayStringAndFnMatcher $arrayStringAndFnMatcher,
-        private array $forbiddenFunctions
+   public function __construct(
+        private ArrayStringAndFnMatcher $arrayStringAndFnMatcher
    ) {
    }
 
-    public function formatError(string $errorMessage, string $funcName): string {
-        foreach($this->getForbiddenFunctionsWithMessages() as $forbiddenFunction => $additionalMessage) {
+    /**
+     * @param string $errorMessage
+     * @param string $funcName
+     * @return array<string, string|null> $forbiddenFunctions
+     *
+     * @return string
+     */
+    public function formatError(string $errorMessage, string $funcName, array $forbiddenFunctions): string {
+        foreach($forbiddenFunctions as $forbiddenFunction => $additionalMessage) {
             if (!$additionalMessage) {
                 continue;
             }

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -89,6 +89,25 @@ CODE_SAMPLE
                     'forbiddenFunctions' => ['eval'],
                 ]
             ),
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    return eval('...');
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    return echo '...';
+}
+CODE_SAMPLE
+            ,
+                [
+                    'forbiddenFunctions' => ['dump' => 'seems you missed some debugging function'],
+                ]
+            ),
         ]);
     }
 

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -138,8 +138,6 @@ CODE_SAMPLE
                  */
 
                 $forbidden[] = array_key_first($forbiddenFunction);
-            } else {
-                throw new \RuntimeException('forbiddenFunctions can either be defined as a list of strings, or a list of string-mappings.');
             }
         }
         return $forbidden;

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -10,6 +10,7 @@ use PHPStan\Analyser\Scope;
 use SimpleXMLElement;
 use Symplify\Astral\Naming\SimpleNameResolver;
 use Symplify\PackageBuilder\Matcher\ArrayStringAndFnMatcher;
+use Symplify\PHPStanRules\Forbidden\ForbiddenCallable;
 use Symplify\PHPStanRules\TypeAnalyzer\ObjectTypeAnalyzer;
 use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
@@ -32,7 +33,8 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
         private ArrayStringAndFnMatcher $arrayStringAndFnMatcher,
         private SimpleNameResolver $simpleNameResolver,
         private ObjectTypeAnalyzer $objectTypeAnalyzer,
-        private array $forbiddenFunctions
+        private array $forbiddenFunctions,
+        private ForbiddenCallable $forbiddenCallable
     ) {
     }
 
@@ -64,7 +66,7 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
             return [];
         }
 
-        return [$this->formatError($funcName)];
+        return [$this->forbiddenCallable->formatError(self::ERROR_MESSAGE, $funcName)];
     }
 
     public function getRuleDefinition(): RuleDefinition
@@ -110,21 +112,6 @@ CODE_SAMPLE
                 ]
             ),
         ]);
-    }
-
-    private function formatError(string $funcName): string {
-        foreach($this->getForbiddenFunctionsWithMessages() as $forbiddenFunction => $additionalMessage) {
-            if (!$additionalMessage) {
-                continue;
-            }
-
-            if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFunction])) {
-                continue;
-            }
-
-            return sprintf(self::ERROR_MESSAGE .': '. $additionalMessage, $funcName);
-        }
-        return sprintf(self::ERROR_MESSAGE, $funcName);
     }
 
     /**

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -66,7 +66,7 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
             return [];
         }
 
-        return [$this->forbiddenCallable->formatError(self::ERROR_MESSAGE, $funcName)];
+        return [$this->forbiddenCallable->formatError(self::ERROR_MESSAGE, $funcName, $this->getForbiddenFunctionsWithMessages())];
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -121,8 +121,8 @@ CODE_SAMPLE
      */
     private function getForbiddenFunctionsWithMessages() {
         $forbidden = [];
-        foreach($this->forbiddenFunctions as $forbiddenFunction) {
-            if (is_string($forbiddenFunction)) {
+        foreach($this->forbiddenFunctions as $key => $value) {
+            if (is_int($key)) {
                 /**
                  * config-format:
                  *
@@ -131,8 +131,8 @@ CODE_SAMPLE
                  * - 'dump'
                  */
 
-                $forbidden[$forbiddenFunction] = null;
-            } elseif (is_array($forbiddenFunction) && count($forbiddenFunction) > 0) {
+                $forbidden[$value] = null;
+            } elseif (is_string($key)) {
                 /**
                  * config-format:
                  *
@@ -141,12 +141,10 @@ CODE_SAMPLE
                  * - 'dump': 'seems you missed some debugging function'
                  */
 
-                $funcName = array_key_first($forbiddenFunction);
-
-                if ($forbiddenFunction[$funcName] === '') {
-                    $forbidden[$funcName] = null;
+                if ($value === '') {
+                    $forbidden[$key] = null;
                 } else {
-                    $forbidden[$funcName] = $forbiddenFunction[$funcName];
+                    $forbidden[$key] = $value;
                 }
             }
         }

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -93,14 +93,15 @@ CODE_SAMPLE
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-    return eval('...');
+    dump('hello world');
+    return true;
 }
 CODE_SAMPLE
                 ,
                 <<<'CODE_SAMPLE'
 class SomeClass
 {
-    return echo '...';
+    return true;
 }
 CODE_SAMPLE
             ,

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -134,7 +134,7 @@ CODE_SAMPLE
                  *
                  * forbiddenFunctions:
                  * - 'extract': 'you shouldn"t use this dynamic things'
-                 * - 'dump': 'seems you missed some debugging function'                 *
+                 * - 'dump': 'seems you missed some debugging function'
                  */
 
                 $forbidden[] = array_key_first($forbiddenFunction);

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
 
     private function formatError(string $funcName): string {
         foreach($this->forbiddenFunctions as $forbiddenFunction) {
-            if (is_array($forbiddenFunction)) {
+            if (is_array($forbiddenFunction) && count(forbiddenFunction) > 0) {
                 $forbiddenFuncName = array_key_first($forbiddenFunction);
 
                 if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFuncName])) {
@@ -128,7 +128,7 @@ CODE_SAMPLE
                  */
 
                 $forbidden[] = $forbiddenFunction;
-            } elseif (is_array($forbiddenFunction)) {
+            } elseif (is_array($forbiddenFunction) && count(forbiddenFunction) > 0) {
                 /**
                  * config-format:
                  *

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -55,7 +55,8 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
             return [];
         }
 
-        if (! $this->arrayStringAndFnMatcher->isMatch($funcName, array_keys($this->getForbiddenFunctionsWithMessages()))) {
+        $forbiddenFunctions = array_keys($this->getForbiddenFunctionsWithMessages());
+        if (! $this->arrayStringAndFnMatcher->isMatch($funcName, $forbiddenFunctions)) {
             return [];
         }
 
@@ -114,13 +115,15 @@ CODE_SAMPLE
 
     private function formatError(string $funcName): string {
         foreach($this->getForbiddenFunctionsWithMessages() as $forbiddenFunction => $additionalMessage) {
-            if ($additionalMessage) {
-                if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFunction])) {
-                    continue;
-                }
-
-                return sprintf(self::ERROR_MESSAGE .': '. $additionalMessage, $funcName);
+            if (!$additionalMessage) {
+                continue;
             }
+
+            if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFunction])) {
+                continue;
+            }
+
+            return sprintf(self::ERROR_MESSAGE .': '. $additionalMessage, $funcName);
         }
         return sprintf(self::ERROR_MESSAGE, $funcName);
     }

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -55,8 +55,7 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
             return [];
         }
 
-        $forbiddenFunctions = array_keys($this->getForbiddenFunctionsWithMessages());
-        if (! $this->arrayStringAndFnMatcher->isMatch($funcName, $forbiddenFunctions)) {
+        if (! $this->arrayStringAndFnMatcher->isMatch($funcName, $this->getForbiddenFunctionsList())) {
             return [];
         }
 
@@ -126,6 +125,13 @@ CODE_SAMPLE
             return sprintf(self::ERROR_MESSAGE .': '. $additionalMessage, $funcName);
         }
         return sprintf(self::ERROR_MESSAGE, $funcName);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getForbiddenFunctionsList() {
+        return array_keys($this->getForbiddenFunctionsWithMessages());
     }
 
     /**

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -55,7 +55,7 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
             return [];
         }
 
-        if (! $this->arrayStringAndFnMatcher->isMatch($funcName, $this->getForbiddenFunctionsList())) {
+        if (! $this->arrayStringAndFnMatcher->isMatch($funcName, array_keys($this->getForbiddenFunctionsWithMessages()))) {
             return [];
         }
 
@@ -123,13 +123,6 @@ CODE_SAMPLE
             }
         }
         return sprintf(self::ERROR_MESSAGE, $funcName);
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function getForbiddenFunctionsList() {
-        return array_keys($this->getForbiddenFunctionsWithMessages());
     }
 
     /**

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -119,10 +119,6 @@ CODE_SAMPLE
                     continue;
                 }
 
-                if ($additionalMessage === null) {
-                    continue;
-                }
-
                 return sprintf(self::ERROR_MESSAGE .': '. $additionalMessage, $funcName);
             }
         }

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -26,7 +26,7 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
     public const ERROR_MESSAGE = 'Function "%s()" cannot be used/left in the code';
 
     /**
-     * @param string[]|list<array<string, string>> $forbiddenFunctions
+     * @param string[]|array<string, string> $forbiddenFunctions
      */
     public function __construct(
         private ArrayStringAndFnMatcher $arrayStringAndFnMatcher,

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -139,7 +139,7 @@ CODE_SAMPLE
 
                 $forbidden[] = array_key_first($forbiddenFunction);
             } else {
-                throw new \RuntimeException('forbiddenFunctions can either be defined as a list of strings, or a string-array keyed by string.');
+                throw new \RuntimeException('forbiddenFunctions can either be defined as a list of strings, or a list of string-mappings.');
             }
         }
         return $forbidden;

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -100,7 +100,7 @@ CODE_SAMPLE
                 if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFuncName])) {
                     continue;
                 }
-                
+
                 $configuredErrorMessage = $forbiddenFunction[$forbiddenFuncName];
                 if ($configuredErrorMessage === '') {
                     continue;

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -26,7 +26,7 @@ final class ForbiddenFuncCallRule extends AbstractSymplifyRule implements Config
     public const ERROR_MESSAGE = 'Function "%s()" cannot be used/left in the code';
 
     /**
-     * @param string[]|array<string, string> $forbiddenFunctions
+     * @param string[]|list<array<string, string>> $forbiddenFunctions
      */
     public function __construct(
         private ArrayStringAndFnMatcher $arrayStringAndFnMatcher,

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -94,7 +94,7 @@ CODE_SAMPLE
 
     private function formatError(string $funcName): string {
         foreach($this->forbiddenFunctions as $forbiddenFunction) {
-            if (is_array($forbiddenFunction) && count(forbiddenFunction) > 0) {
+            if (is_array($forbiddenFunction) && count($forbiddenFunction) > 0) {
                 $forbiddenFuncName = array_key_first($forbiddenFunction);
 
                 if (! $this->arrayStringAndFnMatcher->isMatch($funcName, [$forbiddenFuncName])) {
@@ -128,7 +128,7 @@ CODE_SAMPLE
                  */
 
                 $forbidden[] = $forbiddenFunction;
-            } elseif (is_array($forbiddenFunction) && count(forbiddenFunction) > 0) {
+            } elseif (is_array($forbiddenFunction) && count($forbiddenFunction) > 0) {
                 /**
                  * config-format:
                  *

--- a/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFuncCallRule.php
@@ -118,62 +118,15 @@ CODE_SAMPLE
     /**
      * @return list<string>
      */
-    private function getForbiddenFunctionsList() {
+    private function getForbiddenFunctionsList(): array {
         return array_keys($this->getForbiddenFunctionsWithMessages());
     }
 
     /**
      * @return array<string, string|null> forbidden functions as keys, optional additional messages as values
      */
-    private function getForbiddenFunctionsWithMessages() {
-        $forbidden = [];
-        foreach($this->forbiddenFunctions as $key => $value) {
-            if (is_int($key)) {
-                if (is_array($value)) {
-                    /**
-                     * config-format:
-                     *
-                     * forbiddenFunctions:
-                     * - 'extract': 'you shouldn"t use this dynamic things'
-                     * - 'dump': 'seems you missed some debugging function'
-                     */
-
-                    $aKey = array_key_first($value);
-                    $aVal = $value[$aKey];
-
-                    if ($aVal === '') {
-                        $forbidden[$aKey] = null;
-                    } else {
-                        $forbidden[$aKey] = $aVal;
-                    }
-                } else {
-                    /**
-                     * config-format:
-                     *
-                     * forbiddenFunctions:
-                     * - 'extract'
-                     * - 'dump'
-                     */
-
-                    $forbidden[$value] = null;
-                }
-            } elseif (is_string($key)) {
-                /**
-                 * config-format:
-                 *
-                 * forbiddenFunctions:
-                 *   'extract': 'you shouldn"t use this dynamic things'
-                 *   'dump': 'seems you missed some debugging function'
-                 */
-
-                if ($value === '') {
-                    $forbidden[$key] = null;
-                } else {
-                    $forbidden[$key] = $value;
-                }
-            }
-        }
-        return $forbidden;
+    private function getForbiddenFunctionsWithMessages(): array {
+        return $this->forbiddenCallable->normalizeConfig($this->forbiddenFunctions);
     }
 
     private function shouldAllowSpecialCase(FuncCall $funcCall, Scope $scope, string $functionName): bool

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithArrayDeprecationsTest.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithArrayDeprecationsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFuncCallRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule;
+
+/**
+ * @extends ForbiddenFuncCallRuleWithDeprecationsTest<ForbiddenFuncCallRule>
+ */
+final class ForbiddenFuncCallRuleWithArrayDeprecationsTest extends ForbiddenFuncCallRuleWithDeprecationsTest
+{
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(ForbiddenFuncCallRule::class, __DIR__ . '/config/configured_rule_with_array_deprecations.neon');
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithDeprecationsTest.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithDeprecationsTest.php
@@ -39,7 +39,7 @@ final class ForbiddenFuncCallRuleWithDeprecationsTest extends AbstractServiceAwa
         $errorMessage .= ': we use a proper http client these days';
         yield [__DIR__ . '/Fixture/CurlCall.php', [[$errorMessage, 11]]];
 
-        // custom error defined as null -> just prints the default message
+        // custom error defined as empty-string -> just prints the default message
         $errorMessage = sprintf(ForbiddenFuncCallRule::ERROR_MESSAGE, 'property_exists');
         yield [__DIR__ . '/Fixture/PropertyExists.php', [[$errorMessage, 11]]];
 

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithDeprecationsTest.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithDeprecationsTest.php
@@ -12,7 +12,7 @@ use Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule;
 /**
  * @extends AbstractServiceAwareRuleTestCase<ForbiddenFuncCallRule>
  */
-final class ForbiddenFuncCallRuleWithDeprecationsTest extends AbstractServiceAwareRuleTestCase
+class ForbiddenFuncCallRuleWithDeprecationsTest extends AbstractServiceAwareRuleTestCase
 {
     /**
      * @dataProvider provideData()
@@ -25,7 +25,7 @@ final class ForbiddenFuncCallRuleWithDeprecationsTest extends AbstractServiceAwa
 
     public function provideData(): Iterator
     {
-        // custom messages are defined in configured_rule_with_deprecations.neon
+        // custom messages are defined in the config file
 
         $errorMessage = sprintf(ForbiddenFuncCallRule::ERROR_MESSAGE, 'dump');
         $errorMessage .= ': seems you missed some debugging function';

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithDeprecationsTest.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/ForbiddenFuncCallRuleWithDeprecationsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFuncCallRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule;
+
+/**
+ * @extends AbstractServiceAwareRuleTestCase<ForbiddenFuncCallRule>
+ */
+final class ForbiddenFuncCallRuleWithDeprecationsTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @param array<string|int> $expectedErrorMessagesWithLines
+     */
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        // custom messages are defined in configured_rule_with_deprecations.neon
+
+        $errorMessage = sprintf(ForbiddenFuncCallRule::ERROR_MESSAGE, 'dump');
+        $errorMessage .= ': seems you missed some debugging function';
+        yield [__DIR__ . '/Fixture/DebugFuncCall.php', [[$errorMessage, 11]]];
+
+        $errorMessage = sprintf(ForbiddenFuncCallRule::ERROR_MESSAGE, 'extract');
+        $errorMessage .= ': you shouldn"t use this dynamic things';
+        yield [__DIR__ . '/Fixture/ExtractCall.php', [[$errorMessage, 11]]];
+
+        $errorMessage = sprintf(ForbiddenFuncCallRule::ERROR_MESSAGE, 'curl_init');
+        $errorMessage .= ': we use a proper http client these days';
+        yield [__DIR__ . '/Fixture/CurlCall.php', [[$errorMessage, 11]]];
+
+        // custom error defined as null -> just prints the default message
+        $errorMessage = sprintf(ForbiddenFuncCallRule::ERROR_MESSAGE, 'property_exists');
+        yield [__DIR__ . '/Fixture/PropertyExists.php', [[$errorMessage, 11]]];
+
+        yield [__DIR__ . '/Fixture/SkipPropertyExistsOnXml.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(ForbiddenFuncCallRule::class, __DIR__ . '/config/configured_rule_with_deprecations.neon');
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/config/configured_rule_with_array_deprecations.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/config/configured_rule_with_array_deprecations.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            forbiddenFunctions:
+                - 'extract': 'you shouldn"t use this dynamic things'
+                - 'dump': 'seems you missed some debugging function'
+                - 'curl_*': 'we use a proper http client these days'
+                - 'property_exists': ''

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/config/configured_rule_with_deprecations.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/config/configured_rule_with_deprecations.neon
@@ -1,0 +1,13 @@
+includes:
+    - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            forbiddenFunctions:
+                - 'extract': 'you shouldn"t use this dynamic things'
+                - 'dump': 'seems you missed some debugging function'
+                - 'curl_*': 'we use a proper http client these days'
+                - 'property_exists': ''

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/config/configured_rule_with_deprecations.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFuncCallRule/config/configured_rule_with_deprecations.neon
@@ -7,7 +7,7 @@ services:
         tags: [phpstan.rules.rule]
         arguments:
             forbiddenFunctions:
-                - 'extract': 'you shouldn"t use this dynamic things'
-                - 'dump': 'seems you missed some debugging function'
-                - 'curl_*': 'we use a proper http client these days'
-                - 'property_exists': ''
+                'extract': 'you shouldn"t use this dynamic things'
+                'dump': 'seems you missed some debugging function'
+                'curl_*': 'we use a proper http client these days'
+                'property_exists': ''


### PR DESCRIPTION
Adds support for adding custom additional error messages, useful to give more context what to use instead of a forbidden function.

example use:

```
services:
    -
        class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
        tags: [phpstan.rules.rule]
        arguments:
            forbiddenFunctions:
                - 'extract': 'you shouldn"t use this dynamic things'
                - 'dump': 'seems you missed some debugging function'
                - 'curl_*': 'we use a proper http client these days'
                - 'property_exists': ''
```

which produces errors like:

```
Function "curl_init()" cannot be used/left in the code: we use a proper http client these days
```