### PR TITLE
fix ecs composer-scripts on windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -203,10 +203,10 @@
         "symplify/vendor-patches": "9.3.26"
     },
     "scripts": {
-        "check-cs": "packages/easy-coding-standard/bin/ecs check --ansi",
+        "check-cs": "@php packages/easy-coding-standard/bin/ecs.php check --ansi",
         "fix-cs": [
-            "packages/easy-coding-standard/bin/ecs check --fix --ansi",
-            "packages/easy-coding-standard/bin/ecs check-markdown README.md packages/**/README.md --fix --ansi",
+            "@php packages/easy-coding-standard/bin/ecs.php check --fix --ansi",
+            "@php packages/easy-coding-standard/bin/ecs.php check-markdown README.md packages/**/README.md --fix --ansi",
             "bin/clear_readmes.sh"
         ],
         "phpstan": "vendor/bin/phpstan analyse --memory-limit=-1 --error-format symplify --ansi",


### PR DESCRIPTION
as is, the custom composer scripts cannot be used on windows.

stumlbed over this while I wannted to automatically cs-fix the content of https://github.com/symplify/symplify/pull/3348 with `composer csfix` but this did not work.

before this PR we run into the following error:
```
$ composer fix-cs  -vvv
Reading ./composer.json (C:\dvl\GitHub\symplify\composer.json)
Loading config file C:/Users/mstaab/AppData/Roaming/Composer/config.json
Loading config file C:/Users/mstaab/AppData/Roaming/Composer/auth.json
Loading config file ./composer.json (C:\dvl\GitHub\symplify\composer.json)
Checked CA file C:\Users\mstaab\AppData\Local\Temp\ope7F9B.tmp: valid
Executing command (C:\dvl\GitHub\symplify): git branch -a --no-color --no-abbrev -v
Reading C:/Users/mstaab/AppData/Roaming/Composer/composer.json (C:\Users\mstaab\AppData\Roaming\Composer\composer.json)
Loading config file C:/Users/mstaab/AppData/Roaming/Composer/config.json
Loading config file C:/Users/mstaab/AppData/Roaming/Composer/auth.json
Loading config file C:/Users/mstaab/AppData/Roaming/Composer/composer.json (C:\Users\mstaab\AppData\Roaming\Composer\composer.json)
Loading config file C:\Users\mstaab\AppData\Roaming\Composer/auth.json
Reading C:\Users\mstaab\AppData\Roaming\Composer/auth.json (C:\Users\mstaab\AppData\Roaming\Composer\auth.json)
Reading C:\dvl\GitHub\symplify/vendor/composer/installed.json (C:\dvl\GitHub\symplify\vendor\composer\installed.json)
Reading C:/Users/mstaab/AppData/Roaming/Composer/vendor/composer/installed.json (C:\Users\mstaab\AppData\Roaming\Composer\vendor\composer\installed.json)
Loading plugin PackageVersions\Installer (from composer/package-versions-deprecated)
Loading plugin cweagans\Composer\Patches (from cweagans/composer-patches)
Loading plugin Bamarni\Composer\Bin\Plugin (from bamarni/composer-bin-plugin, installed globally)
Running 2.1.3 (2021-06-09 16:31:20) with PHP 8.0.6 on Windows NT / 10.0
> fix-cs: packages/easy-coding-standard/bin/ecs check --fix --ansi
Executing command (CWD): packages\easy-coding-standard\bin\ecs check --fix --ansi
Der Befehl "packages\easy-coding-standard\bin\ecs" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.
Script packages/easy-coding-standard/bin/ecs check --fix --ansi handling the fix-cs event returned with error code 1
```

the localized error `Der Befehl "packages\easy-coding-standard\bin\ecs" ist entweder falsch geschrieben oder
konnte nicht gefunden werden.` means that the command could not be found
