### PR TITLE
[PhpConfigPrinter] Support `bind` + `arguments` on resource node

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/resource_arguments_and_bind.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/resource_arguments_and_bind.yaml
@@ -1,0 +1,23 @@
+services:
+  App\:
+    resource: '../src/*'
+    exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+    arguments:
+        $environment: '%kernel.environment%'
+    bind:
+        $debug: '%kernel.debug%'
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->load('App\\', __DIR__ . '/../src/*')
+        ->arg('$environment', '%kernel.environment%')
+        ->bind('$debug', '%kernel.debug%')
+        ->exclude([__DIR__ . '/../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}']);
+};

--- a/packages/php-config-printer/src/NodeFactory/Service/ServicesPhpNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/Service/ServicesPhpNodeFactory.php
@@ -23,7 +23,7 @@ final class ServicesPhpNodeFactory
     public function __construct(
         private CommonNodeFactory $commonNodeFactory,
         private ArgsNodeFactory $argsNodeFactory,
-        private AutoBindNodeFactory $autoBindNodeFactory
+        private ServiceOptionNodeFactory $serviceOptionNodeFactory,
     ) {
     }
 
@@ -31,11 +31,7 @@ final class ServicesPhpNodeFactory
     {
         $servicesLoadMethodCall = $this->createServicesLoadMethodCall($serviceKey, $serviceValues);
 
-        $servicesLoadMethodCall = $this->autoBindNodeFactory->createAutoBindCalls(
-            $serviceValues,
-            $servicesLoadMethodCall,
-            AutoBindNodeFactory::TYPE_SERVICE
-        );
+        $servicesLoadMethodCall = $this->serviceOptionNodeFactory->convertServiceOptionsToNodes($serviceValues, $servicesLoadMethodCall);
 
         if (! isset($serviceValues[self::EXCLUDE])) {
             return new Expression($servicesLoadMethodCall);


### PR DESCRIPTION
This makes sure that YAML config like:
```yaml
services:
  App\:
    resource: '../src/*'
    arguments:
      $environment: '%kernel.environment%'
    bind:
      $debug: '%kernel.debug%'
```

will be properly converted to PHP config like:
```php
    $services->load('App\\', __DIR__ . '/../src/*')
        ->arg('$environment', '%kernel.environment%')
        ->bind('$debug', '%kernel.debug%');
```

Before this change, it would convert it to this:
```php
    $services->load('App\\', __DIR__ . '/../src/*');
```
Resulting in lots of breaks.
