### PR TITLE
[Coding Standard] Reimplement checking for arrow function support

### DIFF
--- a/packages/coding-standard/src/TokenAnalyzer/DocblockRelatedParamNamesResolver.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DocblockRelatedParamNamesResolver.php
@@ -21,7 +21,9 @@ final class DocblockRelatedParamNamesResolver
         $this->functionTokens[] = new Token([T_FUNCTION, 'function']);
 
         // only in PHP 7.4+
-        $this->functionTokens[] = new Token([T_FN, 'fn']);
+        if ($this->doesFnTokenExist()) {
+            $this->functionTokens[] = new Token([T_FN, 'fn']);
+        }
     }
 
     /**
@@ -39,5 +41,11 @@ final class DocblockRelatedParamNamesResolver
         $functionArgumentAnalyses = $this->functionsAnalyzer->getFunctionArguments($tokens, $functionTokenPosition);
 
         return array_keys($functionArgumentAnalyses);
+    }
+
+    private function doesFnTokenExist(): bool
+    {
+        return PHP_VERSION_ID >= 70400
+            && defined('T_FN');
     }
 }


### PR DESCRIPTION
Reverts some of the code that was removed in https://github.com/symplify/symplify/commit/5fd568ca395189440ff6f8e9405f7142c1f88789.

Fixes #3355 

Even though this would fix the issue I'd still be careful since I don't know exactly where else in the project these kinds of errors can appear. I would suggest updating the test matrix to use both PHP 8.0 _and_ PHP 7.1 to prevent any regressions. But that would be out of this PR's scope :)