### PR TITLE
[ConfigTransformer] Alvast try autoload from current working directory first

### DIFF
--- a/packages/config-transformer/bin/config-transformer.php
+++ b/packages/config-transformer/bin/config-transformer.php
@@ -6,6 +6,8 @@ use Symplify\ConfigTransformer\HttpKernel\ConfigTransformerKernel;
 use Symplify\SymplifyKernel\ValueObject\KernelBootAndApplicationRun;
 
 $possibleAutoloadPaths = [
+    // when using `vendor/bin/config-transformer` from project root that depends on this package
+    getcwd() . '/vendor/autoload.php',
     // after split package
     __DIR__ . '/../vendor/autoload.php',
     // dependency


### PR DESCRIPTION
When using the config transformer on a real project, you often install it like:
```
composer req --dev symplify/config-transformer:dev-main
```

And then run it with: 
```
vendor/bin/config-transformer
```

When you are converting a YAML file that loads resources (e.g. Symfony Auto Wire) you get errors like:
```
  Expected to find class "App\AdminBundle\Controller\AdminController" in file "/Volumes/CS/www/src/AdminBundle/Controller/AdminController.php" while importing services from resource "../../{Controller,Repository}", but it was not found! Check the namespace prefix used with the resource.
```

This is caused by the fact that config transformer finds the `vendor/autoload.php` from it's own bundled vendor directory instead of the 
`vendor/autoload.php` from my project. Therefore, when trying to find classes when converting it cannot find the resources.

By using `getcwd` we first check and load the project autoloader.

Fixes #3342