### PR TITLE
[ConfigTransformer] Support services with same short class name

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_with_same_short_name.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_with_same_short_name.yaml
@@ -1,0 +1,20 @@
+services:
+    SimpleBus\CommandBus: ~
+    App\CommandBus: ~
+
+-----
+<?php
+
+declare(strict_types=1);
+
+use App\CommandBus as CommandBus2;
+use SimpleBus\CommandBus;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(CommandBus::class);
+
+    $services->set(CommandBus2::class);
+};

--- a/packages/php-config-printer/src/NodeTraverser/ImportFullyQualifiedNamesNodeTraverser.php
+++ b/packages/php-config-printer/src/NodeTraverser/ImportFullyQualifiedNamesNodeTraverser.php
@@ -84,6 +84,10 @@ final class ImportFullyQualifiedNamesNodeTraverser
                 default => $this->builderFactory->use($name),
             };
 
+            if ($import->getAlias() !== '') {
+                $useBuilder = $useBuilder->as($import->getAlias());
+            }
+
             $useImports[] = $useBuilder->getNode();
         }
 

--- a/packages/php-config-printer/src/NodeVisitor/ImportFullyQualifiedNamesNodeVisitor.php
+++ b/packages/php-config-printer/src/NodeVisitor/ImportFullyQualifiedNamesNodeVisitor.php
@@ -55,16 +55,22 @@ final class ImportFullyQualifiedNamesNodeVisitor extends NodeVisitorAbstract
         }
 
         $shortClassName = $this->classNaming->getShortName($fullyQualifiedName);
+        $shortClassNameAlias = $this->getAliasForShortName($shortClassName);
 
-        if ($parent instanceof FuncCall) {
-            $import = new FullyQualifiedImport(ImportType::FUNCTION_TYPE, $fullyQualifiedName);
-        } else {
-            $import = new FullyQualifiedImport(ImportType::CLASS_TYPE, $fullyQualifiedName);
+        $alias = '';
+        if ($shortClassName !== $shortClassNameAlias ) {
+            $alias = $shortClassNameAlias;
         }
 
-        $this->imports[] = $import;
+        if ($parent instanceof FuncCall) {
+            $import = new FullyQualifiedImport(ImportType::FUNCTION_TYPE, $fullyQualifiedName, $alias);
+        } else {
+            $import = new FullyQualifiedImport(ImportType::CLASS_TYPE, $fullyQualifiedName, $alias);
+        }
 
-        return new Name($shortClassName);
+        $this->imports[$shortClassNameAlias] = $import;
+
+        return new Name($shortClassNameAlias);
     }
 
     /**
@@ -73,5 +79,18 @@ final class ImportFullyQualifiedNamesNodeVisitor extends NodeVisitorAbstract
     public function getImports(): array
     {
         return $this->imports;
+    }
+
+    private function getAliasForShortName(string $shortClassName, int $suffix = 1) : string
+    {
+        if ($suffix > 1) {
+            $shortClassName .= (int) $suffix;
+        }
+
+        if (isset($this->imports[$shortClassName])) {
+            return $this->getAliasForShortName($shortClassName, $suffix + 1);
+        }
+
+        return $shortClassName;
     }
 }

--- a/packages/php-config-printer/src/ValueObject/FullyQualifiedImport.php
+++ b/packages/php-config-printer/src/ValueObject/FullyQualifiedImport.php
@@ -11,6 +11,7 @@ final class FullyQualifiedImport implements Stringable
     public function __construct(
         private string $type,
         private string $fullyQualified,
+        private string $alias
     ) {
     }
 
@@ -27,5 +28,10 @@ final class FullyQualifiedImport implements Stringable
     public function getFullyQualified(): string
     {
         return $this->fullyQualified;
+    }
+
+    public function getAlias() : string
+    {
+        return $this->alias;
     }
 }


### PR DESCRIPTION
When your YAML config contains services with the same shortname like:
```yaml
services:
    SimpleBus\CommandBus: ~
    App\CommandBus: ~
```
it would be transformed into:
```php
use App\CommandBus;
use SimpleBus\CommandBus;

$services->set(CommandBus::class);
$services->set(CommandBus::class);
```

This doesn't make sense.

Instead, it should import them as aliases like this:
```php
use App\CommandBus as CommandBus2;
use SimpleBus\CommandBus;

$services->set(CommandBus::class);
$services->set(CommandBus2::class);
```

A different approach could be to stop importing as short name as soon a duplicate is detected.
```php
use SimpleBus\CommandBus;

$services->set(CommandBus::class);
$services->set(\App\CommandBus::class);
```

@TomasVotruba What do you prefer?