### PR TITLE
[ConfigTransformer] Support aliasing non-FQCN service names

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_alias.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_alias.yaml
@@ -1,4 +1,7 @@
 services:
+    querybus:
+        alias: tactician.commandbus.query
+
     Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass: '@fake.simple_class'
 
     Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass $variable: '@App\Fake\Class'
@@ -20,6 +23,8 @@ use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\Seco
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+
+    $services->alias('querybus', 'tactician.commandbus.query');
 
     $services->alias(FakeClass::class, 'fake.simple_class');
 

--- a/packages/php-config-printer/src/CaseConverter/AliasCaseConverter.php
+++ b/packages/php-config-printer/src/CaseConverter/AliasCaseConverter.php
@@ -128,10 +128,14 @@ final class AliasCaseConverter implements CaseConverterInterface
         return new Expression($methodCall);
     }
 
-    private function createFromAlias(string $className, string $key, Variable $servicesVariable): MethodCall
+    private function createFromAlias(string $serviceName, string $key, Variable $servicesVariable): MethodCall
     {
-        $classReference = $this->commonNodeFactory->createClassReference($className);
-        $args = $this->argsNodeFactory->createFromValues([$key, $classReference]);
+        if ($this->classLikeExistenceChecker->doesClassLikeExist($serviceName)) {
+            $classReference = $this->commonNodeFactory->createClassReference($serviceName);
+            $args = $this->argsNodeFactory->createFromValues([$key, $classReference]);
+        } else {
+            $args = $this->argsNodeFactory->createFromValues([$key, $serviceName]);
+        }
 
         return new MethodCall($servicesVariable, MethodName::ALIAS, $args);
     }


### PR DESCRIPTION
It should convert
```yaml
services:
    querybus:
        alias: tactician.commandbus.query
```
to
```php
$services->alias('querybus', 'tactician.commandbus.query');
```

Before, it would convert it to:
```php
$services->alias('querybus', tactician.commandbus.query::class);
```