### PR TITLE
[PhpConfigTransformer] Failing test for `parent` on `service`

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_parent.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_parent.yaml
@@ -1,0 +1,23 @@
+services:
+    service1:
+        class: Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass
+
+    service2:
+        parent: service1
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set('service1', FakeClass::class);
+
+    $services->set('service2')
+        ->parent('service1');
+};


### PR DESCRIPTION
Can't fix it right now. But this is the failing test that shows `parent` is ignored on `service`. 