### PR TITLE
[PhpConfigTransformer] Failing test for `lazy` on `service`

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_lazy.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_lazy.yaml
@@ -1,0 +1,25 @@
+services:
+    Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass:
+        lazy: false
+
+    Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass:
+        lazy: true
+
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(FakeClass::class)
+        ->lazy(false);
+
+    $services->set(SecondFakeClass::class)
+        ->lazy();
+};


### PR DESCRIPTION
Can't fix it right now. But this is the failing test that shows `lazy` is ignored on `service`.

