### PR TITLE
[CodingStandard] Add DoctrineAnnotationNestedBracketsFixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "ondram/ci-detector": "^4.1",
         "phpunit/phpunit": "^9.5",
         "psr/log": "^1.1",
-        "rector/rector": "dev-main#ecda10a",
+        "rector/rector": "dev-main#e219401",
         "symfony/doctrine-bridge": "^5.3",
         "symfony/framework-bundle": "^5.3",
         "symfony/security-bundle": "^5.3",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "ondram/ci-detector": "^4.1",
         "phpunit/phpunit": "^9.5",
         "psr/log": "^1.1",
-        "rector/rector": "dev-main#e219401",
+        "rector/rector": "dev-main#54dcc7b",
         "symfony/doctrine-bridge": "^5.3",
         "symfony/framework-bundle": "^5.3",
         "symfony/security-bundle": "^5.3",

--- a/ecs.php
+++ b/ecs.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
@@ -11,6 +12,11 @@ use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
     $services->set(LineLengthFixer::class);
+
+    $services->set(DoctrineAnnotationNestedBracketsFixer::class)
+        ->call('configure', [[
+            DoctrineAnnotationNestedBracketsFixer::ANNOTATION_CLASSES => ['Doctrine\ORM\JoinColumns'],
+        ]]);
 
     $containerConfigurator->import(SetList::CLEAN_CODE);
     $containerConfigurator->import(SetList::SYMPLIFY);

--- a/packages/astral/src/NodeTraverser/SimpleCallableNodeTraverser.php
+++ b/packages/astral/src/NodeTraverser/SimpleCallableNodeTraverser.php
@@ -17,7 +17,7 @@ final class SimpleCallableNodeTraverser
     /**
      * @param Node|Node[]|null $nodes
      */
-    public function traverseNodesWithCallable($nodes, callable $callable): void
+    public function traverseNodesWithCallable(Node | array | null $nodes, callable $callable): void
     {
         if ($nodes === null) {
             return;

--- a/packages/coding-standard/config/config.php
+++ b/packages/coding-standard/config/config.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Tokenizer\Analyzer\FunctionsAnalyzer;
+use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\EasyCodingStandard\Caching\ChangedFilesDetector;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
@@ -24,6 +25,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             __DIR__ . '/../src/ValueObject',
         ]);
 
+    $services->set(NamespaceUsesAnalyzer::class);
     $services->set(FunctionsAnalyzer::class);
     $services->set(PrivatesAccessor::class);
 

--- a/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
+++ b/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Fixer\Annotation;
+
+use Doctrine\Common\Annotations\DocLexer;
+use PhpCsFixer\Doctrine\Annotation\Token;
+use PhpCsFixer\Doctrine\Annotation\Tokens as DoctrineAnnotationTokens;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Analyzer\NamespaceUsesAnalyzer;
+use PhpCsFixer\Tokenizer\Tokens;
+use Symplify\CodingStandard\Fixer\AbstractSymplifyFixer;
+use Symplify\CodingStandard\TokenAnalyzer\DoctrineAnnotationElementAnalyzer;
+use Symplify\CodingStandard\TokenAnalyzer\DoctrineAnnotationNameResolver;
+use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+final class DoctrineAnnotationNestedBracketsFixer extends AbstractSymplifyFixer implements ConfigurableRuleInterface, DocumentedRuleInterface
+{
+    /**
+     * @var string
+     */
+    public const ANNOTATION_CLASSES = 'annotation_classes';
+
+    /**
+     * @var string
+     */
+    private const ERROR_MESSAGE = 'Adds nested curly brackets to defined annotations, see https://github.com/doctrine/annotations/issues/418';
+
+    /**
+     * @var string[]
+     */
+    private array $annotationClasses = [];
+
+    public function __construct(
+        private DoctrineAnnotationElementAnalyzer $doctrineAnnotationElementAnalyzer,
+        private DoctrineAnnotationNameResolver $annotationNameResolver,
+        private NamespaceUsesAnalyzer $namespaceUsesAnalyzer
+    ) {
+    }
+
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(self::ERROR_MESSAGE, []);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+/**
+* @MainAnnotation(
+*     @NestedAnnotation(),
+*     @NestedAnnotation(),
+* )
+*/
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+/**
+* @MainAnnotation({
+*     @NestedAnnotation(),
+*     @NestedAnnotation(),
+* })
+*/
+CODE_SAMPLE
+                ,
+                [
+                    self::ANNOTATION_CLASSES => ['MainAnnotation'],
+                ]
+            ),
+        ]);
+    }
+
+    /**
+     * @param array<string, string[]> $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        $annotationsClasses = $configuration[self::ANNOTATION_CLASSES] ?? [];
+        Assert::isArray($annotationsClasses);
+        Assert::allString($annotationsClasses);
+
+        $this->annotationClasses = $annotationsClasses;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(T_DOC_COMMENT);
+    }
+
+    public function fix(\SplFileInfo $fileInfo, Tokens $tokens): void
+    {
+        $useDeclarations = $this->namespaceUsesAnalyzer->getDeclarationsFromTokens($tokens);
+
+        // fetch indexes one time, this is safe as we never add or remove a token during fixing
+
+        /** @var \PhpCsFixer\Tokenizer\Token[] $docCommentTokens */
+        $docCommentTokens = $tokens->findGivenKind(T_DOC_COMMENT);
+        foreach ($docCommentTokens as $index => $docCommentToken) {
+            if (! $this->doctrineAnnotationElementAnalyzer->detect($tokens, $index)) {
+                continue;
+            }
+
+            $doctrineAnnotationTokens = DoctrineAnnotationTokens::createFromDocComment($docCommentToken, []);
+            $this->fixAnnotations($doctrineAnnotationTokens, $useDeclarations);
+
+            $tokens[$index] = new \PhpCsFixer\Tokenizer\Token([T_DOC_COMMENT, $doctrineAnnotationTokens->getCode()]);
+        }
+    }
+
+    /**
+     * @param DoctrineAnnotationTokens<Token> $tokens
+     */
+    private function fixAnnotations(DoctrineAnnotationTokens $tokens, $useDeclarations): void
+    {
+        foreach ($tokens as $index => $token) {
+            $isAtToken = $tokens[$index]->isType(DocLexer::T_AT);
+            if (! $isAtToken) {
+                continue;
+            }
+
+            $annotationName = $this->annotationNameResolver->resolveName($tokens, $index, $useDeclarations);
+            if ($annotationName === null) {
+                continue;
+            }
+
+            if (! in_array($annotationName, $this->annotationClasses, true)) {
+                continue;
+            }
+
+            $closingBraceIndex = $tokens->getAnnotationEnd($index);
+            if ($closingBraceIndex === null) {
+                continue;
+            }
+
+            $braceIndex = $tokens->getNextMeaningfulToken($index + 1);
+            if ($braceIndex === null) {
+                continue;
+            }
+
+            /** @var Token $braceToken */
+            $braceToken = $tokens[$braceIndex];
+            if (! $this->doctrineAnnotationElementAnalyzer->isOpeningBracketFollowedByAnnotation(
+                $braceToken,
+                $tokens,
+                $braceIndex
+            )) {
+                continue;
+            }
+
+            // add closing brace
+            $tokens->insertAt($closingBraceIndex, new Token(DocLexer::T_OPEN_CURLY_BRACES, '}'));
+
+            // add opening brace
+            $tokens->insertAt($braceIndex + 1, new Token(DocLexer::T_OPEN_CURLY_BRACES, '{'));
+        }
+    }
+}

--- a/packages/coding-standard/src/Fixer/Commenting/RemoveCommentedCodeFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/RemoveCommentedCodeFixer.php
@@ -19,7 +19,8 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see https://softwareengineering.stackexchange.com/a/394288/148956
+ * @deprecated This rule is seriously buggy. Don't use it. We're working on a better replacement
+ * @see https://github.com/symplify/symplify/issues/3395
  *
  * @see \Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveCommentedCodeFixer\RemoveCommentedCodeFixerTest
  */

--- a/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/DocBlockLineLengthFixer.php
@@ -122,6 +122,9 @@ final class DocBlockLineLengthFixer extends AbstractSymplifyFixer implements Con
         }
     }
 
+    /**
+     * @param array<string, int> $configuration
+     */
     public function configure(array $configuration): void
     {
         $this->lineLength = $configuration[self::LINE_LENGTH] ?? self::DEFAULT_LINE_LENGHT;

--- a/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationElementAnalyzer.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationElementAnalyzer.php
@@ -17,10 +17,13 @@ use PhpCsFixer\Tokenizer\TokensAnalyzer;
  */
 final class DoctrineAnnotationElementAnalyzer
 {
+    /**
+     * @param Tokens<\PhpCsFixer\Tokenizer\Token> $tokens
+     */
     public function detect(Tokens $tokens, int $index): bool
     {
-        $analyzer = new TokensAnalyzer($tokens);
-        $classyElements = $analyzer->getClassyElements();
+        $tokensAnalyzer = new TokensAnalyzer($tokens);
+        $classyElements = $tokensAnalyzer->getClassyElements();
 
         do {
             $index = $tokens->getNextMeaningfulToken($index);
@@ -49,11 +52,11 @@ final class DoctrineAnnotationElementAnalyzer
     /**
      * We look for "(@SomeAnnotation"
      *
-     * @param DoctrineAnnotationTokens<Token> $tokens
+     * @param DoctrineAnnotationTokens<Token> $doctrineAnnotationTokens
      */
     public function isOpeningBracketFollowedByAnnotation(
         Token $token,
-        DoctrineAnnotationTokens $tokens,
+        DoctrineAnnotationTokens $doctrineAnnotationTokens,
         int $braceIndex
     ): bool {
         // should be "("
@@ -62,13 +65,13 @@ final class DoctrineAnnotationElementAnalyzer
             return false;
         }
 
-        $nextTokenIndex = $tokens->getNextMeaningfulToken($braceIndex + 1);
+        $nextTokenIndex = $doctrineAnnotationTokens->getNextMeaningfulToken($braceIndex);
         if ($nextTokenIndex === null) {
             return false;
         }
 
         /** @var Token $nextToken */
-        $nextToken = $tokens[$nextTokenIndex];
+        $nextToken = $doctrineAnnotationTokens[$nextTokenIndex];
 
         // next token must be nested annotation, we don't care otherwise
         return $nextToken->isType(DocLexer::T_AT);

--- a/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationElementAnalyzer.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationElementAnalyzer.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\TokenAnalyzer;
+
+use Doctrine\Common\Annotations\DocLexer;
+use PhpCsFixer\Doctrine\Annotation\Token;
+use PhpCsFixer\Doctrine\Annotation\Tokens as DoctrineAnnotationTokens;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+
+/**
+ * Copied from \PhpCsFixer\AbstractDoctrineAnnotationFixer::nextElementAcceptsDoctrineAnnotations() so it can be used as
+ * a normal service
+ */
+final class DoctrineAnnotationElementAnalyzer
+{
+    public function detect(Tokens $tokens, int $index): bool
+    {
+        $analyzer = new TokensAnalyzer($tokens);
+        $classyElements = $analyzer->getClassyElements();
+
+        do {
+            $index = $tokens->getNextMeaningfulToken($index);
+
+            if ($index === null) {
+                return false;
+            }
+        } while ($tokens[$index]->isGivenKind([T_ABSTRACT, T_FINAL]));
+
+        if ($tokens[$index]->isClassy()) {
+            return true;
+        }
+
+        while ($tokens[$index]->isGivenKind(
+            [T_PUBLIC, T_PROTECTED, T_PRIVATE, T_FINAL, T_ABSTRACT, T_NS_SEPARATOR, T_STRING, CT::T_NULLABLE_TYPE]
+        )) {
+            $index = $tokens->getNextMeaningfulToken($index);
+            if (! is_int($index)) {
+                return false;
+            }
+        }
+
+        return isset($classyElements[$index]);
+    }
+
+    /**
+     * We look for "(@SomeAnnotation"
+     *
+     * @param DoctrineAnnotationTokens<Token> $tokens
+     */
+    public function isOpeningBracketFollowedByAnnotation(
+        Token $token,
+        DoctrineAnnotationTokens $tokens,
+        int $braceIndex
+    ): bool {
+        // should be "("
+        $isNextOpenParenthesis = $token->isType(DocLexer::T_OPEN_PARENTHESIS);
+        if (! $isNextOpenParenthesis) {
+            return false;
+        }
+
+        $nextTokenIndex = $tokens->getNextMeaningfulToken($braceIndex + 1);
+        if ($nextTokenIndex === null) {
+            return false;
+        }
+
+        /** @var Token $nextToken */
+        $nextToken = $tokens[$nextTokenIndex];
+
+        // next token must be nested annotation, we don't care otherwise
+        return $nextToken->isType(DocLexer::T_AT);
+    }
+}

--- a/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
@@ -30,16 +30,16 @@ final class DoctrineAnnotationNameResolver
             $annotationShortName .= $currentToken->getContent();
         }
 
-        if ($annotationShortName) {
-            foreach ($namespaceUseAnalyses as $namespaceUseAnalysis) {
-                if ($namespaceUseAnalysis->getShortName() === $annotationShortName) {
-                    return $namespaceUseAnalysis->getFullName();
-                }
-            }
-
-            return $annotationShortName;
+        if ($annotationShortName === '') {
+            return null;
         }
 
-        return null;
+        foreach ($namespaceUseAnalyses as $namespaceUseAnalysis) {
+            if ($namespaceUseAnalysis->getShortName() === $annotationShortName) {
+                return $namespaceUseAnalysis->getFullName();
+            }
+        }
+
+        return $annotationShortName;
     }
 }

--- a/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\TokenAnalyzer;
+
+use Doctrine\Common\Annotations\DocLexer;
+use PhpCsFixer\Doctrine\Annotation\Token;
+use PhpCsFixer\Doctrine\Annotation\Tokens;
+use PhpCsFixer\Tokenizer\Analyzer\Analysis\NamespaceUseAnalysis;
+
+final class DoctrineAnnotationNameResolver
+{
+    /**
+     * @param Tokens<Token> $tokens
+     * @param NamespaceUseAnalysis[] $namespaceUseAnalyses
+     */
+    public function resolveName(Tokens $tokens, int $index, array $namespaceUseAnalyses): ?string
+    {
+        $openParenthesisPosition = $tokens->getNextTokenOfType(DocLexer::T_OPEN_PARENTHESIS, $index);
+        if ($openParenthesisPosition === null) {
+            return null;
+        }
+
+        $annotationShortName = '';
+
+        for ($i = $index + 1; $i < $openParenthesisPosition; ++$i) {
+            /** @var Token $currentToken */
+            $currentToken = $tokens[$i];
+            $annotationShortName .= $currentToken->getContent();
+        }
+
+        if ($annotationShortName) {
+            foreach ($namespaceUseAnalyses as $namespaceUseAnalysis) {
+                if ($namespaceUseAnalysis->getShortName() === $annotationShortName) {
+                    return $namespaceUseAnalysis->getFullName();
+                }
+            }
+
+            return $annotationShortName;
+        }
+
+        return null;
+    }
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/DoctrineAnnotationNestedBracketsFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/DoctrineAnnotationNestedBracketsFixerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer;
+
+use Iterator;
+use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
+use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+final class DoctrineAnnotationNestedBracketsFixerTest extends AbstractCheckerTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<mixed, SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfig(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Fixture/skip_already_wrapped.php.inc
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Fixture/skip_already_wrapped.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Fixture;
+
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotation;
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotations;
+
+/**
+ * @SomeAnnotations({
+ *     @SomeAnnotation(),
+ *     @SomeAnnotation()
+ * })
+ */
+final class SkipAlreadyWrapped
+{
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Fixture/skip_not_configured_annotation.php.inc
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Fixture/skip_not_configured_annotation.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Fixture;
+
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\MissingYou;
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotation;
+
+/**
+ * @MissingYou(
+ *     @SomeAnnotation(),
+ *     @SomeAnnotation()
+ * )
+ */
+final class SkipNotConfiguredAnnotation
+{
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Fixture/some_nested_annotation_without_brackets.php.inc
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Fixture/some_nested_annotation_without_brackets.php.inc
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Fixture;
+
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotations;
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotation;
+
+/**
+ * @SomeAnnotations(
+ *     @SomeAnnotation(),
+ *     @SomeAnnotation()
+ * )
+ */
+class SomeNestedAnnotationWithoutBrackets
+{
+}
+
+?>
+-----
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Fixture;
+
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotations;
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotation;
+
+/**
+ * @SomeAnnotations({
+ *     @SomeAnnotation(),
+ *     @SomeAnnotation()
+ * })
+ */
+class SomeNestedAnnotationWithoutBrackets
+{
+}
+
+?>

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Source/MissingYou.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Source/MissingYou.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source;
+
+final class MissingYou
+{
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Source/SomeAnnotation.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Source/SomeAnnotation.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source;
+
+final class SomeAnnotation
+{
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Source/SomeAnnotations.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/Source/SomeAnnotations.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source;
+
+final class SomeAnnotations
+{
+}

--- a/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/config/configured_rule.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer;
+use Symplify\CodingStandard\Tests\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer\Source\SomeAnnotations;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(DoctrineAnnotationNestedBracketsFixer::class)
+        ->call('configure', [[
+            DoctrineAnnotationNestedBracketsFixer::ANNOTATION_CLASSES => [SomeAnnotations::class],
+        ]]);
+};

--- a/packages/phpstan-rules/src/PhpDoc/ClassReferencePhpDocNodeVisitor.php
+++ b/packages/phpstan-rules/src/PhpDoc/ClassReferencePhpDocNodeVisitor.php
@@ -46,10 +46,7 @@ final class ClassReferencePhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $this->className = $className;
     }
 
-    /**
-     * @return int|Node|null
-     */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): Node
     {
         if ($node instanceof PhpDocTagNode) {
             $this->processPhpDocTagNode($node);

--- a/packages/simple-php-doc-parser/src/Bundle/SimplePhpDocParserBundle.php
+++ b/packages/simple-php-doc-parser/src/Bundle/SimplePhpDocParserBundle.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Symplify\SimplePhpDocParser\Bundle;
 
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symplify\SimplePhpDocParser\Bundle\DependencyInjection\Extension\SimplePhpDocParserExtension;
 
 final class SimplePhpDocParserBundle extends Bundle
 {
-    public function getContainerExtension(): ?ExtensionInterface
+    public function getContainerExtension(): SimplePhpDocParserExtension
     {
         return new SimplePhpDocParserExtension();
     }

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CloningPhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CloningPhpDocNodeVisitor.php
@@ -13,10 +13,7 @@ use Symplify\SimplePhpDocParser\ValueObject\PhpDocAttributeKey;
  */
 final class CloningPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 {
-    /**
-     * @return int|Node|null
-     */
-    public function enterNode(Node $origNode)
+    public function enterNode(Node $origNode): Node
     {
         $node = clone $origNode;
         $node->setAttribute(PhpDocAttributeKey::ORIG_NODE, $origNode);

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/ParentConnectingPhpDocNodeVisitor.php
@@ -24,10 +24,7 @@ final class ParentConnectingPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
         $this->stack = [$node];
     }
 
-    /**
-     * @return int|Node|null
-     */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): Node
     {
         if ($this->stack !== []) {
             $parentNode = $this->stack[count($this->stack) - 1];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -524,3 +524,6 @@ parameters:
         -
             message: '#Cognitive complexity for "Symplify\\SimplePhpDocParser\\PhpDocNodeTraverser\:\:(.*?)\(\)" is \d+, keep it under \d+#'
             path: packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+
+        # wrong php-cs-fixer doc types
+        - '#Parameter \#1 \$type of method PhpCsFixer\\Doctrine\\Annotation\\Tokens\:\:getNextTokenOfType\(\) expects array<string\>\|string, int given#'

--- a/rector.php
+++ b/rector.php
@@ -98,6 +98,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // many false postivies
         RenameForeachValueVariableToMatchExprVariableRector::class,
 
+        // buggy on array access object
+        \Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector::class => [
+            __DIR__ . '/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php',
+        ],
+
         // buggy with parent interface contract
         ParamTypeDeclarationRector::class => [__DIR__ . '/packages/skipper/src/SkipVoter/*SkipVoter.php'],
         UnSpreadOperatorRector::class => [__DIR__ . '/packages/git-wrapper'],


### PR DESCRIPTION
Solves https://github.com/doctrine/annotations/issues/418#issue-940872356

```diff
 /**
- * @MainAnnotation(
+ * @MainAnnotation({
  *     @NestedAnnotation('one'),
  *     @NestedAnnotation('two'),
- * )
+ * })
 */
```


## Use and Configure

```php
# ecs.php

use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer;

return static function (ContainerConfigurator $containerConfigurator): void {
    $services = $containerConfigurator->services();
    $services->set(LineLengthFixer::class);
    
    $services->set(DoctrineAnnotationNestedBracketsFixer::class)
        ->call('configure', [[
                DoctrineAnnotationNestedBracketsFixer::ANNOTATION_CLASSES => [
                    'MainAnnotation' 
                ]
        ]]);
    ]);
};

```