### PR TITLE
Purge container cache directory on boot

### DIFF
--- a/packages/easy-coding-standard/src/HttpKernel/EasyCodingStandardKernel.php
+++ b/packages/easy-coding-standard/src/HttpKernel/EasyCodingStandardKernel.php
@@ -36,10 +36,7 @@ final class EasyCodingStandardKernel extends AbstractSymplifyKernel
 
     public function getCacheDir(): string
     {
-        $cacheDir = sys_get_temp_dir() . '/ecs_' . get_current_user() . '_' . random_int(0, 100000);
-        FileSystem::createDir($cacheDir);
-
-        return $cacheDir;
+        return sys_get_temp_dir() . '/ecs_' . get_current_user();
     }
 
     public function getLogDir(): string
@@ -51,6 +48,17 @@ final class EasyCodingStandardKernel extends AbstractSymplifyKernel
         }
 
         return $logDirectory;
+    }
+
+    public function boot(): void
+    {
+        $cacheDir = $this->getCacheDir();
+
+        // Rebuild the container on each run
+        FileSystem::delete($cacheDir);
+        FileSystem::createDir($cacheDir);
+
+        parent::boot();
     }
 
     protected function prepareContainer(ContainerBuilder $containerBuilder): void

--- a/packages/easy-coding-standard/tests/HttpKernel/EasyCodingStandardKernelTest.php
+++ b/packages/easy-coding-standard/tests/HttpKernel/EasyCodingStandardKernelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Tests\HttpKernel;
+
+use Nette\Utils\FileSystem;
+use PHPUnit\Framework\TestCase;
+use Symplify\EasyCodingStandard\HttpKernel\EasyCodingStandardKernel;
+
+final class EasyCodingStandardKernelTest extends TestCase
+{
+    public function testCacheDirIsConsistentAcrossCalls(): void
+    {
+        $kernel = new EasyCodingStandardKernel('foo', false);
+
+        $this->assertSame($kernel->getCacheDir(), $kernel->getCacheDir());
+    }
+
+    public function testPurgesCacheDirOnBoot(): void
+    {
+        $kernel = new EasyCodingStandardKernel('foo', false);
+
+        $dummyFile = $kernel->getCacheDir() . '/dummy';
+        FileSystem::write($dummyFile, '');
+
+        $this->assertFileExists($dummyFile);
+        $kernel->boot();
+        $this->assertFileDoesNotExist($dummyFile);
+
+        FileSystem::delete($kernel->getCacheDir());
+    }
+}


### PR DESCRIPTION
see https://github.com/symplify/symplify/pull/3399/files#r667500878

This PR makes sure the container cache directory gets purged each time `Kernel#boot()` is called. This makes sure we're using a fresh application container for each run and do not spam the temp directory. 