### PR TITLE
[ConfigTransformer] Use named parameters when tag uses keys

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_arguments.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_arguments.yaml
@@ -9,8 +9,12 @@ services:
       -
         App\FooCommand: '@app.command_handler.foo'
         App\BarCommand: '@app.command_handler.bar'
+
+  Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\MimeTypes:
+    arguments:
       - !tagged_locator { tag: 'app.handler', index_by: 'key' }
       - !tagged_iterator app.handler
+      - !tagged_iterator { tag: app.handler, default_priority_method: getPriority }
 
   Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass:
     arguments: [!tagged_locator { index_by: 'key', tag: 'app.handler', default_index_method: 'myOwnMethodName' }]
@@ -30,6 +34,7 @@ declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeClass;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\MimeTypes;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\SecondFakeClass;
 use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\ThirdFakeClass;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\expr;
@@ -43,10 +48,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->alias(SecondFakeClass::class . ' $shoutyTransformer', 'App\Util\UppercaseTransformer');
 
     $services->set(FakeClass::class)
-        ->args([ref('string'), ['isaevsgdbfhhnth', 1234561456545, 'jean@vgbsetgil.com'], 456, ['App\FooCommand' => ref('app.command_handler.foo'), 'App\BarCommand' => ref('app.command_handler.bar')], tagged_locator('app.handler', 'key'), tagged_iterator('app.handler')]);
+        ->args([ref('string'), ['isaevsgdbfhhnth', 1234561456545, 'jean@vgbsetgil.com'], 456, ['App\FooCommand' => ref('app.command_handler.foo'), 'App\BarCommand' => ref('app.command_handler.bar')]]);
+
+    $services->set(MimeTypes::class)
+        ->args([tagged_locator(tag: 'app.handler', index_by: 'key'), tagged_iterator('app.handler'), tagged_iterator(tag: 'app.handler', default_priority_method: 'getPriority')]);
 
     $services->set(SecondFakeClass::class)
-        ->args([tagged_locator('key', 'app.handler', 'myOwnMethodName')]);
+        ->args([tagged_locator(index_by: 'key', tag: 'app.handler', default_index_method: 'myOwnMethodName')]);
 
     $services->set(ThirdFakeClass::class)
         ->arg('$fake1', ref('id.fake.service'))

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_decoration.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_decoration.yaml
@@ -29,8 +29,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->decorate('App\Mailer');
 
     $services->set(SecondFakeClass::class)
-        ->decorate('App\Mailer', 'App\DecoratingMailer.wooz', 5, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
+        ->decorate('App\Mailer', decoration_inner_name: 'App\DecoratingMailer.wooz', decoration_priority: 5, decoration_on_invalid: ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
 
     $services->set(ThirdFakeClass::class)
-        ->decorate('App\Mailer', null, 0, ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
+        ->decorate('App\Mailer', decoration_inner_name: null, decoration_priority: 0, decoration_on_invalid: ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
 };

--- a/packages/php-config-printer/src/NodeFactory/ArgsNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/ArgsNodeFactory.php
@@ -65,9 +65,14 @@ final class ArgsNodeFactory
     ): array {
         if (is_array($values)) {
             $args = [];
-            foreach ($values as $value) {
+            foreach ($values as $key => $value) {
                 $expr = $this->resolveExpr($value, $skipServiceReference, $skipClassesToConstantReference);
-                $args[] = new Arg($expr);
+
+                if (! is_int($key)) {
+                    $args[] = new Arg($expr, name: new Node\Identifier($key));
+                } else {
+                    $args[] = new Arg($expr);
+                }
             }
 
             return $args;

--- a/packages/phpstan-rules/src/Composer/Psr4PathValidator.php
+++ b/packages/phpstan-rules/src/Composer/Psr4PathValidator.php
@@ -7,6 +7,9 @@ namespace Symplify\PHPStanRules\Composer;
 use Nette\Utils\Strings;
 use Symplify\PHPStanRules\ValueObject\ClassNamespaceAndDirectory;
 
+/**
+ * @see \Symplify\PHPStanRules\Tests\Composer\Psr4PathValidatorTest
+ */
 final class Psr4PathValidator
 {
     public function isClassNamespaceCorrect(

--- a/packages/phpstan-rules/tests/Composer/Psr4PathValidatorTest.php
+++ b/packages/phpstan-rules/tests/Composer/Psr4PathValidatorTest.php
@@ -5,12 +5,19 @@ declare(strict_types=1);
 namespace Symplify\PHPStanRules\Tests\Composer;
 
 use Iterator;
-use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use PHPUnit\Framework\TestCase;
 use Symplify\PHPStanRules\Composer\Psr4PathValidator;
 use Symplify\PHPStanRules\ValueObject\ClassNamespaceAndDirectory;
 
-final class Psr4PathValidatorTest extends AbstractKernelTestCase
+final class Psr4PathValidatorTest extends TestCase
 {
+    private Psr4PathValidator $psr4PathValidator;
+
+    protected function setUp(): void
+    {
+        $this->psr4PathValidator = new Psr4PathValidator();
+    }
+
     /**
      * @dataProvider provideCorrectData()
      */
@@ -31,6 +38,9 @@ final class Psr4PathValidatorTest extends AbstractKernelTestCase
         $this->assertFalse($isClassNamespaceCorrect);
     }
 
+    /**
+     * @return Iterator<string[]>
+     */
     public function provideCorrectData(): Iterator
     {
         yield ['Symplify\\PHPStanRules\\Tests\\', 'packages/phpstan-rules/tests'];
@@ -46,14 +56,12 @@ final class Psr4PathValidatorTest extends AbstractKernelTestCase
 
     private function isNamespaceAndDirectoryCorrect(string $namespace, string $directory): bool
     {
-        $validator = new Psr4PathValidator();
-
         $classNamespaceAndDirectory = new ClassNamespaceAndDirectory(
             $namespace,
             $directory,
             sprintf('%sComposer\\', $namespace)
         );
 
-        return $validator->isClassNamespaceCorrect($classNamespaceAndDirectory, __FILE__);
+        return $this->psr4PathValidator->isClassNamespaceCorrect($classNamespaceAndDirectory, __FILE__);
     }
 }

--- a/packages/phpstan-rules/tests/Composer/Psr4PathValidatorTest.php
+++ b/packages/phpstan-rules/tests/Composer/Psr4PathValidatorTest.php
@@ -33,30 +33,15 @@ final class Psr4PathValidatorTest extends AbstractKernelTestCase
 
     public function provideCorrectData(): Iterator
     {
-        yield [
-            'Symplify\\PHPStanRules\\Tests\\',
-            'packages/phpstan-rules/tests',
-        ];
-        yield [
-            'Symplify\\PHPStanRules\\Tests\\',
-            'packages/phpstan-rules/tests/',
-        ];
+        yield ['Symplify\\PHPStanRules\\Tests\\', 'packages/phpstan-rules/tests'];
+        yield ['Symplify\\PHPStanRules\\Tests\\', 'packages/phpstan-rules/tests/'];
     }
 
     public function provideFailingData(): Iterator
     {
-        yield [
-            'Symplify\\PHPStanRules\\Tests\\',
-            'packages/tests/',
-        ];
-        yield [
-            'Symplify\\PHPStanRules\\Tests\\',
-            'packages/phpstan-rules/',
-        ];
-        yield [
-            'PHPStanRules\\Tests',
-            'packages/tests/',
-        ];
+        yield ['Symplify\\PHPStanRules\\Tests\\', 'packages/tests/'];
+        yield ['Symplify\\PHPStanRules\\Tests\\', 'packages/phpstan-rules/'];
+        yield ['PHPStanRules\\Tests', 'packages/tests/'];
     }
 
     private function isNamespaceAndDirectoryCorrect(string $namespace, string $directory): bool

--- a/packages/phpstan-rules/tests/Rules/ForbiddenForeachEmptyMissingArrayRule/ForbiddenForeachEmptyMissingArrayRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenForeachEmptyMissingArrayRule/ForbiddenForeachEmptyMissingArrayRuleTest.php
@@ -36,6 +36,9 @@ final class ForbiddenForeachEmptyMissingArrayRuleTest extends AbstractServiceAwa
 
     protected function getRule(): Rule
     {
-        return $this->getRuleFromConfig(ForbiddenForeachEmptyMissingArrayRule::class, __DIR__ . '/config/configured_rule.neon');
+        return $this->getRuleFromConfig(
+            ForbiddenForeachEmptyMissingArrayRule::class,
+            __DIR__ . '/config/configured_rule.neon'
+        );
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -291,6 +291,7 @@ parameters:
                  - packages/git-wrapper/src/GitWorkingCopy.php
                  # traversing is complex operatoin
                  - packages/simple-php-doc-parser/src/PhpDocNodeTraverser.php
+                 - packages/php-config-printer/src/NodeFactory/ArgsNodeFactory.php
 
         -
             message: '#Cognitive complexity for "Symplify\\CodingStandard\\Php\\PhpContentAnalyzer\:\:isPhpContent\(\)" is \d+, keep it under 8#'
@@ -537,3 +538,5 @@ parameters:
         -
             message: '#Cannot cast array\|bool\|float\|int\|string\|null to string#'
             path: packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
+
+        - '#Cognitive complexity for "Symplify\\PhpConfigPrinter\\NodeFactory\\ArgsNodeFactory\:\:createFromValues\(\)" is 13, keep it under 8#'


### PR DESCRIPTION
Manual adjust + merge of https://github.com/symplify/symplify/pull/3366

<br>	


- [ConfigTransformer] Use named parameters when tag uses keys
- add named args only on PHP 8
