### PR TITLE
Test `assertDirectoryEquals()` with unexpected files in output dir

### DIFF
--- a/packages/easy-testing/tests/PHPUnit/Behavior/DirectoryAssertableTrait/DirectoryAssertableTraitTest.php
+++ b/packages/easy-testing/tests/PHPUnit/Behavior/DirectoryAssertableTrait/DirectoryAssertableTraitTest.php
@@ -23,4 +23,11 @@ final class DirectoryAssertableTraitTest extends TestCase
 
         $this->assertDirectoryEquals(__DIR__ . '/Fixture/first_directory', __DIR__ . '/Fixture/third_directory');
     }
+
+    public function testItFailsWithExtraFilesInOutputDirectory(): void
+    {
+        $this->expectException(ExpectationFailedException::class);
+
+        $this->assertDirectoryEquals(__DIR__ . '/Fixture/first_directory', __DIR__ . '/Fixture/fourth_directory');
+    }
 }

--- a/packages/easy-testing/tests/PHPUnit/Behavior/DirectoryAssertableTrait/Fixture/fourth_directory/some_file.txt
+++ b/packages/easy-testing/tests/PHPUnit/Behavior/DirectoryAssertableTrait/Fixture/fourth_directory/some_file.txt
@@ -1,0 +1,1 @@
+some content

--- a/packages/easy-testing/tests/PHPUnit/Behavior/DirectoryAssertableTrait/Fixture/fourth_directory/some_other_file.txt
+++ b/packages/easy-testing/tests/PHPUnit/Behavior/DirectoryAssertableTrait/Fixture/fourth_directory/some_other_file.txt
@@ -1,0 +1,1 @@
+this file isn't present in the first_directory


### PR DESCRIPTION
Added failing test test as required in #3418 . 