### PR TITLE
tests: Add a test fixture for extra space issue

### DIFF
--- a/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/IndentDetector.php
+++ b/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/IndentDetector.php
@@ -27,7 +27,8 @@ final class IndentDetector
             $token = $tokens[$i];
 
             $lastNewlinePos = strrpos($token->getContent(), "\n");
-            if ($token->isWhitespace() && $token->getContent() !== ' ') {
+
+            if ($token->isWhitespace() && !$this->containsOnlySpaces($token->getContent())) {
                 return substr_count($token->getContent(), $indent, (int) $lastNewlinePos);
             }
             if ($lastNewlinePos !== false) {
@@ -36,5 +37,10 @@ final class IndentDetector
         }
 
         return 0;
+    }
+
+    private function containsOnlySpaces(string $tokenContent): bool
+    {
+        return '' === trim($tokenContent, ' ');
     }
 }

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/Fixture/correct7.php.inc
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/Fixture/correct7.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\StandaloneLineInMultilineArrayFixer\Fixture;
+
+class SomeClass
+{
+    public function getData()
+    {
+        // Added an extra space after return
+        return  [
+            'a' => 'b',
+            'c' => 'd',
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds a test fixture for the issue https://github.com/symplify/symplify/issues/3417

I also tried to dig down and search for the root of the cause. And this is the line

https://github.com/symplify/symplify/blob/c8ffda4e3a6ef6f94e1e520b2878b90c5cf74e2d/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/IndentDetector.php#L30

The `$token->getContent()` for the token between `return` and `[` returns two spaces instead of one space. So the if condition passes and `0` is returned from there. `2` is returned in the regular scenario (only one space after return unlike the fixture code).

Not sure how this should be fixed so opening a PR to drive some discussion.