### PR TITLE
[ECS] Add additional patcher to scoper.php

### DIFF
--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -122,6 +122,18 @@ return [
                 'PHPUnit\Framework\TestCase'
             );
         },
+        
+        function (string $filePath, string $prefix, string $content): string {
+            if (! str_ends_with($filePath, 'src/Testing/PHPUnit/AbstractCheckerTestCase.php')) {
+                return $content;
+            }
+
+            return Strings::replace(
+                $content,
+                $prefix . '\\\\Symplify\\\\PackageBuilder\\\\Testing\\\\AbstractKernelTestCase#',
+                'Symplify\PackageBuilder\Testing\AbstractKernelTestCase'
+            );
+        },
 
         // add static versions constant values
         function (string $filePath, string $prefix, string $content): string {


### PR DESCRIPTION
- Add additional patcher to fix `Class 'ECSPrefix20210712\Symplify\PackageBuilder\Testing\AbstractKernelTestCase' not found in .../vendor/symplify/easy-coding-standard/src/Testing/PHPUnit/AbstractCheckerTestCase.php:17` error.