### PR TITLE
ComplexityAffectingNodeFinder: remove wrong comment

### DIFF
--- a/packages/phpstan-rules/packages/cognitive-complexity/src/NodeAnalyzer/ComplexityAffectingNodeFinder.php
+++ b/packages/phpstan-rules/packages/cognitive-complexity/src/NodeAnalyzer/ComplexityAffectingNodeFinder.php
@@ -63,7 +63,6 @@ final class ComplexityAffectingNodeFinder
             return true;
         }
 
-        // B1. goto LABEL, break LABEL, continue LABEL
         if ($node instanceof Ternary) {
             return true;
         }


### PR DESCRIPTION
I think this comment is not placed correctly (might be a leftover of a rectoring or similar)