### PR TITLE
NoVoidGetterMethodRule: fix false-positive error on abstract method

### DIFF
--- a/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
+++ b/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
@@ -41,10 +41,10 @@ final class NoVoidGetterMethodRule extends AbstractSymplifyRule
     }
 
     /**
-     * @param ClassMethod $classMethod
+     * @param ClassMethod $node
      * @return string[]
      */
-    public function process(Node $classMethod, Scope $scope): array
+    public function process(Node $node, Scope $scope): array
     {
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {
@@ -55,15 +55,15 @@ final class NoVoidGetterMethodRule extends AbstractSymplifyRule
             return [];
         }
 
-        if ($classMethod->isAbstract()) {
+        if ($node->isAbstract()) {
             return [];
         }
 
-        if (! $this->simpleNameResolver->isName($classMethod, 'get*')) {
+        if (! $this->simpleNameResolver->isName($node, 'get*')) {
             return [];
         }
 
-        if (! $this->isVoidReturnClassMethod($classMethod)) {
+        if (! $this->isVoidReturnClassMethod($node)) {
             return [];
         }
 

--- a/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
+++ b/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
@@ -41,10 +41,10 @@ final class NoVoidGetterMethodRule extends AbstractSymplifyRule
     }
 
     /**
-     * @param ClassMethod $node
+     * @param ClassMethod $classMethod
      * @return string[]
      */
-    public function process(Node $node, Scope $scope): array
+    public function process(Node $classMethod, Scope $scope): array
     {
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {
@@ -55,11 +55,15 @@ final class NoVoidGetterMethodRule extends AbstractSymplifyRule
             return [];
         }
 
-        if (! $this->simpleNameResolver->isName($node, 'get*')) {
+        if ($classMethod->isAbstract()) {
+            return [];
+        }
+        
+        if (! $this->simpleNameResolver->isName($classMethod, 'get*')) {
             return [];
         }
 
-        if (! $this->isVoidReturnClassMethod($node)) {
+        if (! $this->isVoidReturnClassMethod($classMethod)) {
             return [];
         }
 

--- a/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
+++ b/packages/phpstan-rules/src/Rules/NoVoidGetterMethodRule.php
@@ -58,7 +58,7 @@ final class NoVoidGetterMethodRule extends AbstractSymplifyRule
         if ($classMethod->isAbstract()) {
             return [];
         }
-        
+
         if (! $this->simpleNameResolver->isName($classMethod, 'get*')) {
             return [];
         }

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipAbstractGetter.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/Fixture/SkipAbstractGetter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoVoidGetterMethodRule\Fixture;
+
+abstract class SkipGetterWithReturn
+{
+    abstract public function get();
+}

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/NoVoidGetterMethodRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/NoVoidGetterMethodRuleTest.php
@@ -28,6 +28,7 @@ final class NoVoidGetterMethodRuleTest extends AbstractServiceAwareRuleTestCase
         yield [__DIR__ . '/Fixture/SomeGetterVoid.php', [[NoVoidGetterMethodRule::ERROR_MESSAGE, 9]]];
         yield [__DIR__ . '/Fixture/SomeGetterWithNoReturn.php', [[NoVoidGetterMethodRule::ERROR_MESSAGE, 9]]];
 
+        yield [__DIR__ . '/Fixture/SkipAbstractGetter.php', []];
         yield [__DIR__ . '/Fixture/SkipIfElseReturn.php', []];
         yield [__DIR__ . '/Fixture/SkipGetterWithReturn.php', []];
         yield [__DIR__ . '/Fixture/SkipSetter.php', []];


### PR DESCRIPTION
closes https://github.com/symplify/symplify/issues/3427