### PR TITLE
[PHPStanRules] Add SameNamedParamFamilyRule

### DIFF
--- a/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
+++ b/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
@@ -103,7 +103,7 @@ CODE_SAMPLE
     /**
      * @param Tokens<Token> $tokens
      */
-    public function fix(SplFileInfo $fileInfo, Tokens $tokens): void
+    public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         $useDeclarations = $this->namespaceUsesAnalyzer->getDeclarationsFromTokens($tokens);
 

--- a/packages/coding-standard/src/Fixer/ArrayNotation/ArrayListItemNewlineFixer.php
+++ b/packages/coding-standard/src/Fixer/ArrayNotation/ArrayListItemNewlineFixer.php
@@ -61,7 +61,7 @@ final class ArrayListItemNewlineFixer extends AbstractSymplifyFixer implements D
     /**
      * @param Tokens<Token> $tokens
      */
-    public function fix(SplFileInfo $fileInfo, Tokens $tokens): void
+    public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         $arrayBlockInfos = $this->arrayBlockInfoFinder->findArrayOpenerBlockInfos($tokens);
         foreach ($arrayBlockInfos as $arrayBlockInfo) {

--- a/packages/coding-standard/src/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer.php
+++ b/packages/coding-standard/src/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer.php
@@ -83,7 +83,7 @@ CODE_SAMPLE
     /**
      * @param Tokens<Token> $tokens
      */
-    public function fix(SplFileInfo $fileInfo, Tokens $tokens): void
+    public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         $blockInfos = $this->arrayBlockInfoFinder->findArrayOpenerBlockInfos($tokens);
 

--- a/packages/coding-standard/src/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer.php
+++ b/packages/coding-standard/src/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer.php
@@ -85,7 +85,7 @@ CODE_SAMPLE
     /**
      * @param Tokens<Token> $tokens
      */
-    public function fix(SplFileInfo $fileInfo, Tokens $tokens): void
+    public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         foreach ($tokens as $index => $token) {
             if (! $token->isGivenKind(TokenKinds::ARRAY_OPEN_TOKENS)) {

--- a/packages/coding-standard/src/Fixer/Spacing/StandaloneLinePromotedPropertyFixer.php
+++ b/packages/coding-standard/src/Fixer/Spacing/StandaloneLinePromotedPropertyFixer.php
@@ -66,7 +66,7 @@ final class StandaloneLinePromotedPropertyFixer extends AbstractSymplifyFixer im
     /**
      * @param Tokens<Token> $tokens
      */
-    public function fix(SplFileInfo $splFileInfo, Tokens $tokens): void
+    public function fix(SplFileInfo $file, Tokens $tokens): void
     {
         // function arguments, function call parameters, lambda use()
         for ($position = count($tokens) - 1; $position >= 0; --$position) {

--- a/packages/config-transformer/src/DependencyInjection/Loader/IdAwareXmlFileLoader.php
+++ b/packages/config-transformer/src/DependencyInjection/Loader/IdAwareXmlFileLoader.php
@@ -84,7 +84,7 @@ final class IdAwareXmlFileLoader extends XmlFileLoader
         }
     }
 
-    private function processAnonymousServices(DOMDocument $xml, string $file, \DOMNode $root = null): void
+    private function processAnonymousServices(DOMDocument $xml, string $file): void
     {
         $this->count = 0;
         $definitions = [];

--- a/packages/config-transformer/src/DependencyInjection/Loader/IdAwareXmlFileLoader.php
+++ b/packages/config-transformer/src/DependencyInjection/Loader/IdAwareXmlFileLoader.php
@@ -84,13 +84,13 @@ final class IdAwareXmlFileLoader extends XmlFileLoader
         }
     }
 
-    private function processAnonymousServices(DOMDocument $domDocument, string $file): void
+    private function processAnonymousServices(DOMDocument $xml, string $file, \DOMNode $root = null): void
     {
         $this->count = 0;
         $definitions = [];
         $suffix = '~' . ContainerBuilder::hash($file);
 
-        $domxPath = new DOMXPath($domDocument);
+        $domxPath = new DOMXPath($xml);
         $domxPath->registerNamespace('container', self::NS);
 
         $definitions = $this->processAnonymousServicesInArguments($domxPath, $suffix, $file, $definitions);

--- a/packages/monorepo-builder/packages/Merge/ComposerJsonDecorator/AppenderComposerJsonDecorator.php
+++ b/packages/monorepo-builder/packages/Merge/ComposerJsonDecorator/AppenderComposerJsonDecorator.php
@@ -20,13 +20,13 @@ final class AppenderComposerJsonDecorator implements ComposerJsonDecoratorInterf
     ) {
     }
 
-    public function decorate(ComposerJson $mainComposerJson): void
+    public function decorate(ComposerJson $composerJson): void
     {
         $appendingComposerJson = $this->modifyingComposerJsonProvider->getAppendingComposerJson();
         if (! $appendingComposerJson instanceof ComposerJson) {
             return;
         }
 
-        $this->composerJsonMerger->mergeJsonToRoot($mainComposerJson, $appendingComposerJson);
+        $this->composerJsonMerger->mergeJsonToRoot($composerJson, $appendingComposerJson);
     }
 }

--- a/packages/monorepo-builder/packages/Merge/Contract/ComposerKeyMergerInterface.php
+++ b/packages/monorepo-builder/packages/Merge/Contract/ComposerKeyMergerInterface.php
@@ -8,5 +8,5 @@ use Symplify\ComposerJsonManipulator\ValueObject\ComposerJson;
 
 interface ComposerKeyMergerInterface
 {
-    public function merge(ComposerJson $mainComposerJson, ComposerJson $newToMerge): void;
+    public function merge(ComposerJson $mainComposerJson, ComposerJson $newComposerJson): void;
 }

--- a/packages/php-config-printer/src/Contract/Converter/ServiceOptionsKeyYamlToPhpFactoryInterface.php
+++ b/packages/php-config-printer/src/Contract/Converter/ServiceOptionsKeyYamlToPhpFactoryInterface.php
@@ -13,7 +13,7 @@ interface ServiceOptionsKeyYamlToPhpFactoryInterface
      * @param mixed $yaml
      * @param mixed $values
      */
-    public function decorateServiceMethodCall($key, $yaml, $values, MethodCall $serviceMethodCall): MethodCall;
+    public function decorateServiceMethodCall($key, $yaml, $values, MethodCall $methodCall): MethodCall;
 
     public function isMatch($key, $values): bool;
 }

--- a/packages/php-config-printer/src/Printer/PhpParserPhpConfigPrinter.php
+++ b/packages/php-config-printer/src/Printer/PhpParserPhpConfigPrinter.php
@@ -88,16 +88,16 @@ final class PhpParserPhpConfigPrinter extends Standard
         return "'" . Strings::replace($string, self::QUOTE_SLASH_REGEX, '\\\\$0') . "'";
     }
 
-    protected function pExpr_Array(Array_ $array): string
+    protected function pExpr_Array(Array_ $node): string
     {
-        $array->setAttribute(self::KIND, Array_::KIND_SHORT);
+        $node->setAttribute(self::KIND, Array_::KIND_SHORT);
 
-        return parent::pExpr_Array($array);
+        return parent::pExpr_Array($node);
     }
 
-    protected function pExpr_MethodCall(MethodCall $methodCall): string
+    protected function pExpr_MethodCall(MethodCall $node): string
     {
-        $printedMethodCall = parent::pExpr_MethodCall($methodCall);
+        $printedMethodCall = parent::pExpr_MethodCall($node);
         return $this->indentFluentCallToNewline($printedMethodCall);
     }
 

--- a/packages/phpstan-extensions/src/Php/Type/NativeFunctionDynamicFunctionReturnTypeExtension.php
+++ b/packages/phpstan-extensions/src/Php/Type/NativeFunctionDynamicFunctionReturnTypeExtension.php
@@ -21,7 +21,7 @@ final class NativeFunctionDynamicFunctionReturnTypeExtension implements DynamicF
 
     public function getTypeFromFunctionCall(
         FunctionReflection $functionReflection,
-        FuncCall $funcCall,
+        FuncCall $functionCall,
         Scope $scope
     ): Type {
         if ($functionReflection->getName() === 'tmpfile') {

--- a/packages/phpstan-rules/config/services/services.neon
+++ b/packages/phpstan-rules/config/services/services.neon
@@ -2,6 +2,7 @@ includes:
     - name-resolver-services.neon
 
 services:
+    - Symplify\PHPStanRules\Naming\MissMatchingParamResolver
     - Symplify\PHPStanRules\PhpDoc\PhpDocResolver
     - Symplify\PHPStanRules\PhpDoc\PhpDocNodeTraverser\ClassReferencePhpDocNodeTraverser
     - Symplify\PHPStanRules\PhpDoc\ClassReferencePhpDocNodeVisitor

--- a/packages/phpstan-rules/config/static-rules.neon
+++ b/packages/phpstan-rules/config/static-rules.neon
@@ -1,4 +1,9 @@
 services:
+    # explicit
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\SameNamedParamFamilyRule
+        tags: [phpstan.rules.rule]
+
     # domain
     -
         class: Symplify\PHPStanRules\Rules\Domain\RequireExceptionNamespaceRule

--- a/packages/phpstan-rules/src/Naming/MissMatchingParamResolver.php
+++ b/packages/phpstan-rules/src/Naming/MissMatchingParamResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Naming;
+
+use Symplify\PHPStanRules\ValueObject\MissMatchingParamName;
+
+final class MissMatchingParamResolver
+{
+    /**
+     * @param string[] $currentParamNames
+     * @param string[] $parentParamNames
+     * @return MissMatchingParamName[]
+     */
+    public function resolve(array $currentParamNames, array $parentParamNames): array
+    {
+        $missMatchingParamNames = [];
+
+        foreach ($currentParamNames as $key => $currentParamName) {
+            if (! isset($parentParamNames[$key])) {
+                continue;
+            }
+
+            $parentParamName = $parentParamNames[$key];
+            if ($parentParamName === $currentParamName) {
+                continue;
+            }
+
+            $missMatchingParamNames[] = new MissMatchingParamName($key, $currentParamName, $parentParamName);
+        }
+
+        return $missMatchingParamNames;
+    }
+}

--- a/packages/phpstan-rules/src/ParentGuard/ParentElementResolver/ParentMethodResolver.php
+++ b/packages/phpstan-rules/src/ParentGuard/ParentElementResolver/ParentMethodResolver.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\ParentGuard\ParentElementResolver;
 
+use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\Php\PhpMethodReflection;
+use Symplify\Astral\Naming\SimpleNameResolver;
 
 final class ParentMethodResolver
 {
+    public function __construct(
+        private SimpleNameResolver $simpleNameResolver
+    ) {
+    }
+
+    public function resolveFromClassMethod(Scope $scope, ClassMethod $classMethod): ?PhpMethodReflection
+    {
+        /** @var string $methodName */
+        $methodName = $this->simpleNameResolver->getName($classMethod);
+        return $this->resolve($scope, $methodName);
+    }
+
     public function resolve(Scope $scope, string $methodName): ?PhpMethodReflection
     {
         $classReflection = $scope->getClassReflection();

--- a/packages/phpstan-rules/src/Rules/Explicit/SameNamedParamFamilyRule.php
+++ b/packages/phpstan-rules/src/Rules/Explicit/SameNamedParamFamilyRule.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules\Explicit;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Symplify\Astral\Naming\SimpleNameResolver;
+use Symplify\PHPStanRules\ParentGuard\ParentElementResolver\ParentMethodResolver;
+use Symplify\PHPStanRules\Rules\AbstractSymplifyRule;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\SameNamedParamFamilyRuleTest
+ */
+final class SameNamedParamFamilyRule extends AbstractSymplifyRule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Arguments names conflicts with parent class method "%s". This will break named arguments';
+
+    public function __construct(
+        private ParentMethodResolver $parentMethodResolver,
+        private SimpleNameResolver $simpleNameResolver
+    ) {
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        // @see https://stitcher.io/blog/php-8-named-arguments#named-arguments-in-depth
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+interface SomeInterface
+{
+    public function run($value);
+}
+
+final class SomeClass implements SomeInterface
+{
+    public function run($differentValue)
+    {
+    }
+}
+CODE_SAMPLE
+             ,
+                <<<'CODE_SAMPLE'
+interface SomeInterface
+{
+    public function run($value);
+}
+
+final class SomeClass implements SomeInterface
+{
+    public function run($value)
+    {
+    }
+}
+CODE_SAMPLE
+            ),
+
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     * @return mixed[]
+     */
+    public function process(Node $node, Scope $scope): array
+    {
+        if ($this->shouldSkip($scope, $node)) {
+            return [];
+        }
+
+        $phpMethodReflection = $this->parentMethodResolver->resolveFromClassMethod($scope, $node);
+        if (! $phpMethodReflection instanceof PhpMethodReflection) {
+            return [];
+        }
+
+        $currentParamNames = $this->resolveClassMethodParamNames($node);
+        $parentParamNames = $this->resolveMethodReflectionParamNames($phpMethodReflection);
+
+        $conflictingParamNames = $this->resolveConflictingParamNames($currentParamNames, $parentParamNames);
+
+        // everything is the same
+        if ($conflictingParamNames === []) {
+            return [];
+        }
+
+        if (! $this->isContainerBuilderMissmatch($conflictingParamNames, $phpMethodReflection)) {
+            return [self::ERROR_MESSAGE];
+        }
+        return [];
+    }
+
+    /**
+     * @param string[] $conflictingParamNames
+     */
+    private function isContainerBuilderMissmatch(
+        array $conflictingParamNames,
+        PhpMethodReflection $phpMethodReflection
+    ): bool {
+        if ($conflictingParamNames !== ['containerBuilder']) {
+            return false;
+        }
+
+        $parentClassReflection = $phpMethodReflection->getDeclaringClass();
+        // the Container vs ContainerBuilder missmatch
+        return in_array($parentClassReflection->getName(), [
+            ExtensionInterface::class,
+            ConfigurationExtensionInterface::class,
+            Bundle::class,
+            BundleInterface::class,
+            Kernel::class,
+            CompilerPassInterface::class,
+        ], true);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveMethodReflectionParamNames(PhpMethodReflection $phpMethodReflection): array
+    {
+        $paramNames = [];
+
+        $firstVariant = $phpMethodReflection->getVariants()[0];
+        foreach ($firstVariant->getParameters() as $parameterReflectionWithPhpDoc) {
+            $paramNames[] = $parameterReflectionWithPhpDoc->getName();
+        }
+
+        return $paramNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function resolveClassMethodParamNames(ClassMethod $classMethod): array
+    {
+        $paramNames = [];
+        foreach ($classMethod->params as $param) {
+            /** @var string $paramName */
+            $paramName = $this->simpleNameResolver->getName($param->var);
+            $paramNames[] = $paramName;
+        }
+
+        return $paramNames;
+    }
+
+    private function shouldSkip(Scope $scope, ClassMethod $classMethod): bool
+    {
+        if ($classMethod->isMagic()) {
+            return true;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return true;
+        }
+
+        if ($classMethod->params === []) {
+            return true;
+        }
+
+        // no parent interface, class nor trait
+        return count($classReflection->getAncestors()) === 1;
+    }
+
+    /**
+     * @param string[] $currentParamNames
+     * @param string[] $parentParamNames
+     * @return string[]
+     */
+    private function resolveConflictingParamNames(array $currentParamNames, array $parentParamNames): array
+    {
+        $conflictingParamNames = array_diff($currentParamNames, $parentParamNames);
+
+        // reset index keys
+        return array_values($conflictingParamNames);
+    }
+}

--- a/packages/phpstan-rules/src/ValueObject/MissMatchingParamName.php
+++ b/packages/phpstan-rules/src/ValueObject/MissMatchingParamName.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ValueObject;
+
+final class MissMatchingParamName
+{
+    public function __construct(
+        private int $position,
+        private string $currentName,
+        private string $parentName
+    ) {
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function getCurrentName(): string
+    {
+        return $this->currentName;
+    }
+
+    public function getParentName(): string
+    {
+        return $this->parentName;
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/ClassWithDifferentParent.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/ClassWithDifferentParent.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Source\DifferentParent;
+
+final class ClassWithDifferentParent extends DifferentParent
+{
+    public function run($copy)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipContainerBuilderMissmatch.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipContainerBuilderMissmatch.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Fixture;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+
+final class SkipContainerBuilderMissmatch implements ConfigurationExtensionInterface
+{
+    public function getConfiguration(array $config, ContainerBuilder $containerBuilder)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipParentExtraNullableParam.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipParentExtraNullableParam.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Source\WithNullParam;
+
+final class SkipParentExtraNullableParam extends WithNullParam
+{
+    private function run($name)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipSomeClassWithoutParents.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipSomeClassWithoutParents.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Fixture;
+
+final class SkipSomeClassWithoutParents
+{
+    public function run($value)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipWithCompatibleParent.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Fixture/SkipWithCompatibleParent.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Source\DifferentParent;
+
+final class SkipWithCompatibleParent extends DifferentParent
+{
+    public function run($original)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/SameNamedParamFamilyRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/SameNamedParamFamilyRuleTest.php
@@ -28,6 +28,7 @@ final class SameNamedParamFamilyRuleTest extends AbstractServiceAwareRuleTestCas
         yield [__DIR__ . '/Fixture/SkipSomeClassWithoutParents.php', []];
         yield [__DIR__ . '/Fixture/SkipWithCompatibleParent.php', []];
         yield [__DIR__ . '/Fixture/SkipContainerBuilderMissmatch.php', []];
+        yield [__DIR__ . '/Fixture/SkipParentExtraNullableParam.php', []];
 
         yield [__DIR__ . '/Fixture/ClassWithDifferentParent.php', [[SameNamedParamFamilyRule::ERROR_MESSAGE, 11]]];
     }

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/SameNamedParamFamilyRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/SameNamedParamFamilyRuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Rules\Explicit\SameNamedParamFamilyRule;
+
+/**
+ * @extends AbstractServiceAwareRuleTestCase<SameNamedParamFamilyRule>
+ */
+final class SameNamedParamFamilyRuleTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @param array<string|int> $expectedErrorMessagesWithLines
+     */
+    public function testRule(string $filePath, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorMessagesWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        yield [__DIR__ . '/Fixture/SkipSomeClassWithoutParents.php', []];
+        yield [__DIR__ . '/Fixture/SkipWithCompatibleParent.php', []];
+        yield [__DIR__ . '/Fixture/SkipContainerBuilderMissmatch.php', []];
+
+        yield [__DIR__ . '/Fixture/ClassWithDifferentParent.php', [[SameNamedParamFamilyRule::ERROR_MESSAGE, 11]]];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(SameNamedParamFamilyRule::class, __DIR__ . '/config/configured_rule.neon');
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Source/DifferentParent.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Source/DifferentParent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Source;
+
+abstract class DifferentParent
+{
+    public function run($original)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Source/WithNullParam.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/Source/WithNullParam.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\SameNamedParamFamilyRule\Source;
+
+abstract class WithNullParam
+{
+    private function run($name, $surname = null)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/config/configured_rule.neon
@@ -1,0 +1,3 @@
+includes:
+    - ../../../../../config/symplify-rules.neon
+    - ../../../../../config/services/services.neon

--- a/packages/rule-doc-generator/src/DirectoryToMarkdownPrinter.php
+++ b/packages/rule-doc-generator/src/DirectoryToMarkdownPrinter.php
@@ -47,6 +47,7 @@ final class DirectoryToMarkdownPrinter
 
         // 2. create rule definition collection
         $this->symfonyStyle->note('Resolving rule definitions');
+
         $ruleDefinitions = $this->ruleDefinitionsResolver->resolveFromClassNames($documentedRuleClasses);
 
         // 3. print rule definitions to markdown lines

--- a/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CloningPhpDocNodeVisitor.php
+++ b/packages/simple-php-doc-parser/src/PhpDocNodeVisitor/CloningPhpDocNodeVisitor.php
@@ -13,10 +13,10 @@ use Symplify\SimplePhpDocParser\ValueObject\PhpDocAttributeKey;
  */
 final class CloningPhpDocNodeVisitor extends AbstractPhpDocNodeVisitor
 {
-    public function enterNode(Node $origNode): Node
+    public function enterNode(Node $node): Node
     {
-        $node = clone $origNode;
-        $node->setAttribute(PhpDocAttributeKey::ORIG_NODE, $origNode);
-        return $node;
+        $clonedNode = clone $node;
+        $clonedNode->setAttribute(PhpDocAttributeKey::ORIG_NODE, $node);
+        return $clonedNode;
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -8,6 +8,7 @@ use Rector\CodingStyle\Enum\PreferenceSelfThis;
 use Rector\CodingStyle\Rector\ClassMethod\UnSpreadOperatorRector;
 use Rector\CodingStyle\Rector\MethodCall\PreferThisOrSelfMethodCallRector;
 use Rector\Core\Configuration\Option;
+use Rector\Naming\Rector\ClassMethod\RenameParamToMatchTypeRector;
 use Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
@@ -110,6 +111,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         CallableThisArrayToAnonymousFunctionRector::class => [
             // not a callable, accidental array
             __DIR__ . '/packages/phpstan-rules/src/Rules/',
+        ],
+
+        // protected param rename to create miss-matching param names with parent class method
+        // @see https://github.com/symplify/symplify/pull/3429 - paths must be relative, so child process in specific directory skips it
+        RenameParamToMatchTypeRector::class => [
+            'src/Php/Type/NativeFunctionDynamicFunctionReturnTypeExtension.php',
+            'src/Printer/PhpParserPhpConfigPrinter.php',
+            'src/DependencyInjection/Loader/IdAwareXmlFileLoader.php',
         ],
     ]);
 };


### PR DESCRIPTION
What happens if you use different param name than the parent method?

```php
interface SomeInterface
{
    public function run($value);
}

final class SomeClass implements SomeInterface
{
    // here is not "$value" as in parent contract!
    public function run($differentValue)
    {
    }
}
```

↓


```php
new SomeClass(value: "boom");
```

## It will crash :boom: :exploding_head: 

<br>

Don't wait for a chance. 
Be ready for a change :+1:  :safety_vest: 