### PR TITLE
NoDynamicNameRule: added failing IIFE test-case

### DIFF
--- a/packages/phpstan-rules/src/TypeAnalyzer/CallableTypeAnalyzer.php
+++ b/packages/phpstan-rules/src/TypeAnalyzer/CallableTypeAnalyzer.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\ClosureType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use Symplify\Astral\NodeFinder\SimpleNodeFinder;
@@ -32,6 +33,10 @@ final class CallableTypeAnalyzer
         $unwrappedNameStaticType = $this->typeUnwrapper->unwrapNullableType($nameStaticType);
 
         if ($unwrappedNameStaticType instanceof CallableType) {
+            return true;
+        }
+
+        if ($unwrappedNameStaticType instanceof ClosureType) {
             return true;
         }
 

--- a/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipIIFE.php
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipIIFE.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoDynamicNameRule\Fixture;
+
+use Closure;
+
+final class SkipIIFE
+{
+    public function run(string $value)
+    {
+        return (function () use ($value) {
+           return $value;
+        })();
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipImmediatelyInvokedFunctionExpression.php
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipImmediatelyInvokedFunctionExpression.php
@@ -6,26 +6,10 @@ namespace Symplify\PHPStanRules\Tests\Rules\NoDynamicNameRule\Fixture;
 
 final class SkipImmediatelyInvokedFunctionExpression
 {
-    /**
-     * method copied from phpstan-src
-     */
     public function load(string $key, string $variableKey)
     {
         return (function (string $key, string $variableKey) {
-            [,, $filePath] = $this->getFilePaths($key);
-            if (!is_file($filePath)) {
-                return null;
-            }
-
-            $cacheItem = require $filePath;
-            if (!$cacheItem instanceof CacheItem) {
-                return null;
-            }
-            if (!$cacheItem->isVariableKeyValid($variableKey)) {
-                return null;
-            }
-
-            return $cacheItem->getData();
+            return "hello";
         })($key, $variableKey);
     }
 }

--- a/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipImmediatelyInvokedFunctionExpression.php
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipImmediatelyInvokedFunctionExpression.php
@@ -6,10 +6,26 @@ namespace Symplify\PHPStanRules\Tests\Rules\NoDynamicNameRule\Fixture;
 
 final class SkipImmediatelyInvokedFunctionExpression
 {
-    public function run(string $value)
+    /**
+     * method copied from phpstan-src
+     */
+    public function load(string $key, string $variableKey)
     {
-        return (function () use ($value) {
-           return $value;
-        })();
+        return (function (string $key, string $variableKey) {
+            [,, $filePath] = $this->getFilePaths($key);
+            if (!is_file($filePath)) {
+                return null;
+            }
+
+            $cacheItem = require $filePath;
+            if (!$cacheItem instanceof CacheItem) {
+                return null;
+            }
+            if (!$cacheItem->isVariableKeyValid($variableKey)) {
+                return null;
+            }
+
+            return $cacheItem->getData();
+        })($key, $variableKey);
     }
 }

--- a/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipImmediatelyInvokedFunctionExpression.php
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/Fixture/SkipImmediatelyInvokedFunctionExpression.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Tests\Rules\NoDynamicNameRule\Fixture;
 
-use Closure;
-
-final class SkipIIFE
+final class SkipImmediatelyInvokedFunctionExpression
 {
     public function run(string $value)
     {

--- a/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/NoDynamicNameRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/NoDynamicNameRuleTest.php
@@ -38,6 +38,7 @@ final class NoDynamicNameRuleTest extends AbstractServiceAwareRuleTestCase
         yield [__DIR__ . '/Fixture/SkipCallable.php', []];
         yield [__DIR__ . '/Fixture/SkipNullableClosure.php', []];
         yield [__DIR__ . '/Fixture/SkipForeachVariable.php', []];
+        yield [__DIR__ . '/Fixture/SkipImmediatelyInvokedFunctionExpression.php', []];
     }
 
     protected function getRule(): Rule


### PR DESCRIPTION
a immediately invoked function expression (IIFE) should not be considered a 'dynamic name'.