### PR TITLE
[PHPUnitUpgrader] Add support for PHPUnitUpgrader console app

### DIFF
--- a/packages/phpunit-upgrader/config/config.php
+++ b/packages/phpunit-upgrader/config/config.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+use Symplify\PHPUnitUpgrader\Console\PHPUnitUpgraderConsoleApplication;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
@@ -14,4 +17,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->load('Symplify\PHPUnitUpgrader\\', __DIR__ . '/../src')
         ->exclude([__DIR__ . '/../src/HttpKernel', __DIR__ . '/../src/ValueObject']);
+
+    $services->alias(Application::class, PHPUnitUpgraderConsoleApplication::class);
+    $services->set(CommandNaming::class);
 };

--- a/packages/phpunit-upgrader/src/Console/PHPUnitUpgraderConsoleApplication.php
+++ b/packages/phpunit-upgrader/src/Console/PHPUnitUpgraderConsoleApplication.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPUnitUpgrader\Console;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symplify\PackageBuilder\Console\Command\CommandNaming;
+
+final class PHPUnitUpgraderConsoleApplication extends Application
+{
+    /**
+     * @param Command[] $commands
+     */
+    public function __construct(CommandNaming $commandNaming, array $commands)
+    {
+        foreach ($commands as $command) {
+            $commandName = $commandNaming->resolveFromCommand($command);
+            $command->setName($commandName);
+
+            $this->add($command);
+        }
+
+        parent::__construct('PHPUnit Upgrader');
+    }
+}


### PR DESCRIPTION
Adds support for PHPUnitUpgrader console service
Fixes #3436 "You have requested a non-existent service "Symfony\Component\Console\Application""