### PR TITLE
StaticFixtureSplitter: reduce return types to SplFileInfo

### DIFF
--- a/packages/easy-ci/src/Latte/Analyzer/MissingClassStaticCallLatteAnalyzer.php
+++ b/packages/easy-ci/src/Latte/Analyzer/MissingClassStaticCallLatteAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\EasyCI\Latte\Analyzer;
 
 use Nette\Utils\Strings;
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\EasyCI\Latte\Contract\LatteAnalyzerInterface;
 use Symplify\EasyCI\Latte\ValueObject\LatteError;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -33,7 +34,7 @@ final class MissingClassStaticCallLatteAnalyzer implements LatteAnalyzerInterfac
         self::METHOD_KEY_PART . '>\w+)\(#m';
 
     /**
-     * @param SmartFileInfo[] $fileInfos
+     * @param SplFileInfo[] $fileInfos
      * @return LatteError[]
      */
     public function analyze(array $fileInfos): array

--- a/packages/easy-ci/src/Latte/ValueObject/LatteError.php
+++ b/packages/easy-ci/src/Latte/ValueObject/LatteError.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCI\Latte\ValueObject;
 
-use Symplify\SmartFileSystem\SmartFileInfo;
+use Symfony\Component\Finder\SplFileInfo;
 
 final class LatteError
 {
     public function __construct(
         private string $errorMessage,
-        private SmartFileInfo $smartFileInfo
+        private SplFileInfo $smartFileInfo
     ) {
     }
 
@@ -21,6 +21,6 @@ final class LatteError
 
     public function getRelativeFilePath(): string
     {
-        return $this->smartFileInfo->getRelativeFilePath();
+        return $this->smartFileInfo->getRelativePathname();
     }
 }

--- a/packages/easy-coding-standard/packages/FixerRunner/Application/FixerFileProcessor.php
+++ b/packages/easy-coding-standard/packages/FixerRunner/Application/FixerFileProcessor.php
@@ -13,6 +13,7 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
 use PhpCsFixer\Tokenizer\Token;
 use PhpCsFixer\Tokenizer\Tokens;
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
 use Symplify\EasyCodingStandard\Contract\Application\FileProcessorInterface;
 use Symplify\EasyCodingStandard\Error\FileDiffFactory;
@@ -175,7 +176,7 @@ final class FixerFileProcessor implements FileProcessorInterface
      * @param Tokens<Token> $tokens
      * @return bool If fixer applied
      */
-    private function processTokensByFixer(SmartFileInfo $smartFileInfo, Tokens $tokens, FixerInterface $fixer): bool
+    private function processTokensByFixer(SplFileInfo $smartFileInfo, Tokens $tokens, FixerInterface $fixer): bool
     {
         if ($this->shouldSkip($smartFileInfo, $fixer, $tokens)) {
             return false;
@@ -212,7 +213,7 @@ final class FixerFileProcessor implements FileProcessorInterface
     /**
      * @param Tokens<Token> $tokens
      */
-    private function shouldSkip(SmartFileInfo $smartFileInfo, FixerInterface $fixer, Tokens $tokens): bool
+    private function shouldSkip(SplFileInfo $smartFileInfo, FixerInterface $fixer, Tokens $tokens): bool
     {
         if ($this->skipper->shouldSkipElementAndFileInfo($fixer, $smartFileInfo)) {
             return true;

--- a/packages/easy-testing/src/StaticFixtureSplitter.php
+++ b/packages/easy-testing/src/StaticFixtureSplitter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\EasyTesting;
 
 use Nette\Utils\Strings;
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\EasyTesting\ValueObject\InputAndExpected;
 use Symplify\EasyTesting\ValueObject\InputFileInfoAndExpected;
 use Symplify\EasyTesting\ValueObject\InputFileInfoAndExpectedFileInfo;
@@ -64,7 +65,7 @@ final class StaticFixtureSplitter
         SmartFileInfo $fixtureSmartFileInfo,
         string $prefix,
         string $fileContent
-    ): SmartFileInfo {
+    ): SplFileInfo {
         $temporaryFilePath = self::createTemporaryPathWithPrefix($fixtureSmartFileInfo, $prefix);
 
         $smartFileSystem = new SmartFileSystem();

--- a/packages/easy-testing/src/ValueObject/InputFileInfoAndExpected.php
+++ b/packages/easy-testing/src/ValueObject/InputFileInfoAndExpected.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\EasyTesting\ValueObject;
 
-use Symplify\SmartFileSystem\SmartFileInfo;
+use Symfony\Component\Finder\SplFileInfo;
 
 final class InputFileInfoAndExpected
 {
@@ -12,7 +12,7 @@ final class InputFileInfoAndExpected
      * @param mixed $expected
      */
     public function __construct(
-        private SmartFileInfo $inputFileInfo,
+        private SplFileInfo $inputFileInfo,
         private $expected
     ) {
     }
@@ -22,7 +22,7 @@ final class InputFileInfoAndExpected
         return $this->inputFileInfo->getContents();
     }
 
-    public function getInputFileInfo(): SmartFileInfo
+    public function getInputFileInfo(): SplFileInfo
     {
         return $this->inputFileInfo;
     }

--- a/packages/easy-testing/src/ValueObject/InputFileInfoAndExpectedFileInfo.php
+++ b/packages/easy-testing/src/ValueObject/InputFileInfoAndExpectedFileInfo.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Symplify\EasyTesting\ValueObject;
 
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class InputFileInfoAndExpectedFileInfo
 {
     public function __construct(
-        private SmartFileInfo $inputFileInfo,
-        private SmartFileInfo $expectedFileInfo
+        private SplFileInfo $inputFileInfo,
+        private SplFileInfo $expectedFileInfo
     ) {
     }
 
-    public function getInputFileInfo(): SmartFileInfo
+    public function getInputFileInfo(): SplFileInfo
     {
         return $this->inputFileInfo;
     }
 
-    public function getExpectedFileInfo(): SmartFileInfo
+    public function getExpectedFileInfo(): SplFileInfo
     {
         return $this->expectedFileInfo;
     }

--- a/packages/latte-to-twig-converter/src/LatteToTwigConverter.php
+++ b/packages/latte-to-twig-converter/src/LatteToTwigConverter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\LatteToTwigConverter;
 
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\LatteToTwigConverter\Contract\CaseConverter\CaseConverterInterface;
 use Symplify\LatteToTwigConverter\Exception\ConfigurationException;
 use Symplify\SmartFileSystem\SmartFileInfo;
@@ -31,7 +32,7 @@ final class LatteToTwigConverter
         krsort($this->caseConverters);
     }
 
-    public function convertFile(SmartFileInfo $fileInfo): string
+    public function convertFile(SplFileInfo $fileInfo): string
     {
         $content = $fileInfo->getContents();
 

--- a/packages/phpunit-upgrader/src/FileInfoDecorator/SetUpTearDownVoidFileInfoDecorator.php
+++ b/packages/phpunit-upgrader/src/FileInfoDecorator/SetUpTearDownVoidFileInfoDecorator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\PHPUnitUpgrader\FileInfoDecorator;
 
 use Nette\Utils\Strings;
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
@@ -18,7 +19,7 @@ final class SetUpTearDownVoidFileInfoDecorator
      */
     private const VOID_LESS_REGEX = '#(?<method>setUp|tearDown)\(\)\n#i';
 
-    public function decorate(SmartFileInfo $fileInfo): string
+    public function decorate(SplFileInfo $fileInfo): string
     {
         return Strings::replace($fileInfo->getContents(), self::VOID_LESS_REGEX, "$1(): void\n");
     }

--- a/packages/skipper/src/Skipper/Skipper.php
+++ b/packages/skipper/src/Skipper/Skipper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\Skipper\Skipper;
 
+use Symfony\Component\Finder\SplFileInfo;
 use Symplify\Skipper\Contract\SkipVoterInterface;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
@@ -36,7 +37,7 @@ final class Skipper
         return $this->shouldSkipElementAndFileInfo(self::FILE_ELEMENT, $smartFileInfo);
     }
 
-    public function shouldSkipElementAndFileInfo(string | object $element, SmartFileInfo $smartFileInfo): bool
+    public function shouldSkipElementAndFileInfo(string | object $element, SplFileInfo $smartFileInfo): bool
     {
         foreach ($this->skipVoters as $skipVoter) {
             if ($skipVoter->match($element)) {


### PR DESCRIPTION
refs https://github.com/symplify/symplify/issues/3437

lets see how dependent the test-suite is on `SmartFileInfo`. maybe `SplFileInfo` is enough?

if `SplFileInfo` is enough we get room for some kind of `LazySplFileInfo` or similar, which we might use for the `createTemporaryFileInfo` case (holding a string-file-content internally, instead of writing everything to disc)