### PR TITLE
StaticFixtureSplitter: don't use `SmartFileSystem->dump()` for performance reasons

### DIFF
--- a/packages/easy-testing/src/StaticFixtureSplitter.php
+++ b/packages/easy-testing/src/StaticFixtureSplitter.php
@@ -67,6 +67,7 @@ final class StaticFixtureSplitter
     ): SmartFileInfo {
         $temporaryFilePath = self::createTemporaryPathWithPrefix($fixtureSmartFileInfo, $prefix);
 
+        mkdir(dirname($temporaryFilePath), 0777, true);
         /** @phpstan-ignore-next-line we don't use SmartFileSystem->dump() for performance reasons */
         file_put_contents($temporaryFilePath, $fileContent);
 

--- a/packages/easy-testing/src/StaticFixtureSplitter.php
+++ b/packages/easy-testing/src/StaticFixtureSplitter.php
@@ -67,7 +67,11 @@ final class StaticFixtureSplitter
     ): SmartFileInfo {
         $temporaryFilePath = self::createTemporaryPathWithPrefix($fixtureSmartFileInfo, $prefix);
 
-        mkdir(dirname($temporaryFilePath), 0777, true);
+        $dir = dirname($temporaryFilePath);
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        
         /** @phpstan-ignore-next-line we don't use SmartFileSystem->dump() for performance reasons */
         file_put_contents($temporaryFilePath, $fileContent);
 

--- a/packages/easy-testing/src/StaticFixtureSplitter.php
+++ b/packages/easy-testing/src/StaticFixtureSplitter.php
@@ -67,8 +67,8 @@ final class StaticFixtureSplitter
     ): SmartFileInfo {
         $temporaryFilePath = self::createTemporaryPathWithPrefix($fixtureSmartFileInfo, $prefix);
 
-        $smartFileSystem = new SmartFileSystem();
-        $smartFileSystem->dumpFile($temporaryFilePath, $fileContent);
+        /** @phpstan-ignore-next-line we don't use SmartFileSystem->dump() for performance reasons */
+        file_put_contents($temporaryFilePath, $fileContent);
 
         return new SmartFileInfo($temporaryFilePath);
     }


### PR DESCRIPTION
doing less file-IO in `StaticFixtureSplitter->createTemporaryFileInfo()`.

`SmartFileSystem->dump` gives us some gurantees like atomic file writes which protect writing files from race conditions when writing to the same file-path in parallel. this is not necessary for the StaticFixtureSplitter, and therefore using simpler primitives is faster.

with this change I can see a improvement of 2-3 seconds

![image](https://user-images.githubusercontent.com/47448731/127324931-4d79fefd-b673-4256-b02d-c4b7a3bb07e9.png)


refs https://github.com/symplify/symplify/issues/3437