### PR TITLE
Fix bug: `--git-dir` param does not exist

### DIFF
--- a/packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
+++ b/packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
@@ -25,13 +25,13 @@ final class ProcessRunner
     /**
      * @param string|string[] $commandLine
      */
-    public function run(string | array $commandLine): string
+    public function run(string | array $commandLine, ?string $cwd = null): string
     {
         if ($this->symfonyStyle->isVerbose()) {
             $this->symfonyStyle->note('Running process: ' . $this->normalizeToString($commandLine));
         }
 
-        $process = $this->createProcess($commandLine);
+        $process = $this->createProcess($commandLine, $cwd);
         $process->run();
 
         $this->reportResult($process);
@@ -54,14 +54,14 @@ final class ProcessRunner
     /**
      * @param string|string[] $commandLine
      */
-    private function createProcess(string | array $commandLine): Process
+    private function createProcess(string | array $commandLine, ?string $cwd = null): Process
     {
         // @since Symfony 4.2: https://github.com/symfony/symfony/pull/27821
         if (is_string($commandLine) && method_exists(Process::class, 'fromShellCommandline')) {
-            return Process::fromShellCommandline($commandLine, null, null, null, self::TIMEOUT);
+            return Process::fromShellCommandline($commandLine, $cwd, null, null, self::TIMEOUT);
         }
 
-        return new Process($commandLine, null, null, null, self::TIMEOUT);
+        return new Process($commandLine, $cwd, null, null, self::TIMEOUT);
     }
 
     private function reportResult(Process $process): void

--- a/packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
+++ b/packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
@@ -54,7 +54,7 @@ final class ProcessRunner
     /**
      * @param string|string[] $commandLine
      */
-    private function createProcess(string | array $commandLine, ?string $cwd = null): Process
+    private function createProcess(string | array $commandLine, ?string $cwd): Process
     {
         // @since Symfony 4.2: https://github.com/symfony/symfony/pull/27821
         if (is_string($commandLine) && method_exists(Process::class, 'fromShellCommandline')) {

--- a/packages/monorepo-builder/src/Git/MostRecentTagResolver.php
+++ b/packages/monorepo-builder/src/Git/MostRecentTagResolver.php
@@ -40,8 +40,8 @@ final class MostRecentTagResolver
 
         // Remove all "\r" chars in case the CLI env like the Windows OS.
         // Otherwise (ConEmu, git bash, mingw cli, e.g.), leave as is.
-        $tags = str_replace("\r", '', $tags);
+        $normalizedTags = str_replace("\r", '', $tags);
 
-        return explode("\n", $tags);
+        return explode("\n", $normalizedTags);
     }
 }

--- a/packages/monorepo-builder/src/Git/MostRecentTagResolver.php
+++ b/packages/monorepo-builder/src/Git/MostRecentTagResolver.php
@@ -19,13 +19,7 @@ final class MostRecentTagResolver
     public function resolve(string $gitDirectory): ?string
     {
         $command = ['git', 'tag', '-l', '--sort=committerdate'];
-
-        if (getcwd() !== $gitDirectory) {
-            $command[] = '--git-dir';
-            $command[] = $gitDirectory;
-        }
-
-        $tagList = $this->parseTags($this->processRunner->run($command));
+        $tagList = $this->parseTags($this->processRunner->run($command, $gitDirectory));
 
         /** @var string $theMostRecentTag */
         $theMostRecentTag = (string) array_pop($tagList);
@@ -46,8 +40,8 @@ final class MostRecentTagResolver
 
         // Remove all "\r" chars in case the CLI env like the Windows OS.
         // Otherwise (ConEmu, git bash, mingw cli, e.g.), leave as is.
-        $normalizedTags = str_replace("\r", '', $tags);
+        $tags = str_replace("\r", '', $tags);
 
-        return explode("\n", $normalizedTags);
+        return explode("\n", $tags);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -523,3 +523,4 @@ parameters:
         -
             message: '#Parameter "cwd" cannot be nullable#'
             path: packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
+            

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -519,3 +519,7 @@ parameters:
 
         - '#Method Symplify\\EasyCodingStandard\\FixerRunner\\Parser\\FileToTokensParser\:\:parseFromFilePath\(\) should return iterable<PhpCsFixer\\Tokenizer\\Token\>&PhpCsFixer\\Tokenizer\\Tokens but returns PhpCsFixer\\Tokenizer\\Tokens#'
         - '#Method Symplify\\CodingStandard\\TokenRunner\\Traverser\\ArrayBlockInfoFinder\:\:reverseTokens\(\) should return array<PhpCsFixer\\Tokenizer\\Token\> but returns array<int, PhpCsFixer\\Tokenizer\\Token\|null\>#'
+
+        -
+            message: '#Parameter "cwd" cannot be nullable#'
+            path: packages/monorepo-builder/packages/Release/Process/ProcessRunner.php


### PR DESCRIPTION
Option `--git-dir` does not exist when doing `git tag -l`.

## Error in detail

Executing this command:

```bash
git tag -l --sort=committerdate --git-dir <some dir>
```

thows an error:

```
The command "'git' 'tag' '-l' '--sort=committerdate' '--git-dir' '/Users/leo/GitRepos/GitHub/Project  
  s/leoloso/PRO/submodules/PoP'" failed.                                                                
                                                                                                        
  Exit Code: 129(Hangup)                                                                                
                                                                                                        
  Working directory: /Users/leo/GitRepos/GitHub/Projects/leoloso/PRO                                    
                                                                                                        
  Output:                                                                                               
  ================                                                                                      
                                                                                                        
                                                                                                        
  Error Output:                                                                                         
  ================                                                                                      
  error: unknown option `git-dir'                                                                       
  usage: git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]                                    
                <tagname> [<head>]                                                                                    
     or: git tag -d <tagname>...                                                                        
     or: git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--points-at <object>]   
                [--format=<format>] [--merged <commit>] [--no-merged <commit>] [<pattern>...]                         
     or: git tag -v [--format=<format>] <tagname>...                                                    
                                                                                                        
      -l, --list            list tag names                                                              
      -n[<n>]               print <n> lines of each tag message                                         
      -d, --delete          delete tags                                                                 
      -v, --verify          verify tags                                                                 
                                                                                                        
  Tag creation options                                                                                  
      -a, --annotate        annotated tag, needs a message                                              
      -m, --message <message>                                                                           
                            tag message                                                                 
      -F, --file <file>     read message from file                                                      
      -e, --edit            force edit of tag message                                                   
      -s, --sign            annotated and GPG-signed tag                                                
      --cleanup <mode>      how to strip spaces and #comments from message                              
      -u, --local-user <key-id>                                                                         
                            use another key to sign the tag                                             
      -f, --force           replace the tag if exists                                                   
      --create-reflog       create a reflog                                                             
                                                                                                        
  Tag listing options                                                                                   
      --column[=<style>]    show tag list in columns                                                    
      --contains <commit>   print only tags that contain the commit                                     
      --no-contains <commit>                                                                            
                            print only tags that don't contain the commit                               
      --merged <commit>     print only tags that are merged                                             
      --no-merged <commit>  print only tags that are not merged                                         
      --sort <key>          field name to sort on                                                       
      --points-at <object>  print only tags of the object                                               
      --format <format>     format to use for the output                                                
      --color[=<when>]      respect format colors                                                       
      -i, --ignore-case     sorting and filtering are case insensitive      
```

## Solution

Pass the `$cwd` to the `Process`, defaulting to `null` so the current behavior is still supported.