### PR TITLE
Unset cache in `JsonFileManager` after file contents are modified

### DIFF
--- a/packages/composer-json-manipulator/src/FileSystem/JsonFileManager.php
+++ b/packages/composer-json-manipulator/src/FileSystem/JsonFileManager.php
@@ -58,7 +58,10 @@ final class JsonFileManager
     {
         $jsonString = $this->encodeJsonToFileContent($json);
         $this->smartFileSystem->dumpFile($smartFileInfo->getPathname(), $jsonString);
-
+        
+        $realPath = $smartFileInfo->getRealPath();
+        unset($this->cachedJSONFiles[$realPath]);
+        
         return $jsonString;
     }
 

--- a/packages/monorepo-builder/tests/FileSystem/JsonFileManager/JsonFileManagerTest.php
+++ b/packages/monorepo-builder/tests/FileSystem/JsonFileManager/JsonFileManagerTest.php
@@ -47,6 +47,33 @@ final class JsonFileManagerTest extends AbstractKernelTestCase
         $this->assertSame($expectedJson, $loadedJsonFromFileInfo);
     }
 
+    public function testPrint(): void
+    {
+        $createdJson = [
+            'key' => 'value',
+        ];
+        $this->jsonFileManager->printJsonToFileInfo(
+            $createdJson,
+            new SmartFileInfo(__DIR__ . '/Source/dynamic.json')
+        );
+        $loadedJsonFromFileInfo = $this->jsonFileManager->loadFromFileInfo(
+            new SmartFileInfo(__DIR__ . '/Source/dynamic.json')
+        );
+        $this->assertSame($createdJson, $loadedJsonFromFileInfo);
+
+        $updatedJson = [
+            'key' => 'updatedValue',
+        ];
+        $this->jsonFileManager->printJsonToFileInfo(
+            $updatedJson,
+            new SmartFileInfo(__DIR__ . '/Source/dynamic.json')
+        );
+        $loadedJsonFromFileInfo = $this->jsonFileManager->loadFromFileInfo(
+            new SmartFileInfo(__DIR__ . '/Source/dynamic.json')
+        );
+        $this->assertSame($updatedJson, $loadedJsonFromFileInfo);
+    }
+
     public function testEncodeArrayToString(): void
     {
         $jsonContent = $this->jsonFileManager->encodeJsonToFileContent([

--- a/packages/monorepo-builder/tests/FileSystem/JsonFileManager/Source/dynamic.json
+++ b/packages/monorepo-builder/tests/FileSystem/JsonFileManager/Source/dynamic.json
@@ -1,0 +1,3 @@
+{
+    "key": "updatedValue"
+}


### PR DESCRIPTION
When doing this:

```php
$json = $this->jsonFileManager->loadFromFileInfo($packageComposerFileInfo);
```

The contents of the file are cached. If then they are modified, for instance here:

```php
$json = $this->processSectionWithPackages($json, $packageNames, $version, ComposerJsonSection::REQUIRE_DEV);

$this->jsonFileManager->printJsonToFileInfo($json, $packageComposerFileInfo);
```

Then the cache for that file must be purged. Otherwise, this code fails:

```php
// Read 1st time
$json = $this->jsonFileManager->loadFromFileInfo($packageComposerFileInfo);

// Do something ...
$json = $this->processSectionWithPackages($json, $packageNames, $version, ComposerJsonSection::REQUIRE_DEV);

// Save...
$this->jsonFileManager->printJsonToFileInfo($json, $packageComposerFileInfo);

// Read 2nd time
$json = $this->jsonFileManager->loadFromFileInfo($packageComposerFileInfo);

// ERROR: I got the contents from the cache, not the modified contents
```