### PR TITLE
Fixed bug: Do not remove "suggest" entry from `composer json`

### DIFF
--- a/packages/composer-json-manipulator/src/ComposerJsonFactory.php
+++ b/packages/composer-json-manipulator/src/ComposerJsonFactory.php
@@ -127,6 +127,10 @@ final class ComposerJsonFactory
             $composerJson->setScriptsDescriptions($jsonArray[ComposerJsonSection::SCRIPTS_DESCRIPTIONS]);
         }
 
+        if (isset($jsonArray[ComposerJsonSection::SUGGEST])) {
+            $composerJson->setSuggest($jsonArray[ComposerJsonSection::SUGGEST]);
+        }
+
         if (isset($jsonArray[ComposerJsonSection::MINIMUM_STABILITY])) {
             $composerJson->setMinimumStability($jsonArray[ComposerJsonSection::MINIMUM_STABILITY]);
         }

--- a/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
+++ b/packages/composer-json-manipulator/src/ValueObject/ComposerJson.php
@@ -122,6 +122,11 @@ final class ComposerJson
      */
     private $scriptsDescriptions = [];
 
+    /**
+     * @var array<string, string>
+     */
+    private $suggest = [];
+
     private ?string $version = null;
 
     public function __construct()
@@ -411,6 +416,7 @@ final class ComposerJson
             ComposerJsonSection::BIN => $this->bin,
             ComposerJsonSection::SCRIPTS => $this->scripts,
             ComposerJsonSection::SCRIPTS_DESCRIPTIONS => $this->scriptsDescriptions,
+            ComposerJsonSection::SUGGEST => $this->suggest,
             ComposerJsonSection::CONFIG => $this->config,
             ComposerJsonSection::REPLACE => $this->replace,
             ComposerJsonSection::CONFLICT => $this->conflicts,
@@ -664,6 +670,14 @@ final class ComposerJson
     }
 
     /**
+     * @return array<string, string>
+     */
+    public function getSuggest(): array
+    {
+        return $this->suggest;
+    }
+
+    /**
      * @return string[]
      */
     public function getAllClassmaps(): array
@@ -720,6 +734,14 @@ final class ComposerJson
     public function setScriptsDescriptions(array $scriptsDescriptions): void
     {
         $this->scriptsDescriptions = $scriptsDescriptions;
+    }
+
+    /**
+     * @param array<string, string> $suggest
+     */
+    public function setSuggest(array $suggest): void
+    {
+        $this->suggest = $suggest;
     }
 
     /**

--- a/packages/composer-json-manipulator/src/ValueObject/ComposerJsonSection.php
+++ b/packages/composer-json-manipulator/src/ValueObject/ComposerJsonSection.php
@@ -123,7 +123,7 @@ final class ComposerJsonSection
     /**
      * @var string
      */
-    public const SUGGESTS = 'suggests';
+    public const SUGGEST = 'suggest';
 
     /**
      * @var string

--- a/packages/monorepo-builder/config/parameters.php
+++ b/packages/monorepo-builder/config/parameters.php
@@ -47,7 +47,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ComposerJsonSection::REPLACE,
         ComposerJsonSection::SCRIPTS,
         ComposerJsonSection::SCRIPTS_DESCRIPTIONS,
-        ComposerJsonSection::SUGGESTS,
+        ComposerJsonSection::SUGGEST,
         ComposerJsonSection::CONFIG,
         ComposerJsonSection::MINIMUM_STABILITY,
         ComposerJsonSection::PREFER_STABLE,


### PR DESCRIPTION
There is a bug: When running `monorepo-builder release`, my `composer.json` files were having their `suggest` entry removed.

This PR adds support for this entry.

Please notice: there was param `SUGGESTS`, but in `composer.json` it is defined as `"suggest"`: https://getcomposer.org/doc/04-schema.md#suggest

So I renamed it. (This param was in fact not used anywhere.)