### PR TITLE
Deploy monorepo-builder to "original" repo

### DIFF
--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -46,10 +46,11 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
 
-            -   name: Set the repository name (always)
+            -   name: Set the repository name
                 run: |
                     echo "REPOSITORY_NAME=${{ matrix.package }}" >> $GITHUB_ENV
-            -   name: Set the repository name (for original packages)
+
+            -   name: Override the repository name (for original packages)
                 if: ${{ matrix.package == 'monorepo-builder' }}
                 run: |
                     echo "REPOSITORY_NAME=${{ matrix.package }}-original" >> $GITHUB_ENV

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -50,7 +50,7 @@ jobs:
                 run: |
                     echo "REPOSITORY_NAME=${{ matrix.package }}" >> $GITHUB_ENV
             -   name: Set the repository name (for original packages)
-                if: ${{ contains(matrix.package, 'monorepo-builder') }}
+                if: ${{ matrix.package == 'monorepo-builder' }}
                 run: |
                     echo "REPOSITORY_NAME=${{ matrix.package }}-original" >> $GITHUB_ENV
 

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -28,7 +28,7 @@ jobs:
             # get package json list
             -
                 id: output_data
-                run: echo "::set-output name=matrix::$(packages/monorepo-builder/bin/monorepo-builder packages-json --exclude-package easy-coding-standard --exclude-package monorepo-builder --exclude-package config-transformer)"
+                run: echo "::set-output name=matrix::$(packages/monorepo-builder/bin/monorepo-builder packages-json --exclude-package easy-coding-standard --exclude-package config-transformer)"
 
         # this step is needed, so the output gets to the next defined job
         outputs:
@@ -46,6 +46,14 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
 
+            -   name: Set the repository name (always)
+                run: |
+                    echo "REPOSITORY_NAME=${{ matrix.package }}" >> $GITHUB_ENV
+            -   name: Set the repository name (for original packages)
+                if: ${{ contains(matrix.package, 'monorepo-builder') }}
+                run: |
+                    echo "REPOSITORY_NAME=${{ matrix.package }}-original" >> $GITHUB_ENV
+
             # no tag
             -
                 if: "!startsWith(github.ref, 'refs/tags/')"
@@ -57,7 +65,7 @@ jobs:
                 with:
                     package-directory: 'packages/${{ matrix.package }}'
                     split-repository-organization: 'symplify'
-                    split-repository-name: '${{ matrix.package }}'
+                    split-repository-name: '${{ env.REPOSITORY_NAME }}'
                     user-name: "GitHub Action"
                     user-email: "action@github.com"
                     branch: "main"
@@ -75,7 +83,7 @@ jobs:
 
                     package-directory: 'packages/${{ matrix.package }}'
                     split-repository-organization: 'symplify'
-                    split-repository-name: '${{ matrix.package }}'
+                    split-repository-name: '${{ env.REPOSITORY_NAME }}'
                     user-name: "GitHub Action"
                     user-email: "action@github.com"
                     branch: "main"


### PR DESCRIPTION
@TomasVotruba While sleeping last night I dreamt with a beautifully simple solution for #3468 :)

No need to duplicate any workflow or anything, just keep doing `split_monorepo` also on package `monorepo-builder`, but for that package, set the `split-repository-name` to `${{ matrix.package}}-original` instead.

How do you like it? You should create `symplify/monorepo-builder-original` 🙏