### PR TITLE
Language fix

### DIFF
--- a/packages/phpstan-rules/src/Rules/NoNullablePropertyRule.php
+++ b/packages/phpstan-rules/src/Rules/NoNullablePropertyRule.php
@@ -20,7 +20,7 @@ final class NoNullablePropertyRule extends AbstractSymplifyRule
     /**
      * @var string
      */
-    public const ERROR_MESSAGE = 'Use required typed property over of nullable property';
+    public const ERROR_MESSAGE = 'Use required typed property instead of nullable property';
 
     public function __construct(
         private EntityClassDetector $entityClassDetector


### PR DESCRIPTION
Actually, I'm not sure what this rule is about ;-) It looks like it's telling me to replace `private ?int $id;` with what? `private int $id;`?