### PR TITLE
AssignmentInConditionSniff should throw errors on warnings

### DIFF
--- a/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
+++ b/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
@@ -8,6 +8,7 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File as BaseFile;
 use PHP_CodeSniffer\Fixer;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff;
 use PHP_CodeSniffer\Util\Common;
@@ -28,7 +29,11 @@ final class File extends BaseFile
      *
      * @var array<class-string<Sniff>>
      */
-    private const REPORT_WARNINGS_SNIFFS = [PropertyDeclarationSniff::class, MethodDeclarationSniff::class];
+    private const REPORT_WARNINGS_SNIFFS = [
+        AssignmentInConditionSniff::class,
+        PropertyDeclarationSniff::class,
+        MethodDeclarationSniff::class,
+    ];
 
     /**
      * @var string

--- a/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
+++ b/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
@@ -8,7 +8,6 @@ use PHP_CodeSniffer\Config;
 use PHP_CodeSniffer\Files\File as BaseFile;
 use PHP_CodeSniffer\Fixer;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff;
 use PHP_CodeSniffer\Util\Common;
@@ -30,7 +29,7 @@ final class File extends BaseFile
      * @var array<class-string<Sniff>>
      */
     private const REPORT_WARNINGS_SNIFFS = [
-        AssignmentInConditionSniff::class,
+        '\PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff',
         PropertyDeclarationSniff::class,
         MethodDeclarationSniff::class,
     ];


### PR DESCRIPTION
as mentioned in issue #3242, AssignmentInConditionSniff was removed from list of sniffs that only throw warnings in PR #3173
this PR adds it back in