### PR TITLE
[PHPStanRules] Skip existing property in false positive reporting of missing twig method

### DIFF
--- a/packages/phpstan-rules/packages/symfony/src/Twig/TwigNodeVisitor/MissingMethodCallNodeVisitor.php
+++ b/packages/phpstan-rules/packages/symfony/src/Twig/TwigNodeVisitor/MissingMethodCallNodeVisitor.php
@@ -85,6 +85,10 @@ final class MissingMethodCallNodeVisitor implements NodeVisitorInterface
             return $node;
         }
 
+        if ($variableType->hasProperty($methodName)->yes()) {
+            return $node;
+        }
+
         $variableTypeClassName = $variableType->getClassName();
         $this->variableAndMissingMethodNames[] = new VariableAndMissingMethodName(
             $variableName,

--- a/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/Fixture/SkipExistingProperty.php
+++ b/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/Fixture/SkipExistingProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Symfony\Tests\Rules\NoTwigMissingMethodCallRule\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symplify\PHPStanRules\Symfony\Tests\Rules\NoTwigMissingMethodCallRule\Source\SomeType;
+
+final class SkipExistingProperty extends AbstractController
+{
+    public function __invoke()
+    {
+        return $this->render(__DIR__ . '/../Source/skip_existing_property.twig', [
+            'some_type' => new SomeType()
+        ]);
+    }
+}

--- a/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/NoTwigMissingMethodCallRuleTest.php
+++ b/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/NoTwigMissingMethodCallRuleTest.php
@@ -43,6 +43,7 @@ final class NoTwigMissingMethodCallRuleTest extends AbstractServiceAwareRuleTest
         yield [__DIR__ . '/Fixture/SomeForeachMissingVariableController.php', $errorMessages];
 
         yield [__DIR__ . '/Fixture/SkipExistingMethod.php', []];
+        yield [__DIR__ . '/Fixture/SkipExistingProperty.php', []];
     }
 
     protected function getRule(): Rule

--- a/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/Source/SomeType.php
+++ b/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/Source/SomeType.php
@@ -6,6 +6,8 @@ namespace Symplify\PHPStanRules\Symfony\Tests\Rules\NoTwigMissingMethodCallRule\
 
 final class SomeType
 {
+    public $some_property;
+
     public function getExistingMethod()
     {
     }

--- a/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/Source/skip_existing_property.twig
+++ b/packages/phpstan-rules/packages/symfony/tests/Rules/NoTwigMissingMethodCallRule/Source/skip_existing_property.twig
@@ -1,0 +1,1 @@
+some {{ some_type.some_property }}


### PR DESCRIPTION
Closes https://github.com/symplify/symplify/issues/3534