### PR TITLE
Using non-prefixed class for ComposerJsonSection (fixes #3474)

### DIFF
--- a/packages/monorepo-builder/scoper.php
+++ b/packages/monorepo-builder/scoper.php
@@ -36,6 +36,8 @@ return [
         'Symplify\MonorepoBuilder\*',
         // part of public API in \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface
         'PharIo\Version\*',
+        // needed by the monorepo-builder command (avoid failing with a "class not found" error)
+        'Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection',
     ],
     'patchers' => [
         // unprefix polyfill functions


### PR DESCRIPTION
I had the same issue as #3474 and this is my attempt to fix it.
I tried to understand the suggestions by @TomasVotruba, but I don't know anything about [PHP Scoper](https://github.com/humbug/php-scoper) and the structure of this repo is a bit advanced for my skills so I hope I did the right thing.

If I understand correctly, PHP Scoper wraps the whole dependencies of a project under a custom namespace and allows you to build a self-contained packaged with no conflict with the project in which you install it. This cannot be done at runtime, so I can't test any change to the `scoper.php` file without building the "scoped" package locally. _(Is this correct??)_
I cloned the repo and run the commands found in [`build_monorepo_builder_prefixed.yaml`](https://github.com/symplify/symplify/blob/main/.github/workflows/build_monorepo_builder_prefixed.yaml) to simulate the build behavior and then I linked my project to the `monorepo-builder-prefixed-downgraded` folder.

Without my changes, any attempt to run `bin/monorepo-builder` in my project ends up with:
```bash
> vendor/bin/monorepo-builder merge

                                                                                                                        
 [ERROR] Class "Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection" not found                             
                                                                                                                        
```

With my changes it seems to work correctly:
```bash
> vendor/bin/monorepo-builder merge

                                                                                                                        
 [OK] Main "composer.json" was updated.                                                                                 
                                                                                                                                                      
```

Thank you for your time.