### PR TITLE
Bumping `phpstan/phpdoc-parser` to `^1.0`

### DIFF
--- a/packages/phpstan-rules/composer.json
+++ b/packages/phpstan-rules/composer.json
@@ -9,7 +9,7 @@
         "latte/latte": "^2.10",
         "twig/twig": "^3.3",
         "nette/utils": "^3.2",
-        "phpstan/phpdoc-parser": "^0.5",
+        "phpstan/phpdoc-parser": "^1.0",
         "phpstan/phpstan": "^0.12.91",
         "symplify/astral": "^9.5",
         "symplify/composer-json-manipulator": "^9.5",


### PR DESCRIPTION
See https://github.com/symplify/symplify/issues/3581
I haven't tested it ;-)