### PR TITLE
[PHPStanRules] Use last latte line if no latte line found in doc or there is no doc

### DIFF
--- a/packages/phpstan-rules/packages/latte-phpstan-printer/src/PhpParser/NodeVisitor/LatteLineNumberNodeVisitor.php
+++ b/packages/phpstan-rules/packages/latte-phpstan-printer/src/PhpParser/NodeVisitor/LatteLineNumberNodeVisitor.php
@@ -41,14 +41,18 @@ final class LatteLineNumberNodeVisitor extends NodeVisitorAbstract
         $docComment = $node->getDocComment();
 
         if (! $docComment instanceof Doc) {
-            $this->phpLinesToLatteLines[$node->getStartLine()] = $this->lastLatteLine;
+            if ($this->lastLatteLine !== null) {
+                $this->phpLinesToLatteLines[$node->getStartLine()] = $this->lastLatteLine;
+            }
             return null;
         }
 
         $docCommentText = $docComment->getText();
         $latteLine = $this->lineCommentMatcher->matchLine($docCommentText);
         if ($latteLine === null) {
-            $this->phpLinesToLatteLines[$node->getStartLine()] = $this->lastLatteLine;
+            if ($this->lastLatteLine !== null) {
+                $this->phpLinesToLatteLines[$node->getStartLine()] = $this->lastLatteLine;
+            }
             return null;
         }
 

--- a/packages/phpstan-rules/packages/latte-phpstan-printer/src/PhpParser/NodeVisitor/LatteLineNumberNodeVisitor.php
+++ b/packages/phpstan-rules/packages/latte-phpstan-printer/src/PhpParser/NodeVisitor/LatteLineNumberNodeVisitor.php
@@ -17,6 +17,8 @@ final class LatteLineNumberNodeVisitor extends NodeVisitorAbstract
      */
     private array $phpLinesToLatteLines = [];
 
+    private ?int $lastLatteLine = null;
+
     public function __construct(
         private LineCommentMatcher $lineCommentMatcher
     ) {
@@ -39,16 +41,19 @@ final class LatteLineNumberNodeVisitor extends NodeVisitorAbstract
         $docComment = $node->getDocComment();
 
         if (! $docComment instanceof Doc) {
+            $this->phpLinesToLatteLines[$node->getStartLine()] = $this->lastLatteLine;
             return null;
         }
 
         $docCommentText = $docComment->getText();
         $latteLine = $this->lineCommentMatcher->matchLine($docCommentText);
         if ($latteLine === null) {
+            $this->phpLinesToLatteLines[$node->getStartLine()] = $this->lastLatteLine;
             return null;
         }
 
         $this->phpLinesToLatteLines[$node->getStartLine()] = $latteLine;
+        $this->lastLatteLine = $latteLine;
 
         return null;
     }

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRule/LatteCompleteCheckRuleTest.php
@@ -36,7 +36,7 @@ final class LatteCompleteCheckRuleTest extends AbstractServiceAwareRuleTestCase
             'Parameter #1 $name of method %s::render() expects string, int given.',
             InvalidControlRenderArguments::class
         );
-        yield [__DIR__ . '/Fixture/InvalidControlRenderArguments.php', [[$errorMessage, 25]]];
+        yield [__DIR__ . '/Fixture/InvalidControlRenderArguments.php', [[$errorMessage, 1]]];
 
         yield [__DIR__ . '/Fixture/SkipExistingMethodCall.php', []];
         yield [__DIR__ . '/Fixture/SkipVariableInBlockControl.php', []];


### PR DESCRIPTION
Fix for controls, where in compiled file there is only one comment above control assign, but not above method calls redrawControl() and render().

```php
/** line in latte file: 23 */
/* line 23 */
$abcControl = $this->global->uiControl->getComponent("abc");
if ($abcControl instanceof \Nette\Application\UI\IRenderable) {
    $abcControl->redrawControl(\null, \false);
}
$abcControl->render('xxx');
```

It causes wrong line numbers in error output.