### PR TITLE
[PHPStanRules] Do not suppress errors in latte (might not be defined and has an unused variable)

### DIFF
--- a/packages/phpstan-rules/packages/nette/src/Rules/LatteCompleteCheckRule.php
+++ b/packages/phpstan-rules/packages/nette/src/Rules/LatteCompleteCheckRule.php
@@ -50,9 +50,6 @@ final class LatteCompleteCheckRule extends AbstractSymplifyRule
         '#Ternary operator condition is always (.*?)#',
         '#Access to an undefined property Latte\\\\Runtime\\\\FilterExecutor::#',
         '#Anonymous function should have native return typehint "void"#',
-        // impossible to resolve with conditions in PHP
-        '#might not be defined#',
-        '#has an unused variable#',
     ];
 
     private TemplateRulesRegistry $templateRulesRegistry;


### PR DESCRIPTION
I don't get it why to ignore these errors. Imho that's why we are doing this latte check by phpstan or not? Undefined variable is one of most errors in latte, we should not ignore it. Not sure what that second one is, but it is probably something similar :)