### PR TITLE
[TwigPHPStanCompiler] Add twig comment

### DIFF
--- a/packages/twig-phpstan-compiler/src/PhpParser/NodeVisitor/ReplaceEchoWithVarDocTypeNodeVisitor.php
+++ b/packages/twig-phpstan-compiler/src/PhpParser/NodeVisitor/ReplaceEchoWithVarDocTypeNodeVisitor.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\TwigPHPStanCompiler\PhpParser\NodeVisitor;
+
+use Nette\Utils\Strings;
+use PhpParser\Comment;
+use PhpParser\Node;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Echo_;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\NodeVisitorAbstract;
+use Symplify\Astral\ValueObject\AttributeKey;
+use Symplify\TwigPHPStanCompiler\TwigToPhpCompiler;
+use Symplify\TwigPHPStanCompiler\ValueObject\VarTypeDoc;
+
+final class ReplaceEchoWithVarDocTypeNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node)
+    {
+        if (! $node instanceof Echo_) {
+            return null;
+        }
+
+        if (count($node->exprs) !== 1) {
+            return null;
+        }
+
+        if (! $node->exprs[0] instanceof String_) {
+            return null;
+        }
+
+        $string = $node->exprs[0];
+
+        $match = Strings::match($string->value, TwigToPhpCompiler::TWIG_VAR_TYPE_DOCBLOCK_REGEX);
+        if ($match === null) {
+            return null;
+        }
+
+        $varTypeDoc = new VarTypeDoc($match['name'], $match['type']);
+
+        $varDoc = sprintf('/** @var %s $%s */', $varTypeDoc->getType(), $varTypeDoc->getVariableName());
+
+        $comments = $node->getComments();
+        $comments[] = new Comment($varDoc);
+
+        $nop = new Nop();
+        $nop->setAttribute(AttributeKey::COMMENTS, $comments);
+
+        return $nop;
+    }
+}

--- a/packages/twig-phpstan-compiler/src/ValueObject/VarTypeDoc.php
+++ b/packages/twig-phpstan-compiler/src/ValueObject/VarTypeDoc.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\TwigPHPStanCompiler\ValueObject;
+
+final class VarTypeDoc
+{
+    public function __construct(
+        private string $variableName,
+        private string $type
+    ) {
+    }
+
+    public function getVariableName(): string
+    {
+        return $this->variableName;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Fixture/var_doc_variable.twig
+++ b/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Fixture/var_doc_variable.twig
@@ -1,4 +1,5 @@
-{% include "_some_file.twig" with { posts: posts } %}
+{# @var someValue \Symplify\TwigPHPStanCompiler\Tests\TwigToPhpCompiler\Source\SomeDocType  #}
+{{ someValue.name }}
 -----
 <?php
 
@@ -13,7 +14,7 @@ use Twig\Sandbox\SecurityNotAllowedFilterError;
 use Twig\Sandbox\SecurityNotAllowedFunctionError;
 use Twig\Source;
 use Twig\Template;
-/* /tmp/_temp_fixture_easy_testing/input_%s_included_file.twig */
+/* /tmp/_temp_fixture_easy_testing/input_%s_var_doc_variable.twig */
 class __TwigTemplate_%s extends \Twig\Template
 {
     private $source;
@@ -30,11 +31,14 @@ class __TwigTemplate_%s extends \Twig\Template
         extract($context);
         $macros = $this->macros;
         // line 1
-        $this->loadTemplate("_some_file.twig", "/tmp/_temp_fixture_easy_testing/input_%s_included_file.twig", 1)->display(\twig_array_merge($context, ["posts" => $posts]));
+        /** @var \Symplify\TwigPHPStanCompiler\Tests\TwigToPhpCompiler\Source\SomeDocType $someValue */
+        // line 2
+        echo \strlen($someValue->name(), "html", \null, \true);
+        echo "\n";
     }
     public function getTemplateName()
     {
-        return "/tmp/_temp_fixture_easy_testing/input_%s_included_file.twig";
+        return "/tmp/_temp_fixture_easy_testing/input_%s_var_doc_variable.twig";
     }
     public function isTraitable()
     {
@@ -42,10 +46,10 @@ class __TwigTemplate_%s extends \Twig\Template
     }
     public function getDebugInfo()
     {
-        return array(37 => 1);
+        return array(40 => 2, 37 => 1);
     }
     public function getSourceContext()
     {
-        return new \Twig\Source("", "/tmp/_temp_fixture_easy_testing/input_%s_included_file.twig", "");
+        return new \Twig\Source("", "/tmp/_temp_fixture_easy_testing/input_%s_var_doc_variable.twig", "");
     }
 }

--- a/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Source/SomeDocType.php
+++ b/packages/twig-phpstan-compiler/tests/TwigToPhpCompiler/Source/SomeDocType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\TwigPHPStanCompiler\Tests\TwigToPhpCompiler\Source;
+
+final class SomeDocType
+{
+    public function getName()
+    {
+    }
+}


### PR DESCRIPTION
Unfortunately, the Twig parser removes all the comments from original Twig template.
Along with them also useful comments like:

```html
{# @var name string #}
```

That are seen by Symfony plugin as:

```php
/** @var string $name */
```

This PR tried to get them back :) 