### PR TITLE
[PHPStanRules] Test specific rule only

### DIFF
--- a/packages/phpstan-rules/tests/Rules/AnnotateRegexClassConstWithRegexLinkRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/AnnotateRegexClassConstWithRegexLinkRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\AnnotateRegexClassConstWithRegexLinkRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/BoolishClassMethodPrefixRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/BoolishClassMethodPrefixRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\BoolishClassMethodPrefixRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckClassNamespaceFollowPsr4Rule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckClassNamespaceFollowPsr4Rule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckClassNamespaceFollowPsr4Rule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckConstantExpressionDefinedInConstructOrSetupRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckConstantExpressionDefinedInConstructOrSetupRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckConstantExpressionDefinedInConstructOrSetupRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckNotTestsNamespaceOutsideTestsDirectoryRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckParentChildMethodParameterTypeCompatibleRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckParentChildMethodParameterTypeCompatibleRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckParentChildMethodParameterTypeCompatibleRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckRequiredInterfaceInContractNamespaceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckRequiredInterfaceInContractNamespaceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckRequiredInterfaceInContractNamespaceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckRequiredMethodNamingRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckRequiredMethodNamingRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckRequiredMethodNamingRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/CheckTypehintCallerTypeRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\CheckTypehintCallerTypeRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ClassNameRespectsParentSuffixRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ClassNameRespectsParentSuffixRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ClassNameRespectsParentSuffixRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenArrayMethodCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenArrayMethodCallRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\ForbiddenArrayMethodCallRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenComplexForeachIfExprRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenComplexForeachIfExprRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\ForbiddenComplexForeachIfExprRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenInlineClassMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenInlineClassMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\ForbiddenInlineClassMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenSameNamedAssignRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenSameNamedAssignRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\ForbiddenSameNamedAssignRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenSameNamedNewInstanceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/ForbiddenSameNamedNewInstanceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\ForbiddenSameNamedNewInstanceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/NoAbstractRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/NoAbstractRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\NoAbstractRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/NoDuplicatedArgumentRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/NoDuplicatedArgumentRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\NoDuplicatedArgumentRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/NoMirrorAssertRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/NoMirrorAssertRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\NoMirrorAssertRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Complexity/NoParentDuplicatedTraitUseRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Complexity/NoParentDuplicatedTraitUseRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Complexity\NoParentDuplicatedTraitUseRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ConstantMapRuleRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ConstantMapRuleRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ConstantMapRuleRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/DifferentMethodNameToParameterRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/DifferentMethodNameToParameterRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\DifferentMethodNameToParameterRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Domain/RequireAttributeNamespaceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Domain/RequireAttributeNamespaceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Domain\RequireAttributeNamespaceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Domain/RequireExceptionNamespaceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Domain/RequireExceptionNamespaceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Domain\RequireExceptionNamespaceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Enum/EmbeddedEnumClassConstSpotterRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Enum/EmbeddedEnumClassConstSpotterRule/config/configured_rule.neon
@@ -7,5 +7,4 @@ services:
                 - Symplify\PHPStanRules\Tests\Rules\Enum\EmbeddedEnumClassConstSpotterRule\Source\SomeParentObject
 
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon

--- a/packages/phpstan-rules/tests/Rules/Enum/RequireUniqueEnumConstantRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Enum/RequireUniqueEnumConstantRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Enum\RequireUniqueEnumConstantRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Explicit/RequireSpecificReturnTypeOverAbstractRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Explicit/RequireSpecificReturnTypeOverAbstractRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\RequireSpecificReturnTypeOverAbstractRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Explicit/SameNamedParamFamilyRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\SameNamedParamFamilyRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Explicit/ValueObjectOverArrayShapeRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Explicit/ValueObjectOverArrayShapeRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Explicit\ValueObjectOverArrayShapeRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenAnonymousClassRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenAnonymousClassRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenAnonymousClassRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenArrayDestructRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenArrayDestructRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenArrayDestructRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenArrayWithStringKeysRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenArrayWithStringKeysRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenArrayWithStringKeysRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenComplexArrayConfigInSetRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenComplexArrayConfigInSetRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenComplexArrayConfigInSetRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenMethodCallOnNewRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenMethodCallOnNewRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenMethodCallOnNewRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenMultipleClassLikeInOneFileRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenMultipleClassLikeInOneFileRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenNestedCallInAssertMethodCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenNestedCallInAssertMethodCallRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenNestedCallInAssertMethodCallRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenNestedForeachWithEmptyStatementRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenNestedForeachWithEmptyStatementRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenNestedForeachWithEmptyStatementRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenNodeRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenNodeRule/config/configured_rule.neon
@@ -1,3 +1,12 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenNodeRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            forbiddenNodes:
+                - PhpParser\Node\Expr\Empty_
+                - PhpParser\Node\Stmt\Switch_
+                - PhpParser\Node\Expr\ErrorSuppress

--- a/packages/phpstan-rules/tests/Rules/ForbiddenProtectedPropertyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenProtectedPropertyRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenProtectedPropertyRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenReturnValueOfIncludeOnceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenReturnValueOfIncludeOnceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenReturnValueOfIncludeOnceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenSpreadOperatorRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenSpreadOperatorRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenSpreadOperatorRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenTestsNamespaceOutsideTestsDirectoryRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenTestsNamespaceOutsideTestsDirectoryRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenTestsNamespaceOutsideTestsDirectoryRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/ForbiddenThisArgumentRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenThisArgumentRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenThisArgumentRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/MatchingTypeConstantRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/MatchingTypeConstantRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\MatchingTypeConstantRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckReferencedClassInAnnotationRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckReferencedClassInAnnotationRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Missing\CheckReferencedClassInAnnotationRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprinfMatchingTypesRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprinfMatchingTypesRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Missing\CheckSprinfMatchingTypesRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Naming/DifferentMethodNameToReturnTypeRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Naming/DifferentMethodNameToReturnTypeRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Naming\DifferentMethodNameToReturnTypeRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoAbstractMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoAbstractMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoAbstractMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoArrayAccessOnObjectRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoArrayAccessOnObjectRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoArrayAccessOnObjectRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoArrayStringObjectReturnRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoArrayStringObjectReturnRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoArrayStringObjectReturnRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoBinaryOpCallCompareRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoBinaryOpCallCompareRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoBinaryOpCallCompareRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoClassWithStaticMethodWithoutStaticNameRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoClassWithStaticMethodWithoutStaticNameRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoClassWithStaticMethodWithoutStaticNameRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoConstantInterfaceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoConstantInterfaceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoConstantInterfaceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoConstructorInTestRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoConstructorInTestRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoConstructorInTestRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoContainerInjectionInConstructorRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoContainerInjectionInConstructorRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoContainerInjectionInConstructorRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoDefaultExceptionRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoDefaultExceptionRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoDefaultExceptionRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoDependencyJugglingRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoDependencyJugglingRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoDependencyJugglingRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicNameRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoDynamicNameRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoDynamicPropertyOnStaticCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoDynamicPropertyOnStaticCallRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoDynamicPropertyOnStaticCallRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoEmptyClassRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoEmptyClassRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoEmptyClassRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoFactoryInConstructorRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoFuncCallInMethodCallRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoFuncCallInMethodCallRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoGetRepositoryOutsideConstructorRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoGetRepositoryOutsideConstructorRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoGetRepositoryOutsideConstructorRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoInlineStringRegexRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoInlineStringRegexRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoInlineStringRegexRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoIssetOnObjectRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoIssetOnObjectRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoIssetOnObjectRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoMagicClosureRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoMagicClosureRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoMagicClosureRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoMaskWithoutSprintfRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoMaskWithoutSprintfRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoMaskWithoutSprintfRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoMethodTagInClassDocblockRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoMethodTagInClassDocblockRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoMethodTagInClassDocblockRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoMissingDirPathRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoMissingDirPathRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoMissingDirPathRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoModifyAndReturnSelfObjectRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoModifyAndReturnSelfObjectRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoModifyAndReturnSelfObjectRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoMultiArrayAssignRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoMultiArrayAssignRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoMultiArrayAssignRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoNestedFuncCallRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoNestedFuncCallRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoNullableArrayPropertyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoNullableArrayPropertyRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoNullableArrayPropertyRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoNullablePropertyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoNullablePropertyRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoNullablePropertyRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoParentMethodCallOnEmptyStatementInParentMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoParentMethodCallOnEmptyStatementInParentMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoParentMethodCallOnEmptyStatementInParentMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoParentMethodCallOnNoOverrideProcessRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoParentMethodCallOnNoOverrideProcessRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoParentMethodCallOnNoOverrideProcessRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoPostIncPostDecRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoPostIncPostDecRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoPostIncPostDecRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoProtectedElementInFinalClassRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoProtectedElementInFinalClassRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoProtectedElementInFinalClassRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoReferenceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoReferenceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoReferenceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoReturnArrayVariableListRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoReturnArrayVariableListRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoReturnArrayVariableListRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoReturnSetterMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoReturnSetterMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoReturnSetterMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoSetterOnServiceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoSetterOnServiceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoSetterOnServiceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoStaticPropertyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoStaticPropertyRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoStaticPropertyRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoSuffixValueObjectClassRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoSuffixValueObjectClassRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoSuffixValueObjectClassRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoTraitRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoTraitRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoTraitRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/NoVoidGetterMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\NoVoidGetterMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/PreferredRawDataInTestDataProviderRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/PreferredRawDataInTestDataProviderRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\PreferredRawDataInTestDataProviderRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/PrefixAbstractClassRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/PrefixAbstractClassRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\PrefixAbstractClassRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/PreventDoubleSetParameterRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/PreventDoubleSetParameterRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\PreventDoubleSetParameterRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/PreventDuplicateClassMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/PreventDuplicateClassMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\PreventDuplicateClassMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/PreventParentMethodVisibilityOverrideRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/PreventParentMethodVisibilityOverrideRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\PreventParentMethodVisibilityOverrideRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RegexSuffixInRegexConstantRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RegexSuffixInRegexConstantRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RegexSuffixInRegexConstantRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequireAttributeNameRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireAttributeNameRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireAttributeNameRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequireQuoteStringValueSprintfRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireQuoteStringValueSprintfRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireQuoteStringValueSprintfRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequireSkipPrefixForRuleSkippedFixtureRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireSkipPrefixForRuleSkippedFixtureRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireSkipPrefixForRuleSkippedFixtureRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequireStringRegexMatchKeyRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireStringRegexMatchKeyRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireStringRegexMatchKeyRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequireThisCallOnLocalMethodRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireThisCallOnLocalMethodRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireThisCallOnLocalMethodRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequireThisOnParentMethodCallRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequireThisOnParentMethodCallRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequireThisOnParentMethodCallRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/RequiredAbstractClassKeywordRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/RequiredAbstractClassKeywordRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\RequiredAbstractClassKeywordRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/Spotter/IfElseToMatchSpotterRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Spotter/IfElseToMatchSpotterRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../../config/symplify-rules.neon
     - ../../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\Spotter\IfElseToMatchSpotterRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/SuffixInterfaceRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/SuffixInterfaceRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\SuffixInterfaceRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/SuffixTraitRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/SuffixTraitRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\SuffixTraitRule
+        tags: [phpstan.rules.rule]

--- a/packages/phpstan-rules/tests/Rules/UppercaseConstantRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/UppercaseConstantRule/config/configured_rule.neon
@@ -1,3 +1,7 @@
 includes:
-    - ../../../../config/symplify-rules.neon
     - ../../../../config/services/services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\UppercaseConstantRule
+        tags: [phpstan.rules.rule]

--- a/specify-rule.php
+++ b/specify-rule.php
@@ -1,0 +1,61 @@
+<?php
+
+use Nette\Utils\Strings;
+use Symplify\SmartFileSystem\SmartFileSystem;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$finder = new Symfony\Component\Finder\Finder();
+$fileInfos = $finder->in(__DIR__ . '/packages/phpstan-rules/tests')
+    ->files()
+    ->name('*.neon')
+    ->getIterator();
+
+$smartFileSystem = new SmartFileSystem();
+
+foreach ($fileInfos as $fileInfo) {
+    $configFileContent = $smartFileSystem->readFile($fileInfo->getRealPath());
+    // 1. is generic config?
+    if (! str_contains($configFileContent, 'symplify-rules.neon')) {
+        continue;
+    }
+
+    // 2. detect rule class name from the test
+    $baseRuleDirectory = dirname($fileInfo->getPath());
+    $specificRuleDirectory = Strings::after($baseRuleDirectory, 'tests/');
+
+    $specificRuleDirectory = str_replace('/', '\\', $specificRuleDirectory);
+
+    $ruleClass = 'Symplify\\PHPStanRules\\' . $specificRuleDirectory;
+    if (! class_exists($ruleClass)) {
+        continue;
+    }
+
+    // 3. remove symplify-rules line
+    $configFileContentLines = explode(PHP_EOL, $configFileContent);
+    foreach ($configFileContentLines as $key => $configFileContentLine) {
+        if (! str_contains($configFileContentLine, 'symplify-rules.neon')) {
+            continue;
+        }
+
+        unset($configFileContentLines[$key]);
+    }
+
+    $configFileContent = implode(PHP_EOL, $configFileContentLines);
+
+    // 4. add services section with rule registration :)
+
+    $ruleServicesTemplate = <<<'CODE_SAMPLE'
+services:
+    -
+        class: %s
+        tags: [phpstan.rules.rule]
+CODE_SAMPLE;
+
+    $ruleServicesContent = sprintf($ruleServicesTemplate, $ruleClass);
+
+    $newConfigContent = $configFileContent . PHP_EOL . $ruleServicesContent . PHP_EOL;
+
+    // 5. dump content
+    $smartFileSystem->dumpFile($fileInfo->getRealPath(), $newConfigContent);
+}


### PR DESCRIPTION
Before, test were including all the rules and their services. It was fine for time being, but when more rules need various services across many packages, the mess of complex service trees gets brokens.

This makes sure the configs only include the single rule and make it easier to maintain and split :+1: 