### PR TITLE
Added support for different ways of sending variables to template

### DIFF
--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/GetTemplateAndReplaceExtension/ExampleControl.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/GetTemplateAndReplaceExtension/ExampleControl.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\GetTemplateAndReplaceExtension;
+
+use Nette\Application\UI\Control;
+use Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source\ExampleModel;
+
+final class ExampleControl extends Control
+{
+    /** @var ExampleModel[] */
+    private $listOfObjects = [];
+
+    public function render(?int $param = null): void
+    {
+        $this->getTemplate()->existingVariable = '2021-09-11';
+        $this->getTemplate()->listOfObjects = $this->listOfObjects;
+        $this->getTemplate()->setFile(__DIR__ . '/../../templates/' . str_replace('php', 'latte', pathinfo(__FILE__, PATHINFO_BASENAME)));
+        $this->getTemplate()->render();
+    }
+
+    protected function createComponentExampleSubControl(): ExampleControl
+    {
+        return new ExampleControl();
+    }
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/NoAdditionalPropertyRead/ExampleControl.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/NoAdditionalPropertyRead/ExampleControl.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\NoAdditionalPropertyRead;
+
+use Nette\Application\UI\Control;
+use Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source\ExampleModel;
+
+final class ExampleControl extends Control
+{
+    /** @var ExampleModel[] */
+    private $listOfObjects = [];
+
+    public function render(?int $param = null): void
+    {
+        $this->template->existingVariable = '2021-09-11';
+        $this->template->listOfObjects = $this->listOfObjects;
+        $this->template->setFile(__DIR__ . '/../../templates/ExampleControl.latte');
+        $this->template->render();
+    }
+
+    protected function createComponentExampleSubControl(): ExampleControl
+    {
+        return new ExampleControl();
+    }
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/PropertyReadTemplate/ExampleControl.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/PropertyReadTemplate/ExampleControl.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\PropertyReadTemplate;
+
+use Nette\Application\UI\Control;
+use Nette\Bridges\ApplicationLatte\Template;
+use Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source\ExampleModel;
+
+/**
+ * @property-read Template $template
+ */
+final class ExampleControl extends Control
+{
+    /** @var ExampleModel[] */
+    private $listOfObjects = [];
+
+    public function render(?int $param = null): void
+    {
+        $this->template->existingVariable = '2021-09-11';
+        $this->template->listOfObjects = $this->listOfObjects;
+        $this->template->setFile(__DIR__ . '/../../templates/ExampleControl.latte');
+        $this->template->render();
+    }
+
+    protected function createComponentExampleSubControl(): ExampleControl
+    {
+        return new ExampleControl();
+    }
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/RenderWithParameters/ExampleControl.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/RenderWithParameters/ExampleControl.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\RenderWithParameters;
+
+use Nette\Application\UI\Control;
+use Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source\ExampleModel;
+
+final class ExampleControl extends Control
+{
+    /** @var ExampleModel[] */
+    private $listOfObjects = [];
+
+    public function render(?int $param = null): void
+    {
+        $this->template->render(__DIR__ . '/../../templates/ExampleControl.latte', [
+            'existingVariable' => '2021-09-11',
+            'listOfObjects' => $this->listOfObjects,
+        ]);
+    }
+
+    protected function createComponentExampleSubControl(): ExampleControl
+    {
+        return new ExampleControl();
+    }
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/TemplateAsVariableAndRenderToStringWithParameters/ExampleControl.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Fixtures/TemplateAsVariableAndRenderToStringWithParameters/ExampleControl.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\TemplateAsVariableAndRenderToStringWithParameters;
+
+use Nette\Application\UI\Control;
+use Nette\Bridges\ApplicationLatte\Template;
+use Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source\ExampleModel;
+
+final class ExampleControl extends Control
+{
+    /** @var ExampleModel[] */
+    private $listOfObjects = [];
+
+    public function render(?int $param = null): void
+    {
+        /** @var Template $template */
+        $template = $this->getTemplate();
+        $template->renderToString(__DIR__ . '/../../templates/ExampleControl.latte', [
+            'existingVariable' => '2021-09-11',
+            'listOfObjects' => $this->listOfObjects,
+        ]);
+    }
+
+    protected function createComponentExampleSubControl(): ExampleControl
+    {
+        return new ExampleControl();
+    }
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/LatteCompleteCheckRuleTemplateSetupTest.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/LatteCompleteCheckRuleTemplateSetupTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup;
+
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Nette\Rules\LatteCompleteCheckRule;
+
+/**
+ * @extends AbstractServiceAwareRuleTestCase<LatteCompleteCheckRule>
+ */
+final class LatteCompleteCheckRuleTemplateSetupTest extends AbstractServiceAwareRuleTestCase
+{
+    public function testRule(): void
+    {
+        $fileToClass = [
+            __DIR__ . '/Fixtures/PropertyReadTemplate/ExampleControl.php' => \Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\PropertyReadTemplate\ExampleControl::class,
+            __DIR__ . '/Fixtures/NoAdditionalPropertyRead/ExampleControl.php' => \Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\NoAdditionalPropertyRead\ExampleControl::class,
+            __DIR__ . '/Fixtures/GetTemplateAndReplaceExtension/ExampleControl.php' => \Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\GetTemplateAndReplaceExtension\ExampleControl::class,
+            __DIR__ . '/Fixtures/RenderWithParameters/ExampleControl.php' => \Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\RenderWithParameters\ExampleControl::class,
+            __DIR__ . '/Fixtures/TemplateAsVariableAndRenderToStringWithParameters/ExampleControl.php' => \Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Fixtures\TemplateAsVariableAndRenderToStringWithParameters\ExampleControl::class,
+        ];
+
+        foreach ($fileToClass as $file => $class) {
+            $this->analyse([$file], [
+//                [
+//                    'Static method Latte\Runtime\Filters::date() invoked with 3 parameters, 1-2 required.',
+//                    2
+//                ],
+//                [
+//                    'Parameter #2 $format of static method Latte\Runtime\Filters::date() expects string|null, int given.',
+//                    2
+//                ],
+                [
+                    'Variable $nonExistingVariable might not be defined.',
+                    3
+                ],
+                [
+                    'Call to an undefined method Nette\Security\User::nonExistingMethod().',
+                    6
+                ],
+                [
+                    'Call to an undefined method Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source\ExampleModel::getTitle().',
+                    9
+                ],
+                [
+                    'Method ' . $class . '::render() invoked with 2 parameters, 0-1 required.',
+                    12
+                ],
+                [
+                    'Parameter #1 $param of method ' . $class . '::render() expects int|null, string given.',
+                    12
+                ],
+            ]);
+        }
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(LatteCompleteCheckRule::class, __DIR__ . '/config/configured_rule.neon');
+    }
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Source/ExampleModel.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/Source/ExampleModel.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Nette\Tests\Rules\LatteCompleteCheckRuleTemplateSetup\Source;
+
+final class ExampleModel
+{
+
+}

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/config/configured_rule.neon
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/config/configured_rule.neon
@@ -1,0 +1,35 @@
+includes:
+    - ../../../../../../config/services/services.neon
+    - ../../../../../../packages/nette/config/services.neon
+    - ../../../../../../../../packages/latte-phpstan-compiler/config/services.neon
+    - ../../../../../../../../packages/template-phpstan-compiler/config/services.neon
+
+parameters:
+    # needed to enable missing method rule bellow
+    checkThisOnly: false
+    checkArgumentsPassedByReference: true
+    checkMissingTypehints: true
+    checkNeverInGenericReturnType: true
+    checkExtraArguments: true
+
+    # this is not propagates in test case for some reason, so must be set manually
+    checkArgumentTypes: true
+
+services:
+    -
+        class: Symplify\PHPStanRules\Nette\Rules\LatteCompleteCheckRule
+        tags: [phpstan.rules.rule]
+
+    -
+        class: PHPStan\Rules\Methods\CallMethodsRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            checkFunctionNameCase: true
+            reportMagicMethods: true
+
+    -
+        class: PHPStan\Rules\Variables\DefinedVariableRule
+        tags: [phpstan.rules.rule]
+        arguments:
+            cliArgumentsVariablesRegistered: false
+            checkMaybeUndefinedVariables: true

--- a/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/templates/ExampleControl.latte
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/LatteCompleteCheckRuleTemplateSetup/templates/ExampleControl.latte
@@ -1,0 +1,13 @@
+<div class="output">
+    <p>{$existingVariable|date, 123, 456}</p>
+    <p>{$nonExistingVariable}</p>
+    <p>{$baseUrl}</p>
+    <p>{$user->getId()}</p>
+    <p><!-- {$user->nonExistingMethod()} --></p>
+
+    {foreach $listOfObjects as $item}
+        {$item->getTitle()}
+    {/foreach}
+
+    {control exampleSubControl, 'xxx', 'yyy'}
+</div>

--- a/packages/phpstan-rules/src/Templates/RenderTemplateWithParametersMatcher.php
+++ b/packages/phpstan-rules/src/Templates/RenderTemplateWithParametersMatcher.php
@@ -25,7 +25,11 @@ final class RenderTemplateWithParametersMatcher
         Scope $scope,
         string $templateSuffix
     ): RenderTemplateWithParameters|null {
-        $firstArgValue = $methodCall->args[0]->value;
+        $firstArg = $methodCall->args[0] ?? null;
+        if ($firstArg === null) {
+            return null;
+        }
+        $firstArgValue = $firstArg->value;
 
         $resolvedTemplateFilePaths = $this->pathResolver->resolveExistingFilePaths(
             $firstArgValue,


### PR DESCRIPTION
As we talk here https://twitter.com/VotrubaT/status/1442215099008180224 I'm adding test cases for now. Then I will try to implement it.

Do you have any question / objection for it?

Test fixtures copied from my repository: https://github.com/efabrica-team/phpstan-latte/tree/main/tests/Rule/ControlLatteRule

