### PR TITLE
[PHPStan] Using phpstan ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "^4.13",
         "phar-io/version": "^3.1",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "react/child-process": "^0.6.3",
         "react/event-loop": "^1.2",
         "react/socket": "^1.9",

--- a/packages/astral/composer.json
+++ b/packages/astral/composer.json
@@ -8,7 +8,7 @@
         "nette/utils": "^3.2",
         "symfony/dependency-injection": "^5.3|^6.0",
         "symplify/smart-file-system": "^9.5",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "symfony/http-kernel": "^5.3|^6.0",
         "nikic/php-parser": "^4.13",
         "symplify/package-builder": "^9.5"

--- a/packages/latte-phpstan-compiler/composer.json
+++ b/packages/latte-phpstan-compiler/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0",
         "nette/utils": "^3.2",
         "latte/latte": "^2.10",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "symplify/astral": "^9.5",
         "symplify/template-phpstan-compiler": "^9.5"
     },

--- a/packages/phpstan-extensions/composer.json
+++ b/packages/phpstan-extensions/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "symplify/package-builder": "^9.5",
         "symplify/smart-file-system": "^9.5",
         "symplify/astral": "^9.5"

--- a/packages/phpstan-latte-rules/composer.json
+++ b/packages/phpstan-latte-rules/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "latte/latte": "^2.10",
         "symplify/astral": "^9.5",
         "symplify/rule-doc-generator-contracts": "^9.5",

--- a/packages/phpstan-rules/composer.json
+++ b/packages/phpstan-rules/composer.json
@@ -8,7 +8,7 @@
         "nikic/php-parser": "^4.13",
         "nette/utils": "^3.2",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "symplify/astral": "^9.5",
         "symplify/composer-json-manipulator": "^9.5",
         "symplify/package-builder": "^9.5",

--- a/packages/phpstan-twig-rules/composer.json
+++ b/packages/phpstan-twig-rules/composer.json
@@ -11,7 +11,7 @@
         "symplify/package-builder": "^9.5",
         "symplify/smart-file-system": "^9.5",
         "symplify/twig-phpstan-compiler": "^9.5",
-        "phpstan/phpstan": "1.0.x-dev as 1.0"
+        "phpstan/phpstan": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/packages/rule-doc-generator/composer.json
+++ b/packages/rule-doc-generator/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "friendsofphp/php-cs-fixer": "^3.2"
     },
     "autoload": {

--- a/packages/symfony-php-config/composer.json
+++ b/packages/symfony-php-config/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "symfony/http-kernel": "^5.3|^6.0",
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "1.0.x-dev as 1.0"
+        "phpstan/phpstan": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/packages/symfony-static-dumper/composer.json
+++ b/packages/symfony-static-dumper/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^1.12",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": "^9.5",
         "symfony/framework-bundle": "^5.3|^6.0",
         "symfony/twig-bundle": "^5.3|^6.0"

--- a/packages/template-phpstan-compiler/composer.json
+++ b/packages/template-phpstan-compiler/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0",
         "nette/utils": "^3.2",
         "symplify/astral": "^9.5",
-        "phpstan/phpstan": "1.0.x-dev as 1.0"
+        "phpstan/phpstan": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/packages/twig-phpstan-compiler/composer.json
+++ b/packages/twig-phpstan-compiler/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.0",
         "nette/utils": "^3.2",
         "twig/twig": "^3.3",
-        "phpstan/phpstan": "1.0.x-dev as 1.0",
+        "phpstan/phpstan": "^1.0",
         "symplify/package-builder": "^9.5",
         "symplify/smart-file-system": "^9.5",
         "symplify/template-phpstan-compiler": "^9.5"


### PR DESCRIPTION
Same like in rector-src:

https://github.com/rectorphp/rector-src/blob/e525dad6ab1a005e79b751f4cfb1eaf94ae3c90f/composer.json#L23

The `^1.0` already load `dev-master` if using : 

```javascript
    "minimum-stability": "dev",
    "prefer-stable": true
```

so when PHPStan next released, it is should no longer need change, as prefer-stable to true.