### PR TITLE
fix: cronjob workflows not working.

### DIFF
--- a/.github/workflows/daily_pull_request.yaml
+++ b/.github/workflows/daily_pull_request.yaml
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
 
         # don't run this action on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.repository_owner == 'symplify'
 
         steps:
             -

--- a/.github/workflows/lock_threads.yaml
+++ b/.github/workflows/lock_threads.yaml
@@ -8,8 +8,8 @@ jobs:
     lock:
         runs-on: ubuntu-latest
         # don't run this action on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        
+        if: github.repository_owner == 'symplify'
+
         steps:
             # see https://github.com/dessant/lock-threads
             -

--- a/.github/workflows/weekly_pull_requests.yaml
+++ b/.github/workflows/weekly_pull_requests.yaml
@@ -1,4 +1,4 @@
-name: Daily Pull Requests
+name: Weekly Pull Requests
 
 on:
     schedule:
@@ -25,7 +25,7 @@ jobs:
 
         runs-on: ubuntu-latest
         # don't run this action on forks
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: github.repository_owner == 'symplify'
 
         steps:
             -


### PR DESCRIPTION
Currently cronjob workflows not working because it have condition to check to run:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```
but we not have `github.event.pull_request` context. In this PR I have improve the condition.

References:

https://github.com/prisma/prisma/issues/3539

 