### PR TITLE
fix: monorepo builder autoload priority.

### DIFF
--- a/packages/monorepo-builder/bin/monorepo-builder.php
+++ b/packages/monorepo-builder/bin/monorepo-builder.php
@@ -16,8 +16,6 @@ $possibleAutoloadPaths = [
     __DIR__ . '/../../../autoload.php',
     // monorepo
     __DIR__ . '/../../../vendor/autoload.php',
-    // after split package
-    __DIR__ . '/../vendor/autoload.php',
 ];
 
 foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {

--- a/packages/monorepo-builder/bin/monorepo-builder.php
+++ b/packages/monorepo-builder/bin/monorepo-builder.php
@@ -12,12 +12,12 @@ use Symplify\SymplifyKernel\ValueObject\KernelBootAndApplicationRun;
 
 # 1. autoload
 $possibleAutoloadPaths = [
+    // dependency
+    __DIR__ . '/../../../autoload.php',
     // monorepo
     __DIR__ . '/../../../vendor/autoload.php',
     // after split package
     __DIR__ . '/../vendor/autoload.php',
-    // dependency
-    __DIR__ . '/../../../autoload.php',
 ];
 
 foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {


### PR DESCRIPTION
Hi there,

Look like issue  #3570 still exists because on distribution environment own autoload of `monorepo-builder` package exists and will be use by [L5#scoper-autoload.php](https://github.com/symplify/monorepo-builder/blob/main/vendor/scoper-autoload.php#L5). 

Currently own autoload of `monorepo-builder` get highest priority so dependency autoload never touch and we can not add custom container services, I think dependency autoload should get highest priority.