### PR TITLE
[PHPStanRules] Extend Enum analyzer to check classes in Enum namespace

### DIFF
--- a/packages/phpstan-rules/src/NodeAnalyzer/EnumAnalyzer.php
+++ b/packages/phpstan-rules/src/NodeAnalyzer/EnumAnalyzer.php
@@ -27,14 +27,19 @@ final class EnumAnalyzer
 
         $classReflection = $scope->getClassReflection();
         if (! $classReflection instanceof ClassReflection) {
-            return $this->hasEnumAnnotation($classLike);
+            return false;
         }
 
-        if (! $classReflection->isSubclassOf(Enum::class)) {
-            return $this->hasEnumAnnotation($classLike);
+        if ($this->hasEnumAnnotation($classLike)) {
+            return true;
         }
 
-        return true;
+        if ($classReflection->isSubclassOf(Enum::class)) {
+            return true;
+        }
+
+        // is in /Enum/ namespace
+        return str_contains($classReflection->getName(), '\\Enum\\');
     }
 
     private function hasEnumAnnotation(Class_ $class): bool

--- a/packages/phpstan-rules/tests/Rules/StrictTypes/RespectPropertyTypeInGetterReturnTypeRule/Fixture/SkipPromotedProperty.php
+++ b/packages/phpstan-rules/tests/Rules/StrictTypes/RespectPropertyTypeInGetterReturnTypeRule/Fixture/SkipPromotedProperty.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\StrictTypes\RespectPropertyTypeInGetterReturnTypeRule\Fixture;
+
+final class SkipPromotedProperty
+{
+    public function __construct(
+        private string $name
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/StrictTypes/RespectPropertyTypeInGetterReturnTypeRule/RespectPropertyTypeInGetterReturnTypeRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/StrictTypes/RespectPropertyTypeInGetterReturnTypeRule/RespectPropertyTypeInGetterReturnTypeRuleTest.php
@@ -25,6 +25,7 @@ final class RespectPropertyTypeInGetterReturnTypeRuleTest extends AbstractServic
 
     public function provideData(): Iterator
     {
+        yield [__DIR__ . '/Fixture/SkipPromotedProperty.php', []];
         yield [__DIR__ . '/Fixture/SkipMatchingArrayType.php', []];
         yield [__DIR__ . '/Fixture/SkipInterface.php', []];
         yield [__DIR__ . '/Fixture/SkipUntrustableDocblock.php', []];


### PR DESCRIPTION
- skip getter property name
- [PHPStanRules] Extend Enum analyzer to check classes in Enum namespace
