### PR TITLE
[ConfigTransformer]ECS][MonorepoBuilder] Remove unneded usage of UNSAFE_TYPES_TO_METHODS constant in DowngradeParameterTypeWideningRector

### DIFF
--- a/packages/config-transformer/build/config/config-downgrade.php
+++ b/packages/config-transformer/build/config/config-downgrade.php
@@ -16,10 +16,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(DowngradeParameterTypeWideningRector::class)
         ->configure([
-            DowngradeParameterTypeWideningRector::UNSAFE_TYPES_TO_METHODS => [
                 LoaderInterface::class => ['load'],
                 Loader::class => ['import'],
-            ],
         ]);
 
     $parameters = $containerConfigurator->parameters();

--- a/packages/easy-coding-standard/build/config/config-downgrade.php
+++ b/packages/easy-coding-standard/build/config/config-downgrade.php
@@ -20,10 +20,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(DowngradeParameterTypeWideningRector::class)
         ->configure([
-            DowngradeParameterTypeWideningRector::UNSAFE_TYPES_TO_METHODS => [
                 LoaderInterface::class => ['load'],
                 Loader::class => ['import'],
-            ],
         ]);
 
     $services->set(DowngradeAttributeToAnnotationRector::class)

--- a/packages/monorepo-builder/build/config/config-downgrade.php
+++ b/packages/monorepo-builder/build/config/config-downgrade.php
@@ -17,10 +17,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(DowngradeParameterTypeWideningRector::class)
         ->configure([
-            DowngradeParameterTypeWideningRector::UNSAFE_TYPES_TO_METHODS => [
                 LoaderInterface::class => ['load'],
                 Loader::class => ['import'],
-            ],
         ]);
 
     $parameters = $containerConfigurator->parameters();


### PR DESCRIPTION
There is no other constants to compare, so UNSAFE_TYPES_TO_METHODS usage is not needed. Ref https://github.com/rectorphp/rector-src/pull/1451 . Use direct config values instead.