### PR TITLE
[Latte PHPStan Compiler] Concrete types for variables $presenter and $control

### DIFF
--- a/packages/latte-phpstan-compiler/src/TemplateFileVarTypeDocBlocksDecorator.php
+++ b/packages/latte-phpstan-compiler/src/TemplateFileVarTypeDocBlocksDecorator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symplify\LattePHPStanCompiler;
 
+use Nette\Application\UI\Control;
+use Nette\Application\UI\Presenter;
 use PhpParser\Node\Expr\Array_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
@@ -66,11 +68,15 @@ final class TemplateFileVarTypeDocBlocksDecorator
 
         $classReflection = $scope->getClassReflection();
         if ($classReflection instanceof ClassReflection) {
-            $variablesAndTypes[] = new VariableAndType('actualClass', new ObjectType($classReflection->getName()));
+            $actualClass = new ObjectType($classReflection->getName());
+            $variablesAndTypes[] = new VariableAndType('actualClass', $actualClass);
 
-            // scope: presenter -> control and presenter is the presenter = actualclass
-            // scope: control -> control is actualclass, presenter - we dont know from this context
-
+            if ($actualClass->isInstanceOf(Presenter::class)->yes()) {
+                $variablesAndTypes[] = new VariableAndType('presenter', $actualClass);
+            }
+            if ($actualClass->isInstanceOf(Control::class)->yes()) {
+                $variablesAndTypes[] = new VariableAndType('control', $actualClass);
+            }
         }
 
         return $variablesAndTypes;

--- a/packages/latte-phpstan-compiler/src/TemplateFileVarTypeDocBlocksDecorator.php
+++ b/packages/latte-phpstan-compiler/src/TemplateFileVarTypeDocBlocksDecorator.php
@@ -67,6 +67,10 @@ final class TemplateFileVarTypeDocBlocksDecorator
         $classReflection = $scope->getClassReflection();
         if ($classReflection instanceof ClassReflection) {
             $variablesAndTypes[] = new VariableAndType('actualClass', new ObjectType($classReflection->getName()));
+
+            // scope: presenter -> control and presenter is the presenter = actualclass
+            // scope: control -> control is actualclass, presenter - we dont know from this context
+
         }
 
         return $variablesAndTypes;

--- a/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/FixturePresenterVariable/expected_compiled.php
+++ b/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/FixturePresenterVariable/expected_compiled.php
@@ -1,0 +1,28 @@
+<?php
+
+declare (strict_types=1);
+use Latte\Runtime as LR;
+/** DummyTemplateClass */
+final class DummyTemplateClass extends \Latte\Runtime\Template
+{
+    public function main() : array
+    {
+        \extract($this->params);
+        /** @var Symplify\LattePHPStanCompiler\Tests\LatteToPhpCompiler\Source\FooPresenter $presenter */
+        /** @var Symplify\LattePHPStanCompiler\Tests\LatteToPhpCompiler\Source\FooPresenter $control */
+        /** line in latte file: 1 */
+        echo \Latte\Runtime\Filters::escapeHtmlText($presenter->foo);
+        echo "\n";
+        /** line in latte file: 2 */
+        echo \Latte\Runtime\Filters::escapeHtmlText($control->foo);
+        echo "\n";
+        return \get_defined_vars();
+    }
+    public function prepare() : void
+    {
+        \extract($this->params);
+        /** @var Symplify\LattePHPStanCompiler\Tests\LatteToPhpCompiler\Source\FooPresenter $presenter */
+        /** @var Symplify\LattePHPStanCompiler\Tests\LatteToPhpCompiler\Source\FooPresenter $control */
+        \Nette\Bridges\ApplicationLatte\UIRuntime::initialize($this, $this->parentName, $this->blocks);
+    }
+}

--- a/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/FixturePresenterVariable/input_file.latte
+++ b/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/FixturePresenterVariable/input_file.latte
@@ -1,0 +1,2 @@
+{$presenter->foo}
+{$control->foo}

--- a/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/LatteToPhpCompilerTest.php
+++ b/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/LatteToPhpCompilerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\LattePHPStanCompiler\Tests\LatteToPhpCompiler;
 
 use Iterator;
+use Nette\Application\UI\Presenter;
 use Nette\Localization\Translator;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\Type\ObjectType;
@@ -113,6 +114,18 @@ final class LatteToPhpCompilerTest extends TestCase
             $variablesAndTypes,
             [],
             __DIR__ . '/FixturePresenterLinks/expected_compiled.php',
+        ];
+
+        $variablesAndTypes = [
+            new VariableAndType('presenter', new ObjectType(Presenter::class)),
+            new VariableAndType('presenter', new ObjectType(FooPresenter::class)),
+            new VariableAndType('control', new ObjectType(FooPresenter::class)),
+        ];
+        yield [
+            __DIR__ . '/FixturePresenterVariable/input_file.latte',
+            $variablesAndTypes,
+            [],
+            __DIR__ . '/FixturePresenterVariable/expected_compiled.php',
         ];
     }
 

--- a/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/Source/FooPresenter.php
+++ b/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/Source/FooPresenter.php
@@ -8,6 +8,8 @@ use Nette\Application\UI\Presenter;
 
 final class FooPresenter extends Presenter
 {
+    public string $foo;
+
     public function renderDefault(int $limit, ?array $add = null): void
     {
     }

--- a/packages/template-phpstan-compiler/src/NodeFactory/VarDocNodeFactory.php
+++ b/packages/template-phpstan-compiler/src/NodeFactory/VarDocNodeFactory.php
@@ -21,10 +21,10 @@ final class VarDocNodeFactory
     {
         $docNodes = [];
         foreach ($variablesAndTypes as $variableAndType) {
-            $docNodes[] = $this->createDocNop($variableAndType);
+            $docNodes[$variableAndType->getVariable()] = $this->createDocNop($variableAndType);
         }
 
-        return $docNodes;
+        return array_values($docNodes);
     }
 
     private function createDocNop(VariableAndType $variableAndType): Nop


### PR DESCRIPTION
When we are in scope of Presenter, variables $presenter and $control in template are instances of this presenter, so we can use actual Presenter's type instead of abstract Nette\Application\UI\Presenter / Nette\Application\UI\Control

Also in scope of Control, $presenter is actual presenter (we can't get it in static analysis) and $control is actual rendered Control