### PR TITLE
[ECS] Remove  strict phpunit fixer breaking rule, let Rector handle it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "composer/semver": "^3.2",
         "composer/xdebug-handler": "^2.0",
         "cweagans/composer-patches": "^1.7",
-        "friendsofphp/php-cs-fixer": "^3.3",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "j7mbo/twitter-api-php": "^1.0.6",
         "latte/latte": "^2.10",
         "myclabs/php-enum": "^1.8",

--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
@@ -47,13 +46,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         __DIR__ . '/packages/phpstan-rules/tests/Rules/ForbiddenArrayWithStringKeysRule/FixturePhp80/SkipAttributeArrayKey.php',
         __DIR__ . '/packages/phpstan-rules/tests/Rules/TooDeepNewClassNestingRule/FixturePhp8/SkipExpressionThrow.php',
         __DIR__ . '/packages/latte-phpstan-compiler/tests/LatteToPhpCompiler/Fixture*',
-
-        // class in paths
-        PhpUnitStrictFixer::class => [
-            __DIR__ . '/packages/easy-coding-standard/tests/Indentation/IndentationTest.php',
-            // object compare
-            __DIR__ . '/packages/latte-phpstan-compiler/tests/Filters/FilterMatcherTest.php',
-            __DIR__ . '/packages/easy-ci/packages-tests/Neon/Application/NeonFilesProcessor/NeonFilesProcessorTest.php',
-        ],
     ]);
 };

--- a/packages/coding-standard/composer.json
+++ b/packages/coding-standard/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=8.0",
         "nette/utils": "^3.2",
-        "friendsofphp/php-cs-fixer": "^3.3",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "symplify/symplify-kernel": "^10.1",
         "symplify/package-builder": "^10.1",
         "symplify/autowire-array-parameter": "^10.1",

--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=8.0",
         "composer/xdebug-handler": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.3",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "nette/utils": "^3.2",
         "squizlabs/php_codesniffer": "^3.6",
         "symfony/config": "^5.4|^6.0",

--- a/packages/easy-coding-standard/config/set/common/phpunit.php
+++ b/packages/easy-coding-standard/config/set/common/phpunit.php
@@ -3,16 +3,12 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer;
-use PhpCsFixer\Fixer\PhpUnit\PhpUnitStrictFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(PhpUnitStrictFixer::class);
-
     $services->set(PhpUnitTestAnnotationFixer::class);
-
     $services->set(PhpUnitSetUpTearDownVisibilityFixer::class);
 };

--- a/packages/rule-doc-generator/composer.json
+++ b/packages/rule-doc-generator/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.2",
-        "friendsofphp/php-cs-fixer": "^3.3"
+        "friendsofphp/php-cs-fixer": "^3.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- [ECS] remove PhpUnitStrictFixer from phpunit set as breaking, use Rector and PHPUnit code quality set instead
- cleanup ecs.php
- bump php-cs-fixer fot 3.4 with Symfony 6 support
