### PR TITLE
[PackageBuilder] Added type-safe `PrivatesAccessor`-methods

### DIFF
--- a/packages/package-builder/src/Reflection/PrivatesAccessor.php
+++ b/packages/package-builder/src/Reflection/PrivatesAccessor.php
@@ -50,7 +50,7 @@ final class PrivatesAccessor
      */
     public function setPrivatePropertyOfClass(object $object, string $propertyName, mixed $value, string $valueClassName): void
     {
-        if (!($value instanceof $valueClassName)) {
+        if (! $value instanceof $valueClassName) {
             throw new ShouldNotHappenException();
         }
 

--- a/packages/package-builder/src/Reflection/PrivatesAccessor.php
+++ b/packages/package-builder/src/Reflection/PrivatesAccessor.php
@@ -14,6 +14,24 @@ use Symplify\PHPStanRules\Exception\ShouldNotHappenException;
 final class PrivatesAccessor
 {
     /**
+     * @template T
+     *
+     * @param class-string<T> $valueClassName
+     *
+     * @return T
+     */
+    public function getPrivatePropertyOfClass(object $object, string $propertyName, string $valueClassName)
+    {
+        $value = $this->getPrivateProperty($object, $propertyName);
+
+        if ($value instanceof $valueClassName) {
+            return $value;
+        }
+
+        throw new ShouldNotHappenException();
+    }
+
+    /**
      * @return mixed
      */
     public function getPrivateProperty(object $object, string $propertyName)
@@ -22,6 +40,23 @@ final class PrivatesAccessor
         $propertyReflection->setAccessible(true);
 
         return $propertyReflection->getValue($object);
+    }
+
+    /**
+     * @template T
+     *
+     * @param class-string<T> $valueClassName
+     * @param T $value
+     */
+    public function setPrivatePropertyOfClass(object $object, string $propertyName, mixed $value, string $valueClassName): void
+    {
+        $this->setPrivateProperty($object, $propertyName, $value);
+
+        if ($value instanceof $valueClassName) {
+            return;
+        }
+
+        throw new ShouldNotHappenException();
     }
 
     public function setPrivateProperty(object $object, string $propertyName, mixed $value): void

--- a/packages/package-builder/src/Reflection/PrivatesAccessor.php
+++ b/packages/package-builder/src/Reflection/PrivatesAccessor.php
@@ -50,13 +50,11 @@ final class PrivatesAccessor
      */
     public function setPrivatePropertyOfClass(object $object, string $propertyName, mixed $value, string $valueClassName): void
     {
-        $this->setPrivateProperty($object, $propertyName, $value);
-
-        if ($value instanceof $valueClassName) {
-            return;
+        if (!($value instanceof $valueClassName)) {
+            throw new ShouldNotHappenException();
         }
 
-        throw new ShouldNotHappenException();
+        $this->setPrivateProperty($object, $propertyName, $value);
     }
 
     public function setPrivateProperty(object $object, string $propertyName, mixed $value): void

--- a/packages/package-builder/tests/Reflection/PrivatesAccessorTest.php
+++ b/packages/package-builder/tests/Reflection/PrivatesAccessorTest.php
@@ -11,7 +11,7 @@ use Symplify\PackageBuilder\Tests\Reflection\Source\SomeClassWithPrivateProperty
 
 final class PrivatesAccessorTest extends TestCase
 {
-    public function testGetter(): void
+    public function testGetterSetter(): void
     {
         $privatesAccessor = new PrivatesAccessor();
         $someClassWithPrivateProperty = new SomeClassWithPrivateProperty();
@@ -22,21 +22,21 @@ final class PrivatesAccessorTest extends TestCase
         $fetchedParentValue = $privatesAccessor->getPrivateProperty($someClassWithPrivateProperty, 'parentValue');
         $this->assertSame($someClassWithPrivateProperty->getParentValue(), $fetchedParentValue);
 
-        $fetchedValue = $privatesAccessor->getPrivatePropertyOfClass($someClassWithPrivateProperty, 'object', stdClass::class);
-        $this->assertSame($someClassWithPrivateProperty->getObject(), $fetchedValue);
+        $privatesAccessor->setPrivateProperty($someClassWithPrivateProperty, 'value', 25);
+        $this->assertSame(25, $someClassWithPrivateProperty->getValue());
     }
 
-    public function testSetter(): void
+    public function testGetterSetterTypesafe(): void
     {
         $privatesAccessor = new PrivatesAccessor();
         $someClassWithPrivateProperty = new SomeClassWithPrivateProperty();
-
-        $privatesAccessor->setPrivateProperty($someClassWithPrivateProperty, 'value', 25);
-        $this->assertSame(25, $someClassWithPrivateProperty->getValue());
 
         $newObject = new stdClass();
         $this->assertNotSame($newObject, $someClassWithPrivateProperty->getObject());
         $privatesAccessor->setPrivatePropertyOfClass($someClassWithPrivateProperty, 'object', $newObject, stdClass::class);
         $this->assertSame($newObject, $someClassWithPrivateProperty->getObject());
+
+        $fetchedValue = $privatesAccessor->getPrivatePropertyOfClass($someClassWithPrivateProperty, 'object', stdClass::class);
+        $this->assertSame($someClassWithPrivateProperty->getObject(), $fetchedValue);
     }
 }

--- a/packages/package-builder/tests/Reflection/PrivatesAccessorTest.php
+++ b/packages/package-builder/tests/Reflection/PrivatesAccessorTest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Symplify\PackageBuilder\Tests\Reflection;
 
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 use Symplify\PackageBuilder\Tests\Reflection\Source\SomeClassWithPrivateProperty;
 
 final class PrivatesAccessorTest extends TestCase
 {
-    public function test(): void
+    public function testGetter(): void
     {
         $privatesAccessor = new PrivatesAccessor();
         $someClassWithPrivateProperty = new SomeClassWithPrivateProperty();
@@ -20,5 +21,22 @@ final class PrivatesAccessorTest extends TestCase
 
         $fetchedParentValue = $privatesAccessor->getPrivateProperty($someClassWithPrivateProperty, 'parentValue');
         $this->assertSame($someClassWithPrivateProperty->getParentValue(), $fetchedParentValue);
+
+        $fetchedValue = $privatesAccessor->getPrivatePropertyOfClass($someClassWithPrivateProperty, 'object', stdClass::class);
+        $this->assertSame($someClassWithPrivateProperty->getObject(), $fetchedValue);
+    }
+
+    public function testSetter(): void
+    {
+        $privatesAccessor = new PrivatesAccessor();
+        $someClassWithPrivateProperty = new SomeClassWithPrivateProperty();
+
+        $privatesAccessor->setPrivateProperty($someClassWithPrivateProperty, 'value', 25);
+        $this->assertSame(25, $someClassWithPrivateProperty->getValue());
+
+        $newObject = new stdClass();
+        $this->assertNotSame($newObject, $someClassWithPrivateProperty->getObject());
+        $privatesAccessor->setPrivatePropertyOfClass($someClassWithPrivateProperty, 'object', $newObject, stdClass::class);
+        $this->assertSame($newObject, $someClassWithPrivateProperty->getObject());
     }
 }

--- a/packages/package-builder/tests/Reflection/Source/SomeClassWithPrivateProperty.php
+++ b/packages/package-builder/tests/Reflection/Source/SomeClassWithPrivateProperty.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symplify\PackageBuilder\Tests\Reflection\Source;
 
+use stdClass;
+
 final class SomeClassWithPrivateProperty extends AbstractPrivateProperty
 {
     /**
@@ -11,8 +13,23 @@ final class SomeClassWithPrivateProperty extends AbstractPrivateProperty
      */
     private $value = 5;
 
+    /**
+     * @var stdClass $object
+     */
+    private $object;
+
+    public function __construct()
+    {
+        $this->object = new stdClass();
+    }
+
     public function getValue(): int
     {
         return $this->value;
+    }
+
+    public function getObject() : stdClass
+    {
+        return $this->object;
     }
 }


### PR DESCRIPTION
Inspired by the type-mismatches within https://github.com/rectorphp/rector-src/pull/1589/files I figured it would be good to have a method variant which is typesafe and integrates well with phpstan.

that way we can get rid of the ugly inline `@var`-phpdocs and additionally get type safety