### PR TITLE
[Astral] copy over `findFirst()` and `findFirstPrevious()` from rector

### DIFF
--- a/packages/astral/src/NodeFinder/SimpleNodeFinder.php
+++ b/packages/astral/src/NodeFinder/SimpleNodeFinder.php
@@ -107,36 +107,6 @@ final class SimpleNodeFinder
     }
 
     /**
-     * @param callable(Node $node): bool $filter
-     */
-    public function findFirstPrevious(Node $node, callable $filter): ?Node
-    {
-        $node = $node instanceof Expression ? $node : $node->getAttribute(AttributeKey::CURRENT_NODE);
-        if ($node === null) {
-            return null;
-        }
-
-        $foundNode = $this->findFirst([$node], $filter);
-        // we found what we need
-        if ($foundNode !== null) {
-            return $foundNode;
-        }
-
-        // move to previous expression
-        $previousStatement = $node->getAttribute(AttributeKey::PREVIOUS);
-        if ($previousStatement !== null) {
-            return $this->findFirstPrevious($previousStatement, $filter);
-        }
-
-        $parent = $node->getAttribute(AttributeKey::PARENT);
-        if ($parent === null) {
-            return null;
-        }
-
-        return $this->findFirstPrevious($parent, $filter);
-    }
-
-    /**
      * @param callable(Node $node):bool $filter
      */
     public function findFirstPreviousOfNode(Node $node, callable $filter): ?Node

--- a/packages/astral/tests/NodeFinder/SimpleNodeFinderTest.php
+++ b/packages/astral/tests/NodeFinder/SimpleNodeFinderTest.php
@@ -6,6 +6,7 @@ namespace Symplify\Astral\Tests\NodeFinder;
 
 use Iterator;
 use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Class_;
@@ -15,6 +16,7 @@ use Symplify\Astral\Naming\SimpleNameResolver;
 use Symplify\Astral\NodeFinder\SimpleNodeFinder;
 use Symplify\Astral\PhpParser\SmartPhpParser;
 use Symplify\Astral\Tests\HttpKernel\AstralKernel;
+use Symplify\Astral\ValueObject\AttributeKey;
 use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 
 final class SimpleNodeFinderTest extends AbstractKernelTestCase
@@ -48,7 +50,22 @@ final class SimpleNodeFinderTest extends AbstractKernelTestCase
         $this->assertNotNull($class);
 
         $this->assertInstanceOf(Variable::class, $variable);
+        $this->assertSame('param', $variable->name);
         $this->assertInstanceOf(Class_::class, $class);
+    }
+
+    public function testFindFirstPreviousOfNode(): void {
+        $methodCall = $this->simpleNodeFinder->findFirst($this->nodes, function(Node $node) {
+            return $node instanceof MethodCall;
+        });
+        $this->assertNotNull($methodCall);
+
+        $previous = $this->simpleNodeFinder->findFirstPreviousOfNode($methodCall, function(Node $node) {
+            return $node instanceof Variable;
+        });
+
+        $this->assertInstanceOf(Variable::class, $previous);
+        $this->assertSame('z', $previous->name);
     }
 
 }

--- a/packages/astral/tests/NodeFinder/SimpleNodeFinderTest.php
+++ b/packages/astral/tests/NodeFinder/SimpleNodeFinderTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\Astral\Tests\NodeFinder;
+
+use Iterator;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassLike;
+use Rector\Core\PhpParser\Parser\SimplePhpParser;
+use Symplify\Astral\Naming\SimpleNameResolver;
+use Symplify\Astral\NodeFinder\SimpleNodeFinder;
+use Symplify\Astral\PhpParser\SmartPhpParser;
+use Symplify\Astral\Tests\HttpKernel\AstralKernel;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+
+final class SimpleNodeFinderTest extends AbstractKernelTestCase
+{
+    /**
+     * @var Node[]
+     */
+    private array $nodes = [];
+
+    private SimpleNodeFinder $simpleNodeFinder;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(AstralKernel::class);
+        $this->simpleNodeFinder = $this->getService(SimpleNodeFinder::class);
+
+        $phpParser = $this->getService(SmartPhpParser::class);
+        $this->nodes = $phpParser->parseFile(__DIR__ . '/Source/SomeFile.php.inc');
+    }
+
+    public function testFindFirst(): void
+    {
+        $variable = $this->simpleNodeFinder->findFirst($this->nodes, function(Node $node) {
+            return $node instanceof Variable;
+        });
+        $class = $this->simpleNodeFinder->findFirst($this->nodes, function(Node $node) {
+            return $node instanceof Class_;
+        });
+
+        $this->assertNotNull($variable);
+        $this->assertNotNull($class);
+
+        $this->assertInstanceOf(Variable::class, $variable);
+        $this->assertInstanceOf(Class_::class, $class);
+    }
+
+}

--- a/packages/astral/tests/NodeFinder/Source/SomeFile.php.inc
+++ b/packages/astral/tests/NodeFinder/Source/SomeFile.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+class SomeClass
+{
+    public function someAction()
+    {
+        $variable = 5;
+    }
+}

--- a/packages/astral/tests/NodeFinder/Source/SomeFile.php.inc
+++ b/packages/astral/tests/NodeFinder/Source/SomeFile.php.inc
@@ -2,8 +2,19 @@
 
 class SomeClass
 {
-    public function someAction()
+    public function someAction($param)
     {
         $variable = 5;
+
+        if ($param == 'x') {
+            echo 'hello';
+        }
+        $z = 3;
+
+        $this->anotherAction();
+    }
+
+    public function anotherAction() {
+
     }
 }


### PR DESCRIPTION
it seems these methods are not tested within astral.. so I just copied the methods over from rector

refs https://github.com/rectorphp/rector/discussions/6921