### PR TITLE
[ECS] Use fully qualified code instead of code as checker

### DIFF
--- a/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
+++ b/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
@@ -182,7 +182,7 @@ final class File extends BaseFile
         }
 
         $message = $data !== [] ? vsprintf($message, $data) : $message;
-        $codingStandardError = new CodingStandardError($line, $message, $sniffClassOrCode, $this->getFilename());
+        $codingStandardError = new CodingStandardError($line, $message, $this->resolveFullyQualifiedCode($sniffClassOrCode), $this->getFilename());
         $this->sniffMetadataCollector->addCodingStandardError($codingStandardError);
 
         if ($isFixable) {


### PR DESCRIPTION
Makes it easier to find responsible sniffs.

Before:
```
 src/Support/XML.php:22
 ------------------------------------------------------------------------------------------------------
 Function libxml_disable_entity_loader() has been deprecated

 Reported by: "Deprecated"
 ------------------------------------------------------------------------------------------------------
```
After:
```
 src/Support/XML.php:22
 ------------------------------------------------------------------------------------------------------
 Function libxml_disable_entity_loader() has been deprecated

 Reported by: "PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\DeprecatedFunctionsSniff.Deprecated"
 ------------------------------------------------------------------------------------------------------
```