### PR TITLE
[PackageBuilder] Improve privates accessor invalid type error message

### DIFF
--- a/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
+++ b/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
@@ -182,9 +182,10 @@ final class File extends BaseFile
         }
 
         $message = $data !== [] ? vsprintf($message, $data) : $message;
-        $codingStandardError = new CodingStandardError($line, $message, $this->resolveFullyQualifiedCode(
-            $sniffClassOrCode
-        ), $this->getFilename());
+
+        $checkerClass = $this->resolveFullyQualifiedCode($sniffClassOrCode);
+        $codingStandardError = new CodingStandardError($line, $message, $checkerClass, $this->getFilename());
+
         $this->sniffMetadataCollector->addCodingStandardError($codingStandardError);
 
         if ($isFixable) {

--- a/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
+++ b/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
@@ -182,7 +182,9 @@ final class File extends BaseFile
         }
 
         $message = $data !== [] ? vsprintf($message, $data) : $message;
-        $codingStandardError = new CodingStandardError($line, $message, $this->resolveFullyQualifiedCode($sniffClassOrCode), $this->getFilename());
+        $codingStandardError = new CodingStandardError($line, $message, $this->resolveFullyQualifiedCode(
+            $sniffClassOrCode
+        ), $this->getFilename());
         $this->sniffMetadataCollector->addCodingStandardError($codingStandardError);
 
         if ($isFixable) {

--- a/packages/package-builder/src/Exception/InvalidPrivatePropertyTypeException.php
+++ b/packages/package-builder/src/Exception/InvalidPrivatePropertyTypeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\Exception;
+
+use Exception;
+
+final class InvalidPrivatePropertyTypeException extends Exception
+{
+}

--- a/packages/package-builder/src/Exception/MissingPrivatePropertyException.php
+++ b/packages/package-builder/src/Exception/MissingPrivatePropertyException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PackageBuilder\Exception;
+
+use Exception;
+
+final class MissingPrivatePropertyException extends Exception
+{
+}

--- a/packages/package-builder/src/Reflection/PrivatesAccessor.php
+++ b/packages/package-builder/src/Reflection/PrivatesAccessor.php
@@ -14,7 +14,7 @@ use Symplify\PHPStanRules\Exception\ShouldNotHappenException;
 final class PrivatesAccessor
 {
     /**
-     * @template T of object
+     * @template T as object
      *
      * @param class-string<T> $valueClassName
      * @return T
@@ -22,12 +22,12 @@ final class PrivatesAccessor
     public function getPrivatePropertyOfClass(object $object, string $propertyName, string $valueClassName): object
     {
         $value = $this->getPrivateProperty($object, $propertyName);
-
         if ($value instanceof $valueClassName) {
             return $value;
         }
 
-        throw new ShouldNotHappenException();
+        $errorMessage = sprintf('The type "%s" is required, but "%s" type given', $valueClassName, get_class($value));
+        throw new ShouldNotHappenException($errorMessage);
     }
 
     /**
@@ -42,7 +42,7 @@ final class PrivatesAccessor
     }
 
     /**
-     * @template T of object
+     * @template T
      *
      * @param class-string<T> $valueClassName
      * @param T $value
@@ -54,7 +54,12 @@ final class PrivatesAccessor
         string $valueClassName
     ): void {
         if (! $value instanceof $valueClassName) {
-            throw new ShouldNotHappenException();
+            $errorMessage = sprintf(
+                'The type "%s" is required, but "%s" type given',
+                $valueClassName,
+                get_class($value)
+            );
+            throw new ShouldNotHappenException($errorMessage);
         }
 
         $this->setPrivateProperty($object, $propertyName, $value);

--- a/packages/package-builder/src/Reflection/PrivatesAccessor.php
+++ b/packages/package-builder/src/Reflection/PrivatesAccessor.php
@@ -27,7 +27,7 @@ final class PrivatesAccessor
             return $value;
         }
 
-        $errorMessage = sprintf('The type "%s" is required, but "%s" type given', $valueClassName, get_class($value));
+        $errorMessage = sprintf('The type "%s" is required, but "%s" type given', $valueClassName, $value::class);
         throw new InvalidPrivatePropertyTypeException($errorMessage);
     }
 
@@ -62,7 +62,7 @@ final class PrivatesAccessor
         $errorMessage = sprintf(
             'The type "%s" is required, but "%s" type given',
             $valueClassName,
-            get_class($value)
+            $value::class
         );
         throw new InvalidPrivatePropertyTypeException($errorMessage);
     }

--- a/packages/package-builder/src/Reflection/PrivatesAccessor.php
+++ b/packages/package-builder/src/Reflection/PrivatesAccessor.php
@@ -15,7 +15,7 @@ use Symplify\PackageBuilder\Exception\MissingPrivatePropertyException;
 final class PrivatesAccessor
 {
     /**
-     * @template T as object
+     * @template T of object
      *
      * @param class-string<T> $valueClassName
      * @return T
@@ -43,7 +43,7 @@ final class PrivatesAccessor
     }
 
     /**
-     * @template T
+     * @template T of object
      *
      * @param class-string<T> $valueClassName
      * @param T $value


### PR DESCRIPTION
@staabm At the moment the error message is missing, which makes it hard to debug and guess what is wrong:

![image](https://user-images.githubusercontent.com/924196/148972547-0c745d67-6513-4bc4-a517-19366dfb9acb.png)


I've added currect + expected type, to help user nagive through error to success :+1: 