### PR TITLE
[EasyCI] Do not prefix Symplify\EasyCI\* namespace on scoper

### DIFF
--- a/packages/easy-ci/scoper.php
+++ b/packages/easy-ci/scoper.php
@@ -26,6 +26,8 @@ return [
     'whitelist' => [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
+        // naturally
+        'Symplify\EasyCI\*',
     ],
     'files-whitelist' => [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03


### PR DESCRIPTION
@TomasVotruba this is to avoid error ref https://github.com/rectorphp/rector-src/runs/4829684998?check_suite_focus=true#step:5:7

```bash

Run vendor/bin/easy-ci validate-file-length packages rules src tests

Error: ] Class "Symplify\EasyCI\ValueObject\Option" not found       
```

as it is not part of included `vendor` that need to be prefixed.

From inspiration https://github.com/rectorphp/rector-src/blob/6b965fe744f438b0614597bec485ad8ec23831d9/utils/compiler/src/PhpScoper/StaticEasyPrefixer.php#L30-L31

which the current workaround is pin to `"symplify/easy-ci": "10.0.9"`  

https://github.com/rectorphp/rector-src/blob/6b965fe744f438b0614597bec485ad8ec23831d9/composer.json#L77