### PR TITLE
[EasyCI] Fixing scoper EasyCI for not add prefixed in load() call

### DIFF
--- a/packages/easy-ci/scoper.php
+++ b/packages/easy-ci/scoper.php
@@ -67,11 +67,16 @@ return [
                 return $content;
             }
 
-            // fix symfony config load scoping, except CodingStandard and EasyCodingStandard
+            // fix symfony config load scoping, except EasyCI
             $content = Strings::replace(
                 $content,
                 '#load\(\'Symplify\\\\\\\\(?<package_name>[A-Za-z]+)#',
                 function (array $match) use ($prefix) {
+                    if (in_array($match['package_name'], ['EasyCI'], true)) {
+                        // skip
+                        return $match[0];
+                    }
+
                     return 'load(\'' . $prefix . '\Symplify\\' . $match['package_name'];
                 }
             );


### PR DESCRIPTION
@TomasVotruba this PR try to solve the following error on scoped version:

```bash
Run php bin/easy-ci list --ansi

                                                                                
 [ERROR] Expected to find class                                                 
         "EasyCI20220116\Symplify\EasyCI\ActiveClass\ClassNameResolver" in file 
         "/home/runner/work/easy-ci/easy-ci/packages/ActiveClass/ClassNameResolv
         er.php" while importing services from resource                         
         "/home/runner/work/easy-ci/easy-ci/config/../packages", but it was not 
         found! Check the namespace prefix used with the resource in            
         /home/runner/work/easy-ci/easy-ci/config/config-packages.php (which is 
         being imported from                                                    
         "/home/runner/work/easy-ci/easy-ci/src/Kernel/../../config/config.php")
         .                                                            
```