### PR TITLE
[MonorepoBuilder] Allow the custom `monorepo-builder.php` file to add commands

### DIFF
--- a/packages/monorepo-builder/src/Kernel/MonorepoBuilderKernel.php
+++ b/packages/monorepo-builder/src/Kernel/MonorepoBuilderKernel.php
@@ -18,9 +18,14 @@ final class MonorepoBuilderKernel extends AbstractSymplifyKernel
      */
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
-        $configFiles[] = __DIR__ . '/../../config/config.php';
-        $configFiles[] = ComposerJsonManipulatorConfig::FILE_PATH;
-        $configFiles[] = ConsoleColorDiffConfig::FILE_PATH;
+        $configFiles = array_merge(
+            [
+                __DIR__ . '/../../config/config.php',
+                ComposerJsonManipulatorConfig::FILE_PATH,
+                ConsoleColorDiffConfig::FILE_PATH,
+            ],
+            $configFiles
+        );
 
         $autowireInterfacesCompilerPass = new AutowireInterfacesCompilerPass([ReleaseWorkerInterface::class]);
         $compilerPasses = [$autowireInterfacesCompilerPass];


### PR DESCRIPTION
Fixes #3894