### PR TITLE
Making the commented out code sniff return warnings as errors

### DIFF
--- a/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
+++ b/packages/easy-coding-standard/packages/SniffRunner/ValueObject/File.php
@@ -10,6 +10,7 @@ use PHP_CodeSniffer\Fixer;
 use PHP_CodeSniffer\Sniffs\Sniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Classes\PropertyDeclarationSniff;
 use PHP_CodeSniffer\Standards\PSR2\Sniffs\Methods\MethodDeclarationSniff;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\PHP\CommentedOutCodeSniff;
 use PHP_CodeSniffer\Util\Common;
 use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
 use Symplify\EasyCodingStandard\SniffRunner\DataCollector\SniffMetadataCollector;
@@ -32,6 +33,7 @@ final class File extends BaseFile
         '\PHP_CodeSniffer\Standards\Generic\Sniffs\CodeAnalysis\AssignmentInConditionSniff',
         PropertyDeclarationSniff::class,
         MethodDeclarationSniff::class,
+        CommentedOutCodeSniff::class,
     ];
 
     /**


### PR DESCRIPTION
Fixes #3891