### PR TITLE
[ECS] Allow composer/xdebug-handler 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-simplexml": "*",
         "clue/ndjson-react": "^1.2",
         "composer/semver": "^3.2",
-        "composer/xdebug-handler": "^2.0",
+        "composer/xdebug-handler": "^2.0|^3.0",
         "cweagans/composer-patches": "^1.7",
         "friendsofphp/php-cs-fixer": "^3.4",
         "j7mbo/twitter-api-php": "^1.0.6",

--- a/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
+++ b/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
@@ -112,6 +112,7 @@ CODE_SAMPLE
         /** @var Token[] $docCommentTokens */
         $docCommentTokens = $tokens->findGivenKind(T_DOC_COMMENT);
         foreach ($docCommentTokens as $index => $docCommentToken) {
+            /** @var DoctrineAnnotationTokens<DoctrineAnnotationToken> $doctrineAnnotationTokens */
             $doctrineAnnotationTokens = DoctrineAnnotationTokens::createFromDocComment($docCommentToken, []);
             $this->fixAnnotations($doctrineAnnotationTokens, $useDeclarations);
 
@@ -125,7 +126,7 @@ CODE_SAMPLE
     private function fixAnnotations(DoctrineAnnotationTokens $doctrineAnnotationTokens, array $useDeclarations): void
     {
         foreach ($doctrineAnnotationTokens as $index => $token) {
-            $isAtToken = $doctrineAnnotationTokens[$index]->isType(DocLexer::T_AT);
+            $isAtToken = $token->isType(DocLexer::T_AT);
             if (! $isAtToken) {
                 continue;
             }

--- a/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
@@ -53,7 +53,9 @@ final class DoctrineAnnotationNameResolver
             return null;
         }
 
-        if ($tokens[$openParenthesisPosition]->isType(DocLexer::T_OPEN_PARENTHESIS)) {
+        /** @var Token $nextOpenParenthesis */
+        $nextOpenParenthesis = $tokens[$openParenthesisPosition];
+        if ($nextOpenParenthesis->isType(DocLexer::T_OPEN_PARENTHESIS)) {
             return $openParenthesisPosition;
         }
 

--- a/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
+++ b/packages/coding-standard/src/TokenAnalyzer/DoctrineAnnotationNameResolver.php
@@ -17,7 +17,7 @@ final class DoctrineAnnotationNameResolver
      */
     public function resolveName(Tokens $tokens, int $index, array $namespaceUseAnalyses): ?string
     {
-        $openParenthesisPosition = $tokens->getNextTokenOfType(DocLexer::T_OPEN_PARENTHESIS, $index);
+        $openParenthesisPosition = $this->getNextOpenParenthesisFromTokens($tokens, $index);
         if ($openParenthesisPosition === null) {
             return null;
         }
@@ -41,5 +41,22 @@ final class DoctrineAnnotationNameResolver
         }
 
         return $annotationShortName;
+    }
+
+    /**
+     * @param Tokens<Token> $tokens
+     */
+    private function getNextOpenParenthesisFromTokens(Tokens $tokens, int $index): ?int
+    {
+        $openParenthesisPosition = $tokens->getNextMeaningfulToken($index);
+        if ($openParenthesisPosition === null) {
+            return null;
+        }
+
+        if ($tokens[$openParenthesisPosition]->isType(DocLexer::T_OPEN_PARENTHESIS)) {
+            return $openParenthesisPosition;
+        }
+
+        return $this->getNextOpenParenthesisFromTokens($tokens, $openParenthesisPosition);
     }
 }

--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": ">=8.0",
-        "composer/xdebug-handler": "^2.0",
+        "composer/xdebug-handler": "^2.0|^3.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "nette/utils": "^3.2",
         "squizlabs/php_codesniffer": "^3.6",


### PR DESCRIPTION
This PR contains the following changes

- Allow composer/xdebug-handler 3.x
- Support for friendsofphp/php-cs-fixer 3.5