### PR TITLE
[SymplifyKernel] Change ContainerBuilderFactory::create() to put configs first

### DIFF
--- a/packages/astral/tests/HttpKernel/AstralKernel.php
+++ b/packages/astral/tests/HttpKernel/AstralKernel.php
@@ -13,6 +13,6 @@ final class AstralKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = AstralConfig::FILE_PATH;
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/autowire-array-parameter/tests/HttpKernel/AutowireArrayParameterHttpKernel.php
+++ b/packages/autowire-array-parameter/tests/HttpKernel/AutowireArrayParameterHttpKernel.php
@@ -16,6 +16,6 @@ final class AutowireArrayParameterHttpKernel extends AbstractSymplifyKernel
     {
         $configFiles[] = __DIR__ . '/../config/autowire_array_parameter.php';
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
+++ b/packages/coding-standard/src/Fixer/Annotation/DoctrineAnnotationNestedBracketsFixer.php
@@ -126,8 +126,7 @@ CODE_SAMPLE
     private function fixAnnotations(DoctrineAnnotationTokens $doctrineAnnotationTokens, array $useDeclarations): void
     {
         foreach ($doctrineAnnotationTokens as $index => $token) {
-            $isAtToken = $token->isType(DocLexer::T_AT);
-            if (! $isAtToken) {
+            if (! $token->isType(DocLexer::T_AT)) {
                 continue;
             }
 

--- a/packages/coding-standard/tests/HttpKernel/SymplifyCodingStandardKernel.php
+++ b/packages/coding-standard/tests/HttpKernel/SymplifyCodingStandardKernel.php
@@ -18,6 +18,6 @@ final class SymplifyCodingStandardKernel extends AbstractSymplifyKernel
         $configFiles[] = ConsoleColorDiffConfig::FILE_PATH;
         $configFiles[] = CodingStandardConfig::FILE_PATH;
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/composer-json-manipulator/tests/Kernel/ComposerJsonManipulatorKernel.php
+++ b/packages/composer-json-manipulator/tests/Kernel/ComposerJsonManipulatorKernel.php
@@ -17,6 +17,6 @@ final class ComposerJsonManipulatorKernel extends AbstractSymplifyKernel
     {
         $configFiles[] = ComposerJsonManipulatorConfig::FILE_PATH;
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/config-transformer/src/Kernel/ConfigTransformerKernel.php
+++ b/packages/config-transformer/src/Kernel/ConfigTransformerKernel.php
@@ -18,6 +18,6 @@ final class ConfigTransformerKernel extends AbstractSymplifyKernel
         $configFiles[] = __DIR__ . '/../../config/config.php';
         $configFiles[] = PhpConfigPrinterConfig::FILE_PATH;
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/easy-ci/src/Kernel/EasyCIKernel.php
+++ b/packages/easy-ci/src/Kernel/EasyCIKernel.php
@@ -20,6 +20,6 @@ final class EasyCIKernel extends AbstractSymplifyKernel
         $configFiles[] = ComposerJsonManipulatorConfig::FILE_PATH;
         $configFiles[] = AstralConfig::FILE_PATH;
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/easy-coding-standard/src/Kernel/EasyCodingStandardKernel.php
+++ b/packages/easy-coding-standard/src/Kernel/EasyCodingStandardKernel.php
@@ -39,7 +39,7 @@ final class EasyCodingStandardKernel extends AbstractSymplifyKernel
         $configFiles[] = EasyCodingStandardConfig::FILE_PATH;
         $configFiles[] = EasyParallelConfig::FILE_PATH;
 
-        return $this->create([], $compilerPasses, $configFiles);
+        return $this->create($configFiles, $compilerPasses, []);
     }
 
     /**

--- a/packages/easy-testing/src/Kernel/EasyTestingKernel.php
+++ b/packages/easy-testing/src/Kernel/EasyTestingKernel.php
@@ -16,6 +16,6 @@ final class EasyTestingKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = EasyTestingConfig::FILE_PATH;
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/markdown-diff/tests/HttpKernel/MarkdownDiffKernel.php
+++ b/packages/markdown-diff/tests/HttpKernel/MarkdownDiffKernel.php
@@ -13,6 +13,6 @@ final class MarkdownDiffKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = MarkdownDiffConfig::FILE_PATH;
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/monorepo-builder/src/Kernel/MonorepoBuilderKernel.php
+++ b/packages/monorepo-builder/src/Kernel/MonorepoBuilderKernel.php
@@ -25,6 +25,6 @@ final class MonorepoBuilderKernel extends AbstractSymplifyKernel
         $autowireInterfacesCompilerPass = new AutowireInterfacesCompilerPass([ReleaseWorkerInterface::class]);
         $compilerPasses = [$autowireInterfacesCompilerPass];
 
-        return $this->create([], $compilerPasses, $configFiles);
+        return $this->create($configFiles, $compilerPasses, []);
     }
 }

--- a/packages/neon-config-dumper/src/Kernel/NeonConfigDumperKernel.php
+++ b/packages/neon-config-dumper/src/Kernel/NeonConfigDumperKernel.php
@@ -16,6 +16,6 @@ final class NeonConfigDumperKernel extends AbstractSymplifyKernel
     {
         $configFiles[] = __DIR__ . '/../../config/config.php';
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/package-builder/tests/HttpKernel/PackageBuilderTestKernel.php
+++ b/packages/package-builder/tests/HttpKernel/PackageBuilderTestKernel.php
@@ -12,6 +12,6 @@ final class PackageBuilderTestKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = __DIR__ . '/../config/test_config.php';
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/php-config-printer/tests/HttpKernel/PhpConfigPrinterKernel.php
+++ b/packages/php-config-printer/tests/HttpKernel/PhpConfigPrinterKernel.php
@@ -16,6 +16,6 @@ final class PhpConfigPrinterKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = PhpConfigPrinterConfig::FILE_PATH;
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/rule-doc-generator/src/Kernel/RuleDocGeneratorKernel.php
+++ b/packages/rule-doc-generator/src/Kernel/RuleDocGeneratorKernel.php
@@ -20,6 +20,6 @@ final class RuleDocGeneratorKernel extends AbstractSymplifyKernel
         $configFiles[] = PhpConfigPrinterConfig::FILE_PATH;
         $configFiles[] = MarkdownDiffConfig::FILE_PATH;
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/simple-php-doc-parser/tests/HttpKernel/SimplePhpDocParserKernel.php
+++ b/packages/simple-php-doc-parser/tests/HttpKernel/SimplePhpDocParserKernel.php
@@ -13,6 +13,6 @@ final class SimplePhpDocParserKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = SimplePhpDocParserConfig::FILE_PATH;
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/skipper/tests/HttpKernel/SkipperKernel.php
+++ b/packages/skipper/tests/HttpKernel/SkipperKernel.php
@@ -13,6 +13,6 @@ final class SkipperKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         $configFiles[] = SkipperConfig::FILE_PATH;
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/symfony-php-config/tests/HttpKernel/SymfonyPhpConfigKernel.php
+++ b/packages/symfony-php-config/tests/HttpKernel/SymfonyPhpConfigKernel.php
@@ -14,6 +14,6 @@ final class SymfonyPhpConfigKernel extends AbstractSymplifyKernel
      */
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }

--- a/packages/symplify-kernel/src/ContainerBuilderFactory.php
+++ b/packages/symplify-kernel/src/ContainerBuilderFactory.php
@@ -19,11 +19,11 @@ final class ContainerBuilderFactory
     }
 
     /**
-     * @param ExtensionInterface[] $extensions
-     * @param CompilerPassInterface[] $compilerPasses
      * @param string[] $configFiles
+     * @param CompilerPassInterface[] $compilerPasses
+     * @param ExtensionInterface[] $extensions
      */
-    public function create(array $extensions, array $compilerPasses, array $configFiles): ContainerBuilder
+    public function create(array $configFiles, array $compilerPasses, array $extensions): ContainerBuilder
     {
         Assert::allIsAOf($extensions, ExtensionInterface::class);
         Assert::allIsAOf($compilerPasses, CompilerPassInterface::class);

--- a/packages/symplify-kernel/src/HttpKernel/AbstractSymplifyKernel.php
+++ b/packages/symplify-kernel/src/HttpKernel/AbstractSymplifyKernel.php
@@ -23,11 +23,11 @@ abstract class AbstractSymplifyKernel implements LightKernelInterface
     private Container|null $container = null;
 
     /**
-     * @param ExtensionInterface[] $extensions
-     * @param CompilerPassInterface[] $compilerPasses
      * @param string[] $configFiles
+     * @param CompilerPassInterface[] $compilerPasses
+     * @param ExtensionInterface[] $extensions
      */
-    public function create(array $extensions, array $compilerPasses, array $configFiles): ContainerInterface
+    public function create(array $configFiles, array $compilerPasses, array $extensions): ContainerInterface
     {
         $containerBuilderFactory = new ContainerBuilderFactory(new ParameterMergingLoaderFactory());
 
@@ -35,7 +35,7 @@ abstract class AbstractSymplifyKernel implements LightKernelInterface
 
         $configFiles[] = SymplifyKernelConfig::FILE_PATH;
 
-        $containerBuilder = $containerBuilderFactory->create($extensions, $compilerPasses, $configFiles);
+        $containerBuilder = $containerBuilderFactory->create($configFiles, $compilerPasses, $extensions);
         $containerBuilder->compile();
 
         $this->container = $containerBuilder;

--- a/packages/vendor-patches/src/Kernel/VendorPatchesKernel.php
+++ b/packages/vendor-patches/src/Kernel/VendorPatchesKernel.php
@@ -18,6 +18,6 @@ final class VendorPatchesKernel extends AbstractSymplifyKernel
         $configFiles[] = __DIR__ . '/../../config/config.php';
         $configFiles[] = ComposerJsonManipulatorConfig::FILE_PATH;
 
-        return $this->create([], [], $configFiles);
+        return $this->create($configFiles, [], []);
     }
 }


### PR DESCRIPTION
Ref https://tomasvotruba.com/blog/introducing-light-kernel-for-symfony-console-apps/