### PR TITLE
[CodingStandard] Skip Callable has same param previous definition on ParamReturnAndVarTagMalformsFixer

### DIFF
--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -69,11 +69,13 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
 
         $reversedTokens = $this->reverseTokens($tokens);
         foreach ($reversedTokens as $index => $token) {
-            if ($token->isGivenKind([T_CALLABLE])) {
-                if (isset($tokens[$index + 3]) && $tokens[$index + 3]->getContent() === ')') {
-                    return false;
-                }
+            if (!$token->isGivenKind([T_CALLABLE])) {
+                continue;
             }
+            if (!(isset($tokens[$index + 3]) && $tokens[$index + 3]->getContent() === ')')) {
+                continue;
+            }
+            return false;
         }
 
         return $tokens->isAnyTokenKindsFound([T_FUNCTION, T_VARIABLE]);

--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -67,6 +67,19 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
             return false;
         }
 
+        $callables = $tokens->findGivenKind(T_CALLABLE);
+
+        if ($callables !== []) {
+            $reversedTokens = $this->reverseTokens($tokens);
+            foreach ($reversedTokens as $index => $token) {
+                if ($token->isGivenKind([T_CALLABLE])) {
+                    if (isset($tokens[$index + 3]) && $tokens[$index + 3]->getContent() === ')') {
+                        return false;
+                    }
+                }
+            }
+        }
+
         return $tokens->isAnyTokenKindsFound([T_FUNCTION, T_VARIABLE]);
     }
 

--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -72,9 +72,11 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
             if (!$token->isGivenKind([T_CALLABLE])) {
                 continue;
             }
+
             if (!(isset($tokens[$index + 3]) && $tokens[$index + 3]->getContent() === ')')) {
                 continue;
             }
+
             return false;
         }
 

--- a/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
+++ b/packages/coding-standard/src/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer.php
@@ -67,15 +67,11 @@ final class ParamReturnAndVarTagMalformsFixer extends AbstractSymplifyFixer impl
             return false;
         }
 
-        $callables = $tokens->findGivenKind(T_CALLABLE);
-
-        if ($callables !== []) {
-            $reversedTokens = $this->reverseTokens($tokens);
-            foreach ($reversedTokens as $index => $token) {
-                if ($token->isGivenKind([T_CALLABLE])) {
-                    if (isset($tokens[$index + 3]) && $tokens[$index + 3]->getContent() === ')') {
-                        return false;
-                    }
+        $reversedTokens = $this->reverseTokens($tokens);
+        foreach ($reversedTokens as $index => $token) {
+            if ($token->isGivenKind([T_CALLABLE])) {
+                if (isset($tokens[$index + 3]) && $tokens[$index + 3]->getContent() === ')') {
+                    return false;
                 }
             }
         }

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/skip_callable_has_same_param_previous_definition.php.inc
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/Fixture/skip_callable_has_same_param_previous_definition.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+use PhpParser\Node;
+
+class SkipCallableHasSameParamPreviousDefinition
+{
+    /**
+     * @param Node|Node[] $nodes
+     * @param callable(Node $node): bool $filter
+     */
+    public function findFirst(Node | array $nodes, callable $filter): ?Node
+    {
+
+    }
+}
+?>

--- a/rector.php
+++ b/rector.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'Doctrine\ORM\EntityManager',
             'Nette\*',
             'Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator',
+            'PHPUnit\Framework\TestCase',
         ]);
 
     $services->set(PreferThisOrSelfMethodCallRector::class)


### PR DESCRIPTION
Given the following code:

```php
    /**
     * @param Node|Node[] $nodes
     * @param callable(Node $node): bool $filter
     */
    public function findFirst(Node | array $nodes, callable $filter): ?Node
    {

    }
```

it produce:

```diff
-     * @param Node|Node[] $nodes\n
-     * @param callable(Node $node): bool $filter\n
+     * @param Node|Node[] $filters\n
+     * @param callable(Node $filter): bool $filter\n
```

which should be skipped, @staabm this is for https://github.com/rectorphp/rector-src/pull/1649#discussion_r780695332