### PR TITLE
ECS | `JsonOutputFormatter` should account file diff in exit code

### DIFF
--- a/packages/easy-coding-standard/src/Console/Output/ExitCodeResolver.php
+++ b/packages/easy-coding-standard/src/Console/Output/ExitCodeResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\EasyCodingStandard\Console\Output;
+
+use Symfony\Component\Console\Command\Command;
+use Symplify\EasyCodingStandard\ValueObject\Configuration;
+use Symplify\EasyCodingStandard\ValueObject\Error\ErrorAndDiffResult;
+
+final class ExitCodeResolver
+{
+    public function resolve(ErrorAndDiffResult $errorAndDiffResult, Configuration $configuration): int
+    {
+        if ($errorAndDiffResult->getErrorCount() === 0 && $errorAndDiffResult->getFileDiffsCount() === 0) {
+            return Command::SUCCESS;
+        }
+
+        if ($configuration->isFixer()) {
+            return $errorAndDiffResult->getErrorCount() === 0 ? Command::SUCCESS : Command::FAILURE;
+        }
+
+        return $errorAndDiffResult->getErrorCount() !== 0 || $errorAndDiffResult->getFileDiffsCount() !== 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+}

--- a/packages/easy-coding-standard/src/Console/Output/JsonOutputFormatter.php
+++ b/packages/easy-coding-standard/src/Console/Output/JsonOutputFormatter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\EasyCodingStandard\Console\Output;
 
 use Nette\Utils\Json;
-use Symfony\Component\Console\Command\Command;
 use Symplify\EasyCodingStandard\Console\Style\EasyCodingStandardStyle;
 use Symplify\EasyCodingStandard\Contract\Console\Output\OutputFormatterInterface;
 use Symplify\EasyCodingStandard\ValueObject\Configuration;
@@ -27,7 +26,8 @@ final class JsonOutputFormatter implements OutputFormatterInterface
     private const FILES = 'files';
 
     public function __construct(
-        private EasyCodingStandardStyle $easyCodingStandardStyle
+        private EasyCodingStandardStyle $easyCodingStandardStyle,
+        private ExitCodeResolver $exitCodeResolver
     ) {
     }
 
@@ -36,8 +36,7 @@ final class JsonOutputFormatter implements OutputFormatterInterface
         $json = $this->createJsonContent($errorAndDiffResult);
         $this->easyCodingStandardStyle->writeln($json);
 
-        $errorCount = $errorAndDiffResult->getErrorCount();
-        return $errorCount === 0 ? Command::SUCCESS : Command::FAILURE;
+        return $this->exitCodeResolver->resolve($errorAndDiffResult, $configuration);
     }
 
     public function getName(): string


### PR DESCRIPTION
Right now `JsonOutputFormatter` fails only if there was a "hard error", but this is different from `ConsoleOutputFormatter` which also checks for file diff count.

```bash
$ vendor/bin/ecs check --output-format=json
Total tests to perform 1 out of 10 available
Executing lint - 1 out of 1 selected [Time Elapsed 00:00:00]
Finished in 00:00:57
Running after_script
00:00
Running after script...
$ ./docker/bin/codeclimate.sh --php-cs-fixer ./codequality/php-cs-fixer.json
File                                                                   Line  Description
----                                                                   ----  -----------
src/JobRunnerBundle/Tests/Service/JobHandler/ExecuteTest.php  0     ECS: NativeFunctionInvocationFixer
src/ReviewBundle/Repository/ReviewRepository.php              0     ECS: SingleLineCommentStyleFixer
src/ReviewBundle/Repository/ReviewRepository.php              0     ECS: OrderedImportsFixer
Uploading artifacts for successful job
00:02
Uploading artifacts...
codequality/: found 2 matching files and directories 
Uploading artifacts as "archive" to coordinator... ok  id=2027520134 responseStatus=201 Created token=_Qzst3CS
Cleaning up file based variables
00:01
Job succeeded
```

`Job succeeded` = both commands where successful 