### PR TITLE
[ECS] [Parallel] Add Option PARALLEL_TIMEOUT_IN_SECONDS and PARALLEL_SYSTEM_ERROR_COUNT_LIMIT constant to allow reconfigure it in ecs config

### DIFF
--- a/packages/easy-coding-standard/config/config.php
+++ b/packages/easy-coding-standard/config/config.php
@@ -30,6 +30,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // how many files are processed in single process
     $parameters->set(Option::PARALLEL_JOB_SIZE, 60);
     $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, 16);
+    $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, 120);
+    $parameters->set(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT, 50);
 
     $parameters->set(Option::PATHS, []);
     $parameters->set(Option::FILE_EXTENSIONS, ['php']);

--- a/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
@@ -27,6 +27,7 @@ use Symplify\EasyParallel\Enum\ReactEvent;
 use Symplify\EasyParallel\ValueObject\ParallelProcess;
 use Symplify\EasyParallel\ValueObject\ProcessPool;
 use Symplify\EasyParallel\ValueObject\Schedule;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Throwable;
 
 /**
@@ -37,11 +38,11 @@ use Throwable;
  */
 final class ParallelFileProcessor
 {
-    public $parameterProvider;
     private ProcessPool|null $processPool = null;
 
     public function __construct(
         private WorkerCommandLineFactory $workerCommandLineFactory,
+        private ParameterProvider $parameterProvider
     ) {
     }
 

--- a/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
+++ b/packages/easy-coding-standard/packages/Parallel/Application/ParallelFileProcessor.php
@@ -37,6 +37,7 @@ use Throwable;
  */
 final class ParallelFileProcessor
 {
+    public $parameterProvider;
     private ProcessPool|null $processPool = null;
 
     public function __construct(

--- a/packages/easy-coding-standard/src/ValueObject/Option.php
+++ b/packages/easy-coding-standard/src/ValueObject/Option.php
@@ -150,10 +150,10 @@ final class Option
     /**
      * @var string
      */
-    final public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
+    public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
 
     /**
      * @var string
      */
-    final public const PARALLEL_SYSTEM_ERROR_COUNT_LIMIT = 'parallel-system-error-count-limit';
+    public const PARALLEL_SYSTEM_ERROR_COUNT_LIMIT = 'parallel-system-error-count-limit';
 }

--- a/packages/easy-coding-standard/src/ValueObject/Option.php
+++ b/packages/easy-coding-standard/src/ValueObject/Option.php
@@ -146,4 +146,14 @@ final class Option
      * @var string
      */
     public const MEMORY_LIMIT = 'memory-limit';
+
+    /**
+     * @var string
+     */
+    final public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
+
+    /**
+     * @var string
+     */
+    final public const PARALLEL_SYSTEM_ERROR_COUNT_LIMIT = 'parallel-system-error-count-limit';
 }


### PR DESCRIPTION
- make it minimal 120 seconds
- make configurable


@enumag  this is to handle https://github.com/symplify/symplify/issues/3914

Ref for inspiration came from rector : 

- https://github.com/rectorphp/rector-src/pull/1657
- https://github.com/rectorphp/rector-src/pull/1673