### PR TITLE
[ECS] Deprecate show command to prefer --debug option

### DIFF
--- a/packages/easy-coding-standard/src/Console/Command/ShowCommand.php
+++ b/packages/easy-coding-standard/src/Console/Command/ShowCommand.php
@@ -51,6 +51,12 @@ final class ShowCommand extends AbstractSymplifyCommand
         );
         $this->easyCodingStandardStyle->success($successMessage);
 
-        return self::SUCCESS;
+        $this->easyCodingStandardStyle->error(
+            'The "show" command is deprecated and will be removed, as it was used only for more output on Rector run. Use the "--debug" option and process command for debugging output instead.'
+        );
+        // to spot the error message
+        sleep(3);
+
+        return self::FAILURE;
     }
 }


### PR DESCRIPTION
The "show" command was used only for more output on ECS run.  Kinda of "debug" command.

Now we should use the "--debug" option and process command for debugging output instead :+1: 