### PR TITLE
[DX] Inline PARALLEL_SYSTEM_ERROR_COUNT_LIMIT option to keep user scope outside internal system

### DIFF
--- a/packages/easy-coding-standard/config/config.php
+++ b/packages/easy-coding-standard/config/config.php
@@ -31,7 +31,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::PARALLEL_JOB_SIZE, 60);
     $parameters->set(Option::PARALLEL_MAX_NUMBER_OF_PROCESSES, 16);
     $parameters->set(Option::PARALLEL_TIMEOUT_IN_SECONDS, 120);
-    $parameters->set(Option::PARALLEL_SYSTEM_ERROR_COUNT_LIMIT, 50);
 
     $parameters->set(Option::PATHS, []);
     $parameters->set(Option::FILE_EXTENSIONS, ['php']);

--- a/packages/easy-coding-standard/src/ValueObject/Option.php
+++ b/packages/easy-coding-standard/src/ValueObject/Option.php
@@ -151,9 +151,4 @@ final class Option
      * @var string
      */
     public const PARALLEL_TIMEOUT_IN_SECONDS = 'parallel-timeout-in-seconds';
-
-    /**
-     * @var string
-     */
-    public const PARALLEL_SYSTEM_ERROR_COUNT_LIMIT = 'parallel-system-error-count-limit';
 }

--- a/packages/phpstan-rules/packages/symfony/src/Rules/RequireNamedCommandRule.php
+++ b/packages/phpstan-rules/packages/symfony/src/Rules/RequireNamedCommandRule.php
@@ -136,9 +136,9 @@ CODE_SAMPLE
         return $classReflection->isSubclassOf(Command::class);
     }
 
-    private function hasAsCommandAttribute(ClassMethod $node): bool
+    private function hasAsCommandAttribute(ClassMethod $classMethod): bool
     {
-        $class = $this->simpleNodeFinder->findFirstParentByType($node, Class_::class);
+        $class = $this->simpleNodeFinder->findFirstParentByType($classMethod, Class_::class);
         if (! $class instanceof Class_) {
             return false;
         }


### PR DESCRIPTION
To be consistent with Rector https://github.com/rectorphp/rector-src/pull/1818