### PR TITLE
[PHPStanRules] Add ForbiddenFinalClassMockRule

### DIFF
--- a/packages/phpstan-rules/docs/rules_overview.md
+++ b/packages/phpstan-rules/docs/rules_overview.md
@@ -1025,6 +1025,52 @@ class SomeClass
 
 <br>
 
+## ForbiddenFinalClassMockRule
+
+Class "%s" is mocked, but is final. It might crash
+
+- class: [`Symplify\PHPStanRules\Rules\ForbiddenFinalClassMockRule`](../src/Rules/ForbiddenFinalClassMockRule.php)
+
+```php
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->getMockBuilder(SomeClass::clas);
+    }
+}
+
+final class SomeClass
+{
+}
+```
+
+:x:
+
+<br>
+
+```php
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->getMockBuilder(SomeClass::clas);
+    }
+}
+
+class SomeClass
+{
+}
+```
+
+:+1:
+
+<br>
+
 ## ForbiddenForeachEmptyMissingArrayRule
 
 Foreach over empty missing array is not allowed. Use isset check early instead.

--- a/packages/phpstan-rules/src/NodeAnalyzer/PHPUnit/TestAnalyzer.php
+++ b/packages/phpstan-rules/src/NodeAnalyzer/PHPUnit/TestAnalyzer.php
@@ -39,6 +39,16 @@ final class TestAnalyzer
         return $this->isTestClassMethod($scope, $classMethod);
     }
 
+    public function isInTest(Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (! $classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->isSubclassOf('PHPUnit\Framework\TestCase');
+    }
+
     private function isPublicClassMethod(FunctionLike $functionLike, ClassReflection $classReflection): bool
     {
         if (! $functionLike instanceof ClassMethod) {

--- a/packages/phpstan-rules/src/Rules/ForbiddenFinalClassMockRule.php
+++ b/packages/phpstan-rules/src/Rules/ForbiddenFinalClassMockRule.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Constant\ConstantStringType;
+use Symplify\Astral\Naming\SimpleNameResolver;
+use Symplify\PHPStanRules\NodeAnalyzer\PHPUnit\TestAnalyzer;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @see \Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\ForbiddenFinalClassMockRuleTest
+ */
+final class ForbiddenFinalClassMockRule extends AbstractSymplifyRule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Class "%s" is mocked, but is final. It might crash';
+
+    public function __construct(
+        private SimpleNameResolver $simpleNameResolver,
+        private ReflectionProvider $reflectionProvider,
+        private TestAnalyzer $testAnalyzer
+    ) {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     * @return string[]
+     */
+    public function process(Node $node, Scope $scope): array
+    {
+        if (! $this->simpleNameResolver->isNames($node->name, ['getMockBuilder', 'createMock'])) {
+            return [];
+        }
+
+        if (! $this->testAnalyzer->isInTest($scope)) {
+            return [];
+        }
+
+        $mockedClassName = $this->resolveMockedClass($node, $scope);
+        if ($mockedClassName === null) {
+            return [];
+        }
+
+        if (! $this->reflectionProvider->hasClass($mockedClassName)) {
+            return [];
+        }
+
+        $mockClassReflection = $this->reflectionProvider->getClass($mockedClassName);
+        if (! $mockClassReflection->isFinal()) {
+            return [];
+        }
+
+        $errorMessage = sprintf(self::ERROR_MESSAGE, $mockedClassName);
+        return [$errorMessage];
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(self::ERROR_MESSAGE, [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->getMockBuilder(SomeClass::clas);
+    }
+}
+
+final class SomeClass
+{
+}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+use PHPUnit\Framework\TestCase;
+
+final class SomeTest extends TestCase
+{
+    public function test()
+    {
+        $this->getMockBuilder(SomeClass::clas);
+    }
+}
+
+class SomeClass
+{
+}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    private function resolveMockedClass(MethodCall $methodCall, Scope $scope): ?string
+    {
+        $args = $methodCall->getArgs();
+
+        $firstArgValue = $args[0]->value;
+
+        $firstValueType = $scope->getType($firstArgValue);
+        if (! $firstValueType instanceof ConstantStringType) {
+            return null;
+        }
+
+        return $firstValueType->getValue();
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/CreateMockMethod.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/CreateMockMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source\FinalClass;
+
+final class CreateMockMethod extends TestCase
+{
+    public function test()
+    {
+        $this->createMock(FinalClass::class);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/MockOfFinalClass.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/MockOfFinalClass.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source\FinalClass;
+
+final class MockOfFinalClass extends TestCase
+{
+    public function test()
+    {
+        $this->getMockBuilder(FinalClass::class);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/SkipCreateMockMethodOutsideTestCase.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/SkipCreateMockMethodOutsideTestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source\FinalClass;
+
+final class SkipCreateMockMethodOutsideTestCase
+{
+    public function test()
+    {
+        $this->createMock(FinalClass::class);
+    }
+
+    public function createMock(string $className)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/SkipNormalClass.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Fixture/SkipNormalClass.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source\FinalClass;
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source\NormalClass;
+
+final class SkipNormalClass extends TestCase
+{
+    public function test()
+    {
+        $this->getMockBuilder(NormalClass::class);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/ForbiddenFinalClassMockRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/ForbiddenFinalClassMockRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule;
+
+use Iterator;
+use PHPStan\Rules\Rule;
+use Symplify\PHPStanExtensions\Testing\AbstractServiceAwareRuleTestCase;
+use Symplify\PHPStanRules\Rules\ForbiddenFinalClassMockRule;
+use Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source\FinalClass;
+
+/**
+ * @extends AbstractServiceAwareRuleTestCase<ForbiddenFinalClassMockRule>
+ */
+final class ForbiddenFinalClassMockRuleTest extends AbstractServiceAwareRuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     * @param array<string|string[]|int[]> $expectedErrorsWithLines
+     */
+    public function testRule(string $filePath, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$filePath], $expectedErrorsWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        $errorMessage = sprintf(ForbiddenFinalClassMockRule::ERROR_MESSAGE, FinalClass::class);
+        yield [__DIR__ . '/Fixture/MockOfFinalClass.php', [[$errorMessage, 14]]];
+        yield [__DIR__ . '/Fixture/CreateMockMethod.php', [[$errorMessage, 14]]];
+
+        yield [__DIR__ . '/Fixture/SkipNormalClass.php', []];
+        yield [__DIR__ . '/Fixture/SkipCreateMockMethodOutsideTestCase.php', []];
+    }
+
+    protected function getRule(): Rule
+    {
+        return $this->getRuleFromConfig(
+            ForbiddenFinalClassMockRule::class,
+            __DIR__ . '/config/configured_rule.neon'
+        );
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Source/FinalClass.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Source/FinalClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source;
+
+final class FinalClass
+{
+
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Source/NormalClass.php
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/Source/NormalClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\ForbiddenFinalClassMockRule\Source;
+
+class NormalClass
+{
+
+}

--- a/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/ForbiddenFinalClassMockRule/config/configured_rule.neon
@@ -1,0 +1,7 @@
+includes:
+    - ../../../config/included_services.neon
+
+services:
+    -
+        class: Symplify\PHPStanRules\Rules\ForbiddenFinalClassMockRule
+        tags: [phpstan.rules.rule]


### PR DESCRIPTION
This rule comes handy, when it comes to legacy projects with lot of mocking and finalize Rector rule.