### PR TITLE
Failing test for LineLengthFixer should break attributes

### DIFF
--- a/packages/coding-standard/src/Fixer/LineLength/LineLengthFixer.php
+++ b/packages/coding-standard/src/Fixer/LineLength/LineLengthFixer.php
@@ -93,6 +93,8 @@ final class LineLengthFixer extends AbstractSymplifyFixer implements Configurabl
             CT::T_USE_LAMBDA,
             // "new"
             T_NEW,
+            // "#["
+            T_ATTRIBUTE,
         ]);
     }
 
@@ -112,7 +114,7 @@ final class LineLengthFixer extends AbstractSymplifyFixer implements Configurabl
             }
 
             // opener
-            if ($token->isGivenKind([T_FUNCTION, CT::T_USE_LAMBDA, T_NEW])) {
+            if ($token->isGivenKind([T_ATTRIBUTE, T_FUNCTION, CT::T_USE_LAMBDA, T_NEW])) {
                 $this->processFunctionOrArray($tokens, $position);
                 continue;
             }

--- a/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/BlockFinder.php
+++ b/packages/coding-standard/src/TokenRunner/Analyzer/FixerAnalyzer/BlockFinder.php
@@ -23,12 +23,13 @@ final class BlockFinder
         ']' => Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE,
         '{' => Tokens::BLOCK_TYPE_CURLY_BRACE,
         '}' => Tokens::BLOCK_TYPE_CURLY_BRACE,
+        '#[' => Tokens::BLOCK_TYPE_ATTRIBUTE,
     ];
 
     /**
      * @var string[]
      */
-    private const START_EDGES = ['(', '[', '{'];
+    private const START_EDGES = ['(', '[', '{', '#['];
 
     /**
      * Accepts position to both start and end token, e.g. (, ), [, ], {, } also to: "array"(, "function" ...(, "use"(,
@@ -105,6 +106,9 @@ final class BlockFinder
         if ($token->isArray()) {
             if (in_array($token->getContent(), ['[', ']'], true)) {
                 return Tokens::BLOCK_TYPE_ARRAY_SQUARE_BRACE;
+            }
+            if (in_array($token->getContent(), ['#['], true)) {
+                return Tokens::BLOCK_TYPE_ATTRIBUTE;
             }
 
             return Tokens::BLOCK_TYPE_ARRAY_INDEX_CURLY_BRACE;

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Fixture/break_attribute.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Fixture/break_attribute.php.inc
@@ -1,0 +1,35 @@
+<?php
+
+#[SomeObject($someLongArgument, $someLongArgument, $anotherLongArgument, $anotherLongArgument, $passTheLimit)]
+class SomeClass
+{
+
+}
+
+#[SomeObject($someLongArgument, $someLongArgument, $anotherLongArgument, $anotherLongArgument, $limits)]
+class SomeClass
+{
+
+}
+?>
+-----
+<?php
+
+#[SomeObject(
+    $someLongArgument,
+    $someLongArgument,
+    $anotherLongArgument,
+    $anotherLongArgument,
+    $passTheLimit
+)]
+class SomeClass
+{
+
+}
+
+#[SomeObject($someLongArgument, $someLongArgument, $anotherLongArgument, $anotherLongArgument, $limits)]
+class SomeClass
+{
+
+}
+?>


### PR DESCRIPTION
When the LineLengthFixer is used, it should also break `#[Attribute('long', 'value', 'here')]`.

I don't know to fix this. Added a failing test. 