### PR TITLE
Flatten yaml line before creating arguments

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/XmlToPhp/Fixture/tag_with_additional_attributes.xml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/XmlToPhp/Fixture/tag_with_additional_attributes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+
+<services>
+    <service id="mime_types">
+        <tag name="tag1" priority="1" />
+        <tag name="tag2" priority="2" />
+    </service>
+</services>
+
+</container>
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set('mime_types')
+        ->tag('tag1', ['priority' => 1])
+        ->tag('tag2', ['priority' => 2]);
+};

--- a/packages/php-config-printer/src/Converter/ServiceOptionsKeyYamlToPhpFactory/TagsServiceOptionKeyYamlToPhpFactory.php
+++ b/packages/php-config-printer/src/Converter/ServiceOptionsKeyYamlToPhpFactory/TagsServiceOptionKeyYamlToPhpFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PhpConfigPrinter\Converter\ServiceOptionsKeyYamlToPhpFactory;
 
+use Nette\Utils\Arrays;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
@@ -47,14 +48,15 @@ final class TagsServiceOptionKeyYamlToPhpFactory implements ServiceOptionsKeyYam
             }
 
             $args = [];
-            foreach ($yamlLine as $singleNestedKey => $singleNestedValue) {
+            $flattenedYmlLine = Arrays::flatten($yamlLine, true);
+            foreach ($flattenedYmlLine as $singleNestedKey => $singleNestedValue) {
                 if ($singleNestedKey === 'name') {
                     $args[] = new Arg(BuilderHelpers::normalizeValue($singleNestedValue));
-                    unset($yamlLine[$singleNestedKey]);
+                    unset($flattenedYmlLine[$singleNestedKey]);
                 }
             }
 
-            $restArgs = $this->argsNodeFactory->createFromValuesAndWrapInArray($yamlLine);
+            $restArgs = $this->argsNodeFactory->createFromValuesAndWrapInArray($flattenedYmlLine);
             $args = array_merge($args, $restArgs);
 
             $methodCall = new MethodCall($methodCall, self::TAG, $args);


### PR DESCRIPTION
When you have a service configuration in xml which looks like this:

```xml
<service id="mime_types">
    <tag name="tag1" priority="1" />
</service>
```

This XML will result in the following yml after converting it:

```yml
services:
  mime_types:
    tags:
      - 0: { name: tag1, priority: 1 }
```

And after parsing the yml, this is the resulting PHP array

```php
[
    'services' => [
        'mime_types' => [
            'tags' => [
                0 => [
                    0 => [
                        'name' => 'tag1',
                        'priority' => 1,
                    ],
                ],
            ],
        ],
    ],
];
```

The multi-nesting from the `tags` key was not handled properly and thus resulted in the following (invalid) code:

```php
$services->set('mime_types')
    ->tag([['name' => 'tag1', 'priority' => 1]]);
```

Flattening the array before processing it, fixes the issue.