### PR TITLE
Fix typed property being accessed before init

### DIFF
--- a/packages/git-wrapper/src/GitWrapper.php
+++ b/packages/git-wrapper/src/GitWrapper.php
@@ -182,7 +182,7 @@ final class GitWrapper
 
         if (! $streamOutput && $this->outputEventSubscriber !== null) {
             $this->removeOutputEventSubscriber($this->outputEventSubscriber);
-            unset($this->outputEventSubscriber);
+            $this->outputEventSubscriber = null;
         }
     }
 

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -8,6 +8,7 @@ use Iterator;
 use Nette\Utils\Strings;
 use OndraM\CiDetector\CiDetector;
 use Symfony\Component\Process\Process;
+use Symplify\GitWrapper\EventSubscriber\StreamOutputEventSubscriber;
 use Symplify\GitWrapper\Exception\GitException;
 use Symplify\GitWrapper\GitBranches;
 use Symplify\GitWrapper\GitCommits;
@@ -452,10 +453,25 @@ CODE_SAMPLE;
 
         $this->assertEmpty($empty);
 
+        stream_filter_remove($stdoutSuppress);
+    }
+
+    public function testToggleStreamOutput(): void
+    {
+        $git = $this->getWorkingCopy();
+        $gitWrapper = $git->getWrapper();
+
         $gitWrapper->streamOutput(true);
         $git->status();
 
-        stream_filter_remove($stdoutSuppress);
+        $gitWrapper->streamOutput(false);
+        $git->status();
+
+        $gitWrapper->streamOutput(true);
+        $git->status();
+
+        $invader = (fn() => $this->outputEventSubscriber);
+        $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));
     }
 
     public function testCommitWithAuthor(): void

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -472,6 +472,7 @@ CODE_SAMPLE;
 
         /* @phpstan-ignore-next-line */
         $invader = (fn() => $this->outputEventSubscriber);
+
         $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));
     }
 

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -452,6 +452,9 @@ CODE_SAMPLE;
 
         $this->assertEmpty($empty);
 
+        $gitWrapper->streamOutput(true);
+        $git->status();
+
         stream_filter_remove($stdoutSuppress);
     }
 

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -470,7 +470,6 @@ CODE_SAMPLE;
         $gitWrapper->streamOutput(true);
         $git->status();
 
-        /* @phpstan-ignore-next-line */
         $invader = (fn() => $this->outputEventSubscriber);
 
         $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -470,6 +470,7 @@ CODE_SAMPLE;
         $gitWrapper->streamOutput(true);
         $git->status();
 
+        /* @phpstan-ignore-next-line */
         $invader = (fn() => $this->outputEventSubscriber);
         $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));
     }

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -471,8 +471,9 @@ CODE_SAMPLE;
         $git->status();
 
         $invader = (fn() => $this->outputEventSubscriber);
+        $outputEventSubscriber = $invader->call($this->gitWrapper);
 
-        $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));
+        $this->assertInstanceOf(StreamOutputEventSubscriber::class, $outputEventSubscriber);
     }
 
     public function testCommitWithAuthor(): void

--- a/packages/git-wrapper/tests/GitWrapperTest.php
+++ b/packages/git-wrapper/tests/GitWrapperTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\GitWrapper\Tests;
 
-use Symplify\GitWrapper\EventSubscriber\StreamOutputEventSubscriber;
 use Symplify\GitWrapper\Exception\GitException;
 use Symplify\GitWrapper\GitCommand;
 use Symplify\GitWrapper\GitWorkingCopy;

--- a/packages/git-wrapper/tests/GitWrapperTest.php
+++ b/packages/git-wrapper/tests/GitWrapperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\GitWrapper\Tests;
 
+use Symplify\GitWrapper\EventSubscriber\StreamOutputEventSubscriber;
 use Symplify\GitWrapper\Exception\GitException;
 use Symplify\GitWrapper\GitCommand;
 use Symplify\GitWrapper\GitWorkingCopy;
@@ -206,6 +207,6 @@ final class GitWrapperTest extends AbstractGitWrapperTestCase
         $this->assertNull($invader->call($this->gitWrapper));
 
         $this->gitWrapper->streamOutput();
-        $this->assertNotNull($invader->call($this->gitWrapper));
+        $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));
     }
 }

--- a/packages/git-wrapper/tests/GitWrapperTest.php
+++ b/packages/git-wrapper/tests/GitWrapperTest.php
@@ -197,4 +197,15 @@ final class GitWrapperTest extends AbstractGitWrapperTestCase
         $gitWorkingCopy = $this->gitWrapper->cloneRepository('file:///' . $this->randomString());
         $this->assertTrue($gitWorkingCopy->isCloned());
     }
+
+    public function testToggleStreamOutput(): void
+    {
+        $invader = (fn() => $this->outputEventSubscriber);
+
+        $this->gitWrapper->streamOutput(false);
+        $this->assertNull($invader->call($this->gitWrapper));
+
+        $this->gitWrapper->streamOutput();
+        $this->assertNotNull($invader->call($this->gitWrapper));
+    }
 }

--- a/packages/git-wrapper/tests/GitWrapperTest.php
+++ b/packages/git-wrapper/tests/GitWrapperTest.php
@@ -198,15 +198,4 @@ final class GitWrapperTest extends AbstractGitWrapperTestCase
         $gitWorkingCopy = $this->gitWrapper->cloneRepository('file:///' . $this->randomString());
         $this->assertTrue($gitWorkingCopy->isCloned());
     }
-
-    public function testToggleStreamOutput(): void
-    {
-        $invader = (fn() => $this->outputEventSubscriber);
-
-        $this->gitWrapper->streamOutput(false);
-        $this->assertNull($invader->call($this->gitWrapper));
-
-        $this->gitWrapper->streamOutput();
-        $this->assertInstanceOf(StreamOutputEventSubscriber::class, $invader->call($this->gitWrapper));
-    }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -142,6 +142,11 @@ parameters:
                 - packages/smart-file-system/tests/Finder/FinderSanitizer/FinderSanitizerTest.php
 
         -
+            message: '#Access to an undefined property Symplify\\GitWrapper\\Tests\\GitWorkingCopyTest\:\:\$outputEventSubscriber#'
+            paths:
+                - packages/git-wrapper/tests/GitWorkingCopyTest.php
+
+        -
             message: '#Do not use static property#'
             paths:
                 - packages/easy-testing/src/StaticFixtureSplitter.php # 19


### PR DESCRIPTION
Currently, the following code:

```
$gitWrapper = new GitWrapper(...);
$gitWrapper->streamOutput(false);
$gitWrapper->streamOutput();
```

will result in:

`Typed property Symplify\GitWrapper\GitWrapper::$outputEventSubscriber must not be accessed before initialization`

This is because the property was being `unset()` when calling `GitWrapper::streamOutput(false)`.