### PR TITLE
[GitWrapper] Use PrivateAccesor to get outputEventSubscriber property in GitWorkingCopyTest

### DIFF
--- a/packages/git-wrapper/composer.json
+++ b/packages/git-wrapper/composer.json
@@ -11,6 +11,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
+        "symplify/package-builder": "^10.2",
         "symplify/smart-file-system": "^10.2",
         "psr/log": "^1.1",
         "ondram/ci-detector": "^4.1"

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -16,6 +16,7 @@ use Symplify\GitWrapper\GitWorkingCopy;
 use Symplify\GitWrapper\Tests\EventSubscriber\Source\TestGitOutputEventSubscriber;
 use Symplify\GitWrapper\Tests\Source\StreamSuppressFilter;
 use Symplify\GitWrapper\ValueObject\CommandName;
+use Symplify\PackageBuilder\Reflection\PrivatesAccessor;
 
 final class GitWorkingCopyTest extends AbstractGitWrapperTestCase
 {
@@ -60,6 +61,8 @@ CODE_SAMPLE;
     private string $currentUserName;
 
     private string $currentUserEmail;
+
+    private PrivatesAccessor $privateAccessor;
 
     /**
      * Creates and initializes the local repository used for testing.
@@ -113,6 +116,8 @@ CODE_SAMPLE;
         $gitWorkingCopy->pushTags();
 
         $this->smartFileSystem->remove(self::DIRECTORY);
+
+        $this->privateAccessor = new PrivatesAccessor();
     }
 
     /**
@@ -470,9 +475,7 @@ CODE_SAMPLE;
         $gitWrapper->streamOutput(true);
         $git->status();
 
-        $invader = (fn() => $this->outputEventSubscriber);
-        $outputEventSubscriber = $invader->call($this->gitWrapper);
-
+        $outputEventSubscriber = $this->privateAccessor->getPrivateProperty($gitWrapper, 'outputEventSubscriber');
         $this->assertInstanceOf(StreamOutputEventSubscriber::class, $outputEventSubscriber);
     }
 

--- a/packages/git-wrapper/tests/GitWorkingCopyTest.php
+++ b/packages/git-wrapper/tests/GitWorkingCopyTest.php
@@ -467,6 +467,7 @@ CODE_SAMPLE;
         $gitWrapper = $git->getWrapper();
 
         $gitWrapper->streamOutput(true);
+
         $git->status();
 
         $gitWrapper->streamOutput(false);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -142,11 +142,6 @@ parameters:
                 - packages/smart-file-system/tests/Finder/FinderSanitizer/FinderSanitizerTest.php
 
         -
-            message: '#Access to an undefined property Symplify\\GitWrapper\\Tests\\GitWorkingCopyTest\:\:\$outputEventSubscriber#'
-            paths:
-                - packages/git-wrapper/tests/GitWorkingCopyTest.php
-
-        -
             message: '#Do not use static property#'
             paths:
                 - packages/easy-testing/src/StaticFixtureSplitter.php # 19


### PR DESCRIPTION
@riesjart This is to continue https://github.com/symplify/symplify/pull/3997 to use PrivateAccesor to get clean PHPStan notice.