### PR TITLE
 [ECS] Skip StandaloneLineConstructorParamFixer 

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -7,6 +7,7 @@ use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\Annotation\DoctrineAnnotationNestedBracketsFixer;
 use Symplify\CodingStandard\Fixer\LineLength\LineLengthFixer;
+use Symplify\CodingStandard\Fixer\Spacing\StandaloneLineConstructorParamFixer;
 use Symplify\EasyCodingStandard\ValueObject\Option;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -65,5 +66,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             // breaks interface contract
             __DIR__ . '/packages/config-transformer/src/DependencyInjection/Loader/IdAwareXmlFileLoader.php',
         ],
+        StandaloneLineConstructorParamFixer::class,
     ]);
 };

--- a/ecs.php
+++ b/ecs.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use PhpCsFixer\Fixer\Basic\BracesFixer;
 use SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSniff;
 use SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSniff;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -66,6 +65,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             // breaks interface contract
             __DIR__ . '/packages/config-transformer/src/DependencyInjection/Loader/IdAwareXmlFileLoader.php',
         ],
-        BracesFixer::class,
     ]);
 };


### PR DESCRIPTION
Skip StandaloneLineConstructorParamFixer instead of BracesFixer per https://github.com/symplify/symplify/pull/4004#issuecomment-1068969587

 Can be enabled until it is working again, ref https://github.com/symplify/symplify/pull/4006#issuecomment-1068988918 for use case to be skipped.