### PR TITLE
Add failing test for: LineLengthFixer needs second pass when last argument of long function signature is empty array

### DIFF
--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Fixture/wrong_array_bracket_position_in_arg_list.php.inc
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/Fixture/wrong_array_bracket_position_in_arg_list.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+class Bar
+{
+    public function foo(string $arg1, string $arg2, string $arg3, string $arg4, string $arg5, string $arg6, array $arg7 = []): void
+    {
+        // Do stuff
+    }
+}
+?>
+-----
+<?php
+
+class Bar
+{
+    public function foo(
+        string $arg1,
+        string $arg2,
+        string $arg3,
+        string $arg4,
+        string $arg5,
+        string $arg6,
+        array $arg7 = []
+    ): void
+    {
+        // Do stuff
+    }
+}
+?>


### PR DESCRIPTION
Issue: #4013