### PR TITLE
[Scoper] Clean up missing use with prefixed

### DIFF
--- a/packages/config-transformer/scoper.php
+++ b/packages/config-transformer/scoper.php
@@ -41,11 +41,7 @@ return [
                 return $content;
             }
 
-            $content = Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-
-            // add missing use statements prefixes
-            // @see https://github.com/symplify/easy-coding-standard/commit/5c11eca46fbe341ac30d0d5da2c51e1596950299#diff-87ecc51ebcf33f4c2699c08f35403560ad1ea98d22771df83a29d00dc5f53a1cR12
-            return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
+            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
         },
         // remove namespace frompoly fill stubs
         function (string $filePath, string $prefix, string $content): string {

--- a/packages/easy-ci/scoper.php
+++ b/packages/easy-ci/scoper.php
@@ -43,11 +43,7 @@ return [
                 return $content;
             }
 
-            $content = Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-
-            // add missing use statements prefixes
-            // @see https://github.com/symplify/easy-coding-standard/commit/5c11eca46fbe341ac30d0d5da2c51e1596950299#diff-87ecc51ebcf33f4c2699c08f35403560ad1ea98d22771df83a29d00dc5f53a1cR12
-            return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
+            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
         },
         // remove namespace from polyfill stubs
         function (string $filePath, string $prefix, string $content): string {

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -49,11 +49,7 @@ return [
                 return $content;
             }
 
-            $content = Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-
-            // add missing use statements prefixes
-            // @see https://github.com/symplify/easy-coding-standard/commit/5c11eca46fbe341ac30d0d5da2c51e1596950299#diff-87ecc51ebcf33f4c2699c08f35403560ad1ea98d22771df83a29d00dc5f53a1cR12
-            return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
+            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
         },
         // remove namespace frompoly fill stubs
         function (string $filePath, string $prefix, string $content): string {

--- a/packages/monorepo-builder/scoper.php
+++ b/packages/monorepo-builder/scoper.php
@@ -47,11 +47,7 @@ return [
                 return $content;
             }
 
-            $content = Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-
-            // add missing use statements prefixes
-            // @see https://github.com/symplify/easy-coding-standard/commit/5c11eca46fbe341ac30d0d5da2c51e1596950299#diff-87ecc51ebcf33f4c2699c08f35403560ad1ea98d22771df83a29d00dc5f53a1cR12
-            return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
+            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
         },
 
         // scope symfony configs

--- a/packages/phpstan-rules/src/Rules/AnnotateRegexClassConstWithRegexLinkRule.php
+++ b/packages/phpstan-rules/src/Rules/AnnotateRegexClassConstWithRegexLinkRule.php
@@ -112,12 +112,8 @@ CODE_SAMPLE
         }
 
         $lastChar = Strings::substring($patternWithoutModifiers, -1, 1);
-        if ($firstChar !== $lastChar) {
-            return false;
-        }
-
         // this is probably a regex
-        return true;
+        return $firstChar === $lastChar;
     }
 
     private function hasDocBlockWithRegexLink(ClassConst $classConst): bool


### PR DESCRIPTION
The string replace is not applied, even applied, it will invalid as there is space in replacement.

```
return Strings::replace($content, '#use Symfony\\\\Polyfill#', 'use ' . $prefix . ' Symfony\Polyfill');
```

so it can be removed. 