### PR TITLE
[PHPStan] Set compatible with upcoming PHPStan 1.6.x with set NodeConnectingVisitor tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "^4.13.2",
         "phar-io/version": "^3.2",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "react/child-process": "^0.6.4",
         "react/event-loop": "^1.2",
         "react/socket": "^1.11",

--- a/packages/astral/composer.json
+++ b/packages/astral/composer.json
@@ -8,7 +8,7 @@
         "nette/utils": "^3.2",
         "symfony/dependency-injection": "^6.0",
         "symplify/smart-file-system": "^10.3",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "phpstan/phpdoc-parser": "^1.2",
         "symfony/config": "^6.0",
         "nikic/php-parser": "^4.13.2",
@@ -35,6 +35,7 @@
         },
         "phpstan": {
             "includes": [
+                "config/config.neon",
                 "config/services.neon"
             ]
         }

--- a/packages/astral/config/config.neon
+++ b/packages/astral/config/config.neon
@@ -1,0 +1,3 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true

--- a/packages/easy-coding-standard/src/Application/Version/StaticVersionResolver.php
+++ b/packages/easy-coding-standard/src/Application/Version/StaticVersionResolver.php
@@ -24,6 +24,7 @@ final class StaticVersionResolver
      * @var string
      */
     public const RELEASE_DATE = '@release_date@';
+
     /**
      * @var string
      */

--- a/packages/easy-coding-standard/src/Application/Version/StaticVersionResolver.php
+++ b/packages/easy-coding-standard/src/Application/Version/StaticVersionResolver.php
@@ -24,10 +24,14 @@ final class StaticVersionResolver
      * @var string
      */
     public const RELEASE_DATE = '@release_date@';
+    /**
+     * @var string
+     */
+    private const GIT = 'git';
 
     public static function resolvePackageVersion(): string
     {
-        $pointsAtProcess = new Process(['git', 'tag', '--points-at'], __DIR__);
+        $pointsAtProcess = new Process([self::GIT, 'tag', '--points-at'], __DIR__);
         if ($pointsAtProcess->run() !== Command::SUCCESS) {
             throw new VersionException(
                 'You must ensure to run compile from composer git repository clone and that git binary is available.'
@@ -35,11 +39,11 @@ final class StaticVersionResolver
         }
 
         $tag = trim($pointsAtProcess->getOutput());
-        if ($tag) {
+        if ($tag !== '' && $tag !== '0') {
             return $tag;
         }
 
-        $process = new Process(['git', 'log', '--pretty="%H"', '-n1', 'HEAD'], __DIR__);
+        $process = new Process([self::GIT, 'log', '--pretty="%H"', '-n1', 'HEAD'], __DIR__);
         if ($process->run() !== Command::SUCCESS) {
             throw new VersionException(
                 'You must ensure to run compile from composer git repository clone and that git binary is available.'
@@ -52,7 +56,7 @@ final class StaticVersionResolver
 
     public static function resolverReleaseDateTime(): DateTime
     {
-        $process = new Process(['git', 'log', '-n1', '--pretty=%ci', 'HEAD'], __DIR__);
+        $process = new Process([self::GIT, 'log', '-n1', '--pretty=%ci', 'HEAD'], __DIR__);
         if ($process->run() !== Command::SUCCESS) {
             throw new VersionException(
                 'You must ensure to run compile from composer git repository clone and that git binary is available.'

--- a/packages/latte-phpstan-compiler/composer.json
+++ b/packages/latte-phpstan-compiler/composer.json
@@ -8,7 +8,7 @@
         "nette/utils": "^3.2",
         "nette/application": "^3.1",
         "latte/latte": "^2.11",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "symplify/astral": "^10.3",
         "symplify/package-builder": "^10.3",
         "symplify/template-phpstan-compiler": "^10.3"
@@ -35,6 +35,7 @@
         },
         "phpstan": {
             "includes": [
+                "config/config.neon",
                 "config/services.neon"
             ]
         }

--- a/packages/latte-phpstan-compiler/config/config.neon
+++ b/packages/latte-phpstan-compiler/config/config.neon
@@ -1,0 +1,3 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true

--- a/packages/phpstan-extensions/composer.json
+++ b/packages/phpstan-extensions/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "symplify/package-builder": "^10.3",
         "symplify/smart-file-system": "^10.3",
         "symplify/astral": "^10.3"

--- a/packages/phpstan-extensions/config/config.neon
+++ b/packages/phpstan-extensions/config/config.neon
@@ -1,3 +1,7 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true
+
 includes:
     - symplify.error_formatter.neon
 

--- a/packages/phpstan-latte-rules/composer.json
+++ b/packages/phpstan-latte-rules/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "latte/latte": "^2.11",
         "symplify/astral": "^10.3",
         "symplify/rule-doc-generator-contracts": "^10.3",
@@ -38,6 +38,7 @@
         },
         "phpstan": {
             "includes": [
+                "config/config.neon",
                 "config/rules.neon",
                 "config/services.neon"
             ]

--- a/packages/phpstan-latte-rules/config/config.neon
+++ b/packages/phpstan-latte-rules/config/config.neon
@@ -1,0 +1,3 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true

--- a/packages/phpstan-rules/composer.json
+++ b/packages/phpstan-rules/composer.json
@@ -8,7 +8,7 @@
         "nikic/php-parser": "^4.13.2",
         "nette/utils": "^3.2",
         "phpstan/phpdoc-parser": "^1.2",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "symplify/astral": "^10.3",
         "symplify/composer-json-manipulator": "^10.3",
         "symplify/package-builder": "^10.3",
@@ -54,6 +54,7 @@
         },
         "phpstan": {
             "includes": [
+                "config/config.neon",
                 "config/services/services.neon",
                 "packages/cognitive-complexity/config/cognitive-complexity-services.neon",
                 "packages/symfony/config/services.neon",

--- a/packages/phpstan-rules/config/config.neon
+++ b/packages/phpstan-rules/config/config.neon
@@ -1,0 +1,3 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true

--- a/packages/rule-doc-generator/composer.json
+++ b/packages/rule-doc-generator/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "friendsofphp/php-cs-fixer": "^3.7"
     },
     "autoload": {

--- a/packages/symfony-static-dumper/composer.json
+++ b/packages/symfony-static-dumper/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "doctrine/annotations": "^1.13",
         "doctrine/cache": "^1.12",
-        "phpstan/phpstan": "^1.4.8",
+        "phpstan/phpstan": "^1.5.6",
         "phpunit/phpunit": "^9.5",
         "symfony/framework-bundle": "^6.0",
         "symfony/twig-bundle": "^6.0"

--- a/packages/template-phpstan-compiler/composer.json
+++ b/packages/template-phpstan-compiler/composer.json
@@ -8,7 +8,7 @@
         "nette/utils": "^3.2",
         "symplify/astral": "^10.3",
         "symplify/package-builder": "^10.3",
-        "phpstan/phpstan": "^1.4.8"
+        "phpstan/phpstan": "^1.5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -31,6 +31,7 @@
         },
         "phpstan": {
             "includes": [
+                "config/config.neon",
                 "config/services.neon"
             ]
         }

--- a/packages/template-phpstan-compiler/config/config.neon
+++ b/packages/template-phpstan-compiler/config/config.neon
@@ -1,0 +1,3 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,7 @@
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true
+
 includes:
     - packages/astral/config/services.neon
     - packages/phpstan-extensions/config/config.neon
@@ -489,6 +493,7 @@ parameters:
                 - packages/easy-coding-standard/src/Application/EasyCodingStandardApplication.php
                 - packages/easy-coding-standard/packages/*/Application/*FileProcessor.php
                 - packages/php-config-printer/src/NodeFactory/Service/ServiceOptionNodeFactory.php
+                - packages/php-config-printer/src/Printer/SmartPhpConfigPrinter.php
 
         -
             message: '#Complete known array shape to the method @return type#'


### PR DESCRIPTION
Based on @ondrejmirtes request at https://github.com/rectorphp/rector-src/pull/2014#pullrequestreview-943347221 , this PR update to set compatible with upcoming PHPStan 1.6.x with update require of phpstan to ^1.5.6 and update `conditionalTags` of `NodeConnectingVisitor` for symplify as well.