### PR TITLE
tv phpstan rules simpler 2

### DIFF
--- a/packages/phpstan-rules/packages/nette/src/Rules/ValidNetteInjectRule.php
+++ b/packages/phpstan-rules/packages/nette/src/Rules/ValidNetteInjectRule.php
@@ -8,7 +8,10 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+<<<<<<< HEAD
 use PHPStan\Rules\RuleError;
+=======
+>>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
 use PHPStan\Rules\RuleErrorBuilder;
 use Symplify\PHPStanRules\NodeAnalyzer\AutowiredMethodPropertyAnalyzer;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
@@ -37,24 +40,41 @@ final class ValidNetteInjectRule implements Rule, DocumentedRuleInterface
 
     /**
      * @param Class_ $node
+<<<<<<< HEAD
      * @return RuleError[]
+=======
+     * @return string[]
+>>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
      */
     public function processNode(Node $node, Scope $scope): array
     {
         $ruleErrors = [];
 
         $propertiesAndClassMethods = array_merge($node->getProperties(), $node->getMethods());
+<<<<<<< HEAD
         foreach ($propertiesAndClassMethods as $propertyAndClassMethod) {
             if (! $this->autowiredMethodPropertyAnalyzer->detect($propertyAndClassMethod)) {
                 continue;
             }
 
             if ($propertyAndClassMethod->isPublic()) {
+=======
+        foreach ($propertiesAndClassMethods as $propertyOrClassMethod) {
+            if (! $this->autowiredMethodPropertyAnalyzer->detect($propertyOrClassMethod)) {
+                continue;
+            }
+
+            if ($propertyOrClassMethod->isPublic()) {
+>>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
                 continue;
             }
 
             $ruleErrors[] = RuleErrorBuilder::message(self::ERROR_MESSAGE)
+<<<<<<< HEAD
                 ->line($propertyAndClassMethod->getLine())
+=======
+                ->line($propertyOrClassMethod->getLine())
+>>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
                 ->build();
         }
 

--- a/packages/phpstan-rules/packages/nette/src/Rules/ValidNetteInjectRule.php
+++ b/packages/phpstan-rules/packages/nette/src/Rules/ValidNetteInjectRule.php
@@ -8,14 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
-<<<<<<< HEAD
-<<<<<<< HEAD
 use PHPStan\Rules\RuleError;
-=======
->>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
-=======
-use PHPStan\Rules\RuleError;
->>>>>>> remove unused ClassReflectionResolver
 use PHPStan\Rules\RuleErrorBuilder;
 use Symplify\PHPStanRules\NodeAnalyzer\AutowiredMethodPropertyAnalyzer;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
@@ -44,45 +37,25 @@ final class ValidNetteInjectRule implements Rule, DocumentedRuleInterface
 
     /**
      * @param Class_ $node
-<<<<<<< HEAD
-<<<<<<< HEAD
      * @return RuleError[]
-=======
-     * @return string[]
->>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
-=======
-     * @return RuleError[]
->>>>>>> remove unused ClassReflectionResolver
      */
     public function processNode(Node $node, Scope $scope): array
     {
         $ruleErrors = [];
 
         $propertiesAndClassMethods = array_merge($node->getProperties(), $node->getMethods());
-<<<<<<< HEAD
+
         foreach ($propertiesAndClassMethods as $propertyAndClassMethod) {
             if (! $this->autowiredMethodPropertyAnalyzer->detect($propertyAndClassMethod)) {
                 continue;
             }
 
             if ($propertyAndClassMethod->isPublic()) {
-=======
-        foreach ($propertiesAndClassMethods as $propertyOrClassMethod) {
-            if (! $this->autowiredMethodPropertyAnalyzer->detect($propertyOrClassMethod)) {
-                continue;
-            }
-
-            if ($propertyOrClassMethod->isPublic()) {
->>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
                 continue;
             }
 
             $ruleErrors[] = RuleErrorBuilder::message(self::ERROR_MESSAGE)
-<<<<<<< HEAD
                 ->line($propertyAndClassMethod->getLine())
-=======
-                ->line($propertyOrClassMethod->getLine())
->>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
                 ->build();
         }
 

--- a/packages/phpstan-rules/packages/nette/src/Rules/ValidNetteInjectRule.php
+++ b/packages/phpstan-rules/packages/nette/src/Rules/ValidNetteInjectRule.php
@@ -9,9 +9,13 @@ use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 <<<<<<< HEAD
+<<<<<<< HEAD
 use PHPStan\Rules\RuleError;
 =======
 >>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
+=======
+use PHPStan\Rules\RuleError;
+>>>>>>> remove unused ClassReflectionResolver
 use PHPStan\Rules\RuleErrorBuilder;
 use Symplify\PHPStanRules\NodeAnalyzer\AutowiredMethodPropertyAnalyzer;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
@@ -41,10 +45,14 @@ final class ValidNetteInjectRule implements Rule, DocumentedRuleInterface
     /**
      * @param Class_ $node
 <<<<<<< HEAD
+<<<<<<< HEAD
      * @return RuleError[]
 =======
      * @return string[]
 >>>>>>> [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
+=======
+     * @return RuleError[]
+>>>>>>> remove unused ClassReflectionResolver
      */
     public function processNode(Node $node, Scope $scope): array
     {

--- a/packages/phpstan-rules/src/NodeAnalyzer/AttributeFinder.php
+++ b/packages/phpstan-rules/src/NodeAnalyzer/AttributeFinder.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Symplify\PHPStanRules\NodeAnalyzer;
 
 use PhpParser\Node\Attribute;
-use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Property;
@@ -23,11 +23,25 @@ final class AttributeFinder
     /**
      * @return Attribute[]
      */
+    public function findInClass(Class_ $class): array
+    {
+        $attributes = [];
+
+        $targetNodes = array_merge($class->getMethods(), $class->getProperties(), [$class]);
+        foreach ($targetNodes as $targetNode) {
+            $attributes = array_merge($attributes, $this->findAttributes($targetNode));
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @return Attribute[]
+     */
     public function findAttributes(ClassMethod | Property | ClassLike | Param $node): array
     {
         $attributes = [];
 
-        /** @var AttributeGroup $attrGroup */
         foreach ($node->attrGroups as $attrGroup) {
             $attributes = array_merge($attributes, $attrGroup->attrs);
         }

--- a/packages/phpstan-rules/src/Rules/PreferredAttributeOverAnnotationRule.php
+++ b/packages/phpstan-rules/src/Rules/PreferredAttributeOverAnnotationRule.php
@@ -106,7 +106,7 @@ class SomeController
 CODE_SAMPLE
                 ,
                 [
-                    'annotations' => [Route::class],
+                    'annotations' => ['Symfony\Component\Routing\Annotation\Route'],
                 ]
             ),
         ]);

--- a/packages/phpstan-rules/src/Rules/PreferredAttributeOverAnnotationRule.php
+++ b/packages/phpstan-rules/src/Rules/PreferredAttributeOverAnnotationRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
-use Symfony\Component\Routing\Annotation\Route;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPStan\Analyser\Scope;


### PR DESCRIPTION
- [PHPStanRules] Make ValidNetteInjectRule use directly Rule interface
- [PHPStanRule] Make PreferredAttributeOverAnnotationRule work with Rule interface
- remove unused ClassReflectionResolver
- [PHPStanRules] Make RequireAttributeNameRule use directly Rule
