### PR TITLE
Fix various "sprintf" typos relating to `CheckSprintfMatchingTypesRule`

### DIFF
--- a/packages/phpstan-rules/config/static-rules.neon
+++ b/packages/phpstan-rules/config/static-rules.neon
@@ -4,7 +4,7 @@ rules:
     - Symplify\PHPStanRules\Rules\NoDependencyJugglingRule
 
     - Symplify\PHPStanRules\Rules\Spotter\IfElseToMatchSpotterRule
-    - Symplify\PHPStanRules\Rules\Missing\CheckSprinfMatchingTypesRule
+    - Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule
     - Symplify\PHPStanRules\Rules\Explicit\NoReadonlyStaticVariableRule
     - Symplify\PHPStanRules\Rules\Explicit\ValueObjectOverArrayShapeRule
 

--- a/packages/phpstan-rules/docs/rules_overview.md
+++ b/packages/phpstan-rules/docs/rules_overview.md
@@ -229,11 +229,11 @@ interface ProductRepositoryInterface
 
 <br>
 
-## CheckSprinfMatchingTypesRule
+## CheckSprintfMatchingTypesRule
 
 `sprintf()` call mask types does not match provided arguments types
 
-- class: [`Symplify\PHPStanRules\Rules\Missing\CheckSprinfMatchingTypesRule`](../src/Rules/Missing/CheckSprinfMatchingTypesRule.php)
+- class: [`Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule`](../src/Rules/Missing/CheckSprintfMatchingTypesRule.php)
 
 ```php
 echo sprintf('My name is %s and I have %d children', 10, 'Tomas');

--- a/packages/phpstan-rules/src/Rules/Missing/CheckSprintfMatchingTypesRule.php
+++ b/packages/phpstan-rules/src/Rules/Missing/CheckSprintfMatchingTypesRule.php
@@ -21,11 +21,11 @@ use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
- * @see \Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\CheckSprinfMatchingTypesRuleTest
+ * @see \Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\CheckSprintfMatchingTypesRuleTest
  *
  * @inspiration by https://github.com/phpstan/phpstan-src/blob/master/src/Rules/Functions/PrintfParametersRule.php
  */
-final class CheckSprinfMatchingTypesRule implements Rule, DocumentedRuleInterface
+final class CheckSprintfMatchingTypesRule implements Rule, DocumentedRuleInterface
 {
     /**
      * @var string
@@ -54,7 +54,7 @@ final class CheckSprinfMatchingTypesRule implements Rule, DocumentedRuleInterfac
     }
 
     /**
-     * @param FuncCall $node
+     * @param  FuncCall $node
      * @return string[]
      */
     public function processNode(Node $node, Scope $scope): array
@@ -98,7 +98,8 @@ final class CheckSprinfMatchingTypesRule implements Rule, DocumentedRuleInterfac
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition(self::ERROR_MESSAGE, [
+        return new RuleDefinition(
+            self::ERROR_MESSAGE, [
             new CodeSample(
                 <<<'CODE_SAMPLE'
 echo sprintf('My name is %s and I have %d children', 10, 'Tomas');
@@ -109,11 +110,12 @@ CODE_SAMPLE
 echo sprintf('My name is %s and I have %d children', 'Tomas', 10);
 CODE_SAMPLE
             ),
-        ]);
+            ]
+        );
     }
 
     /**
-     * @see https://github.com/phpstan/phpstan-src/blob/e10a7aac373e8b6f21b430034fc693300c2bbb69/src/Rules/Functions/PrintfParametersRule.php#L105-L115
+     * @see    https://github.com/phpstan/phpstan-src/blob/e10a7aac373e8b6f21b430034fc693300c2bbb69/src/Rules/Functions/PrintfParametersRule.php#L105-L115
      * @return string[]
      */
     private function resolveSpecifierMatches(ConstantStringType $constantStringType): array

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/CheckSprintfMatchingTypesRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/CheckSprintfMatchingTypesRuleTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule;
 
 use Iterator;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
-use Symplify\PHPStanRules\Rules\Missing\CheckSprinfMatchingTypesRule;
+use Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule;
 
 /**
- * @extends RuleTestCase<CheckSprinfMatchingTypesRule>
+ * @extends RuleTestCase<CheckSprintfMatchingTypesRule>
  */
-final class CheckSprinfMatchingTypesRuleTest extends RuleTestCase
+final class CheckSprintfMatchingTypesRuleTest extends RuleTestCase
 {
     /**
      * @dataProvider provideData()
@@ -25,9 +25,12 @@ final class CheckSprinfMatchingTypesRuleTest extends RuleTestCase
 
     public function provideData(): Iterator
     {
-        yield [__DIR__ . '/Fixture/MissMatchSprinft.php', [[CheckSprinfMatchingTypesRule::ERROR_MESSAGE, 11]]];
+        yield [
+            __DIR__ . '/Fixture/MissMatchSprintf.php',
+            [[CheckSprintfMatchingTypesRule::ERROR_MESSAGE, 11]]
+        ];
 
-        yield [__DIR__ . '/Fixture/SkipCorrectSprinft.php', []];
+        yield [__DIR__ . '/Fixture/SkipCorrectSprintf.php', []];
         yield [__DIR__ . '/Fixture/SkipCorrectForeachKey.php', []];
         yield [__DIR__ . '/Fixture/SkipToString.php', []];
         yield [__DIR__ . '/Fixture/SkipErrorType.php', []];
@@ -44,6 +47,6 @@ final class CheckSprinfMatchingTypesRuleTest extends RuleTestCase
 
     protected function getRule(): Rule
     {
-        return self::getContainer()->getByType(CheckSprinfMatchingTypesRule::class);
+        return self::getContainer()->getByType(CheckSprintfMatchingTypesRule::class);
     }
 }

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/MissMatchSprintf.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/MissMatchSprintf.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Fixture;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Fixture;
 
-final class MissMatchSprinft
+final class MissMatchSprintf
 {
     public function run()
     {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipCorrectForeachKey.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipCorrectForeachKey.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Fixture;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Fixture;
 
 final class SkipCorrectForeachKey
 {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipCorrectSprintf.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipCorrectSprintf.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Fixture;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Fixture;
 
-final class SkipCorrectSprinft
+final class SkipCorrectSprintf
 {
     public function run()
     {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipErrorType.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipErrorType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Fixture;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Fixture;
 
 final class SkipErrorType
 {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipToString.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipToString.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Fixture;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Fixture;
 
-use Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Source\SomeToString;
+use Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Source\SomeToString;
 
 final class SkipToString
 {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipValidTernary.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Fixture/SkipValidTernary.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Fixture;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Fixture;
 
 final class SkipValidTernary
 {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Source/SomeToString.php
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/Source/SomeToString.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprinfMatchingTypesRule\Source;
+namespace Symplify\PHPStanRules\Tests\Rules\Missing\CheckSprintfMatchingTypesRule\Source;
 
 final class SomeToString
 {

--- a/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Missing/CheckSprintfMatchingTypesRule/config/configured_rule.neon
@@ -3,5 +3,5 @@ includes:
 
 services:
     -
-        class: Symplify\PHPStanRules\Rules\Missing\CheckSprinfMatchingTypesRule
+        class: Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule
         tags: [phpstan.rules.rule]


### PR DESCRIPTION
See #4062. This PR fixes all the misspellings of "sprintf" I could find.

This probably warrants a major version increase to indicate the breaking change: `CheckSprinfMatchingTypesRule` is now `CheckSprintfMatchingTypesRule`.