### PR TITLE
[phpstan-rules] Removed missing config-files from README.md

### DIFF
--- a/packages/phpstan-rules/README.md
+++ b/packages/phpstan-rules/README.md
@@ -60,11 +60,7 @@ includes:
     - vendor/symplify/phpstan-rules/config/doctrine-rules.neon
     - vendor/symplify/phpstan-rules/config/naming-rules.neon
     - vendor/symplify/phpstan-rules/config/regex-rules.neon
-    - vendor/symplify/phpstan-rules/config/services-rules.neon
-    - vendor/symplify/phpstan-rules/config/size-rules.neon
     - vendor/symplify/phpstan-rules/config/forbidden-static-rules.neon
-    - vendor/symplify/phpstan-rules/config/string-to-constant-rules.neon
-    - vendor/symplify/phpstan-rules/config/symfony-rules.neon
     - vendor/symplify/phpstan-rules/config/test-rules.neon
 ```
 


### PR DESCRIPTION
Starting from version 10.2.6 the following config files were removed (I assume they have been included somewhere else?):
File 'vendor/symplify/phpstan-rules/config/services-rules.neon' is missing or is not readable.
File 'vendor/symplify/phpstan-rules/config/size-rules.neon' is missing or is not readable.
File 'vendor/symplify/phpstan-rules/config/string-to-constant-rules.neon' is missing or is not readable.
File 'vendor/symplify/phpstan-rules/config/symfony-rules.neon' is missing or is not readable.
But the above files were still in the readme.