### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build_ecs_prefixed.yaml
+++ b/.github/workflows/build_ecs_prefixed.yaml
@@ -18,8 +18,13 @@ env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-main"
 
+permissions:
+  contents: read
+
 jobs:
     build_ecs_prefixed:
+        permissions:
+          contents: write  # for Git to git push
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/build_tools.yaml
+++ b/.github/workflows/build_tools.yaml
@@ -21,8 +21,13 @@ env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-main"
 
+permissions:
+  contents: read
+
 jobs:
     build_tools:
+        permissions:
+          contents: write  # for Git to git push
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -10,6 +10,9 @@ env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-main"
 
+permissions:
+  contents: read
+
 jobs:
     code_analysis:
         strategy:

--- a/.github/workflows/lock_threads.yaml
+++ b/.github/workflows/lock_threads.yaml
@@ -4,8 +4,13 @@ on:
     schedule:
         - cron: '0 * * * *'
 
+permissions:
+  contents: read
+
 jobs:
     lock:
+        permissions:
+          contents: none
         runs-on: ubuntu-latest
         # don't run this action on forks
         if: github.repository_owner == 'symplify'

--- a/.github/workflows/split_tests.yaml
+++ b/.github/workflows/split_tests.yaml
@@ -7,6 +7,9 @@ env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-main"
 
+permissions:
+  contents: read
+
 jobs:
     provide_packages_json:
         # see json juggling: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#example-6

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -7,6 +7,9 @@ env:
     # see https://github.com/composer/composer/issues/9368#issuecomment-718112361
     COMPOSER_ROOT_VERSION: "dev-main"
 
+permissions:
+  contents: read
+
 jobs:
     unit_tests:
         runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
