### PR TITLE
Allow ValueObjects to use methods in constructor

### DIFF
--- a/packages/phpstan-rules/src/Rules/NoFactoryInConstructorRule.php
+++ b/packages/phpstan-rules/src/Rules/NoFactoryInConstructorRule.php
@@ -144,7 +144,12 @@ CODE_SAMPLE
             return false;
         }
 
-        return $this->arrayStringAndFnMatcher->isMatch($type->getClassName(), self::ALLOWED_TYPES);
+        $allowedTypesAndSkippedClassNames = array_merge(
+            self::ALLOWED_TYPES,
+            self::SKIP_CLASS_NAMES
+        );
+
+        return $this->arrayStringAndFnMatcher->isMatch($type->getClassName(), $allowedTypesAndSkippedClassNames);
     }
 
     private function isInAllowedClass(Scope $scope): bool

--- a/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/Fixture/SkipValueObject.php
+++ b/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/Fixture/SkipValueObject.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoFactoryInConstructorRule\Fixture;
+
+use Symplify\PHPStanRules\Tests\Rules\NoFactoryInConstructorRule\Source\ValueObject\ValueObject;
+
+final class SkipValueObject
+{
+    private int $value;
+
+    public function __construct(ValueObject $valueObject)
+    {
+        $this->value = $valueObject->getNumber();
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/NoFactoryInConstructorRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/NoFactoryInConstructorRuleTest.php
@@ -42,6 +42,8 @@ final class NoFactoryInConstructorRuleTest extends RuleTestCase
         ];
 
         yield [__DIR__ . '/Fixture/SkipParameterProvider.php', []];
+
+        yield [__DIR__ . '/Fixture/SkipValueObject.php', []];
     }
 
     /**

--- a/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/Source/ValueObject/ValueObject.php
+++ b/packages/phpstan-rules/tests/Rules/NoFactoryInConstructorRule/Source/ValueObject/ValueObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symplify\PHPStanRules\Tests\Rules\NoFactoryInConstructorRule\Source\ValueObject;
+
+final class ValueObject
+{
+    private int $number;
+
+    public function __construct(int $number)
+    {
+        $this->number = $number;
+    }
+
+    public function getNumber(): int
+    {
+        return $this->number;
+    }
+}


### PR DESCRIPTION
By allowing ValueObjects to use methods in the constructor
of an object we can cast object properties to scalars/primitives
which will help with immutability.