### PR TITLE
[build] Bump to php-scoper 0.17.2

### DIFF
--- a/packages/config-transformer/build/build-config-transformer-scoped.sh
+++ b/packages/config-transformer/build/build-config-transformer-scoped.sh
@@ -31,7 +31,7 @@ note "Starts"
 
 # 2. scope it
 note "Running scoper with '$RESULT_DIRECTORY' output directory"
-wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar -N --no-verbose
+wget https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar -N --no-verbose
 
 # create directory
 mkdir "$RESULT_DIRECTORY" -p

--- a/packages/config-transformer/scoper.php
+++ b/packages/config-transformer/scoper.php
@@ -21,6 +21,11 @@ return [
     'excluded-files' => [
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+        'vendor/symfony/polyfill-php80/bootstrap.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',

--- a/packages/config-transformer/scoper.php
+++ b/packages/config-transformer/scoper.php
@@ -6,18 +6,6 @@ use Nette\Utils\Strings;
 
 require __DIR__ . '/vendor/autoload.php';
 
-///**
-// * @see https://regex101.com/r/LMDq0p/1
-// * @var string
-// */
-//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-//
-///**
-// * @see https://regex101.com/r/RBZ0bN/1
-// * @var string
-// */
-//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
-
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
@@ -27,8 +15,10 @@ return [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
     ],
-    'exclude-namespaces' => ['#^Symplify\ConfigTransformer#'],
-    'exclude-files' => [
+
+    // excluded
+    'excluded-namespaces' => ['#^Symplify\ConfigTransformer#'],
+    'excluded-files' => [
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
@@ -49,82 +39,5 @@ return [
 
             return Strings::replace($content, $pattern, 'public const $1 = \'');
         },
-        //        // unprefix polyfill functions
-        //        // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-        //        // remove namespace frompoly fill stubs
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            // remove alias to class have origina PHP names - fix in
-        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-
-        // scope symfony configs
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
-        //                return $content;
-        //            }
-        //
-        //            // fix symfony config load scoping, except CodingStandard and EasyCodingStandard
-        //            $content = Strings::replace(
-        //                $content,
-        //                '#load\(\'Symplify\\\\\\\\(?<package_name>[A-Za-z]+)#',
-        //                function (array $match) use ($prefix) {
-        //                    return 'load(\'' . $prefix . '\Symplify\\' . $match['package_name'];
-        //                }
-        //            );
-        //
-        //            return $content;
-        //        },
-
-        // fixes https://github.com/symplify/symplify/issues/3102
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::contains($filePath, 'vendor/')) {
-        //                return $content;
-        //            }
-        //
-        //            // @see https://regex101.com/r/lBV8IO/2
-        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-        //
-        //            if (! $matches) {
-        //                return $content;
-        //            }
-        //
-        //            foreach ($matches as $match) {
-        //                $content = str_replace($match[0], $match[2], $content);
-        //            }
-        //
-        //            return $content;
-        //        },
-
-        //        // unprefixed ContainerConfigurator
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            // keep vendor prefixed the prefixed file loading; not part of public API
-        //            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
-        //            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
-        //                $filePath,
-        //                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
-        //            )) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace(
-        //                $content,
-        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-        //            );
-        //        },
     ],
 ];

--- a/packages/config-transformer/scoper.php
+++ b/packages/config-transformer/scoper.php
@@ -6,32 +6,36 @@ use Nette\Utils\Strings;
 
 require __DIR__ . '/vendor/autoload.php';
 
-/**
- * @see https://regex101.com/r/LMDq0p/1
- * @var string
- */
-const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-
-/**
- * @see https://regex101.com/r/RBZ0bN/1
- * @var string
- */
-const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
+///**
+// * @see https://regex101.com/r/LMDq0p/1
+// * @var string
+// */
+//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
+//
+///**
+// * @see https://regex101.com/r/RBZ0bN/1
+// * @var string
+// */
+//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
 
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'ConfigTransformer' . $timestamp . random_int(0, 10),
-    'whitelist' => [
+    'expose-classes' => [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
     ],
-    'files-whitelist' => [
-        // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
+    'exclude-namespaces' => ['#^Symplify\ConfigTransformer#'],
+    'exclude-files' => [
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
-        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
+        'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/ValueError.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/UnhandledMatchError.php',
     ],
     'patchers' => [
         // unprefix strings used for config printing
@@ -45,82 +49,82 @@ return [
 
             return Strings::replace($content, $pattern, 'public const $1 = \'');
         },
-        // unprefix polyfill functions
-        // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-                return $content;
-            }
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
-        // remove namespace frompoly fill stubs
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-                return $content;
-            }
-
-            // remove alias to class have origina PHP names - fix in
-            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
+        //        // unprefix polyfill functions
+        //        // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
+        //        // remove namespace frompoly fill stubs
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            // remove alias to class have origina PHP names - fix in
+        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
 
         // scope symfony configs
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
-                return $content;
-            }
-
-            // fix symfony config load scoping, except CodingStandard and EasyCodingStandard
-            $content = Strings::replace(
-                $content,
-                '#load\(\'Symplify\\\\\\\\(?<package_name>[A-Za-z]+)#',
-                function (array $match) use ($prefix) {
-                    return 'load(\'' . $prefix . '\Symplify\\' . $match['package_name'];
-                }
-            );
-
-            return $content;
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
+        //                return $content;
+        //            }
+        //
+        //            // fix symfony config load scoping, except CodingStandard and EasyCodingStandard
+        //            $content = Strings::replace(
+        //                $content,
+        //                '#load\(\'Symplify\\\\\\\\(?<package_name>[A-Za-z]+)#',
+        //                function (array $match) use ($prefix) {
+        //                    return 'load(\'' . $prefix . '\Symplify\\' . $match['package_name'];
+        //                }
+        //            );
+        //
+        //            return $content;
+        //        },
 
         // fixes https://github.com/symplify/symplify/issues/3102
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::contains($filePath, 'vendor/')) {
-                return $content;
-            }
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::contains($filePath, 'vendor/')) {
+        //                return $content;
+        //            }
+        //
+        //            // @see https://regex101.com/r/lBV8IO/2
+        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
+        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
+        //
+        //            if (! $matches) {
+        //                return $content;
+        //            }
+        //
+        //            foreach ($matches as $match) {
+        //                $content = str_replace($match[0], $match[2], $content);
+        //            }
+        //
+        //            return $content;
+        //        },
 
-            // @see https://regex101.com/r/lBV8IO/2
-            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-
-            if (! $matches) {
-                return $content;
-            }
-
-            foreach ($matches as $match) {
-                $content = str_replace($match[0], $match[2], $content);
-            }
-
-            return $content;
-        },
-
-        // unprefixed ContainerConfigurator
-        function (string $filePath, string $prefix, string $content): string {
-            // keep vendor prefixed the prefixed file loading; not part of public API
-            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
-            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
-                $filePath,
-                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
-            )) {
-                return $content;
-            }
-
-            return Strings::replace(
-                $content,
-                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-            );
-        },
+        //        // unprefixed ContainerConfigurator
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            // keep vendor prefixed the prefixed file loading; not part of public API
+        //            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
+        //            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
+        //                $filePath,
+        //                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
+        //            )) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace(
+        //                $content,
+        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
+        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
+        //            );
+        //        },
     ],
 ];

--- a/packages/easy-ci/build/build-easy-ci-scoped.sh
+++ b/packages/easy-ci/build/build-easy-ci-scoped.sh
@@ -31,7 +31,7 @@ note "Starts"
 
 # 2. scope it
 note "Running scoper with '$RESULT_DIRECTORY' output directory"
-wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar -N --no-verbose
+wget https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar -N --no-verbose
 
 # create directory
 mkdir "$RESULT_DIRECTORY" -p

--- a/packages/easy-ci/scoper.php
+++ b/packages/easy-ci/scoper.php
@@ -20,6 +20,11 @@ return [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+        'vendor/symfony/polyfill-php80/bootstrap.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',

--- a/packages/easy-ci/scoper.php
+++ b/packages/easy-ci/scoper.php
@@ -6,18 +6,6 @@ use Nette\Utils\Strings;
 
 require __DIR__ . '/vendor/autoload.php';
 
-///**
-// * @see https://regex101.com/r/LMDq0p/1
-// * @var string
-// */
-//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-//
-///**
-// * @see https://regex101.com/r/RBZ0bN/1
-// * @var string
-// */
-//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
-
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
@@ -39,27 +27,6 @@ return [
         'vendor/symfony/polyfill-php80/Resources/stubs/UnhandledMatchError.php',
     ],
     'patchers' => [
-        // unprefix polyfill functions
-        // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-        //        // remove namespace from polyfill stubs
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            // remove alias to class have origina PHP names - fix in
-        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
             if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
@@ -83,27 +50,6 @@ return [
             return $content;
         },
 
-        //        // fixes https://github.com/symplify/symplify/issues/3102
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::contains($filePath, 'vendor/')) {
-        //                return $content;
-        //            }
-        //
-        //            // @see https://regex101.com/r/lBV8IO/2
-        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-        //
-        //            if (! $matches) {
-        //                return $content;
-        //            }
-        //
-        //            foreach ($matches as $match) {
-        //                $content = str_replace($match[0], $match[2], $content);
-        //            }
-        //
-        //            return $content;
-        //        },
-
         // unprefix string class names to ignore, to keep original class names
         function (string $filePath, string $prefix, string $content): string {
             if (! str_ends_with($filePath, 'packages/ActiveClass/Filtering/PossiblyUnusedClassesFilter.php')) {
@@ -118,23 +64,5 @@ return [
                     Strings::replace($match['content'], '#' . $prefix . '\\\\#', '') . ';';
             });
         },
-
-        // unprefixed ContainerConfigurator
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            // keep vendor prefixed the prefixed file loading; not part of public API
-        //            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
-        //            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
-        //                $filePath,
-        //                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
-        //            )) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace(
-        //                $content,
-        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-        //            );
-        //        },
     ],
 ];

--- a/packages/easy-ci/scoper.php
+++ b/packages/easy-ci/scoper.php
@@ -6,56 +6,59 @@ use Nette\Utils\Strings;
 
 require __DIR__ . '/vendor/autoload.php';
 
-/**
- * @see https://regex101.com/r/LMDq0p/1
- * @var string
- */
-const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-
-/**
- * @see https://regex101.com/r/RBZ0bN/1
- * @var string
- */
-const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
+///**
+// * @see https://regex101.com/r/LMDq0p/1
+// * @var string
+// */
+//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
+//
+///**
+// * @see https://regex101.com/r/RBZ0bN/1
+// * @var string
+// */
+//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
 
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'EasyCI' . $timestamp,
-    'whitelist' => [
+    'expose-classes' => [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
-        // naturally
-        'Symplify\EasyCI\*',
     ],
-    'files-whitelist' => [
+    'excluded-namespaces' => ['#^Symplify\EasyCI\*#'],
+    'excluded-files' => [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
-        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
+        'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/ValueError.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/UnhandledMatchError.php',
     ],
     'patchers' => [
         // unprefix polyfill functions
         // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-                return $content;
-            }
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
-        // remove namespace from polyfill stubs
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-                return $content;
-            }
-
-            // remove alias to class have origina PHP names - fix in
-            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
+        //        // remove namespace from polyfill stubs
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            // remove alias to class have origina PHP names - fix in
+        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
 
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
@@ -80,26 +83,26 @@ return [
             return $content;
         },
 
-        // fixes https://github.com/symplify/symplify/issues/3102
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::contains($filePath, 'vendor/')) {
-                return $content;
-            }
-
-            // @see https://regex101.com/r/lBV8IO/2
-            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-
-            if (! $matches) {
-                return $content;
-            }
-
-            foreach ($matches as $match) {
-                $content = str_replace($match[0], $match[2], $content);
-            }
-
-            return $content;
-        },
+        //        // fixes https://github.com/symplify/symplify/issues/3102
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::contains($filePath, 'vendor/')) {
+        //                return $content;
+        //            }
+        //
+        //            // @see https://regex101.com/r/lBV8IO/2
+        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
+        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
+        //
+        //            if (! $matches) {
+        //                return $content;
+        //            }
+        //
+        //            foreach ($matches as $match) {
+        //                $content = str_replace($match[0], $match[2], $content);
+        //            }
+        //
+        //            return $content;
+        //        },
 
         // unprefix string class names to ignore, to keep original class names
         function (string $filePath, string $prefix, string $content): string {
@@ -117,21 +120,21 @@ return [
         },
 
         // unprefixed ContainerConfigurator
-        function (string $filePath, string $prefix, string $content): string {
-            // keep vendor prefixed the prefixed file loading; not part of public API
-            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
-            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
-                $filePath,
-                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
-            )) {
-                return $content;
-            }
-
-            return Strings::replace(
-                $content,
-                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-            );
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            // keep vendor prefixed the prefixed file loading; not part of public API
+        //            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
+        //            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
+        //                $filePath,
+        //                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
+        //            )) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace(
+        //                $content,
+        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
+        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
+        //            );
+        //        },
     ],
 ];

--- a/packages/easy-coding-standard/build/build-ecs-scoped.sh
+++ b/packages/easy-coding-standard/build/build-ecs-scoped.sh
@@ -31,7 +31,7 @@ note "Starts"
 
 # 2. scope it
 note "Running scoper with '$RESULT_DIRECTORY' output directory"
-wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar -N --no-verbose
+wget https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar -N --no-verbose
 
 # create directory
 mkdir "$RESULT_DIRECTORY" -p

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -24,15 +24,15 @@ $timestamp = (new DateTime('now'))->format('Ymd');
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'ECSPrefix' . $timestamp,
-//    'files-whitelist' => [
-//
-//        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
-//    ],
+    //    'files-whitelist' => [
+    //
+    //        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
+    //    ],
 
-//    'whitelist' => [
-//        // needed for autoload, that is not prefixed, since it's in bin/* file
-//
-//    ],
+    //    'whitelist' => [
+    //        // needed for autoload, that is not prefixed, since it's in bin/* file
+    //
+    //    ],
     'exclude-namespaces' => [
         '#^Symplify\EasyCodingStandard#',
         '#^Symplify\CodingStandardx',
@@ -59,24 +59,24 @@ return [
     'patchers' => [
         // unprefix polyfill functions
         // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-//        function (string $filePath, string $prefix, string $content): string {
-//            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-//                return $content;
-//            }
-//
-//            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-//        },
-//        // remove namespace frompoly fill stubs
-//        function (string $filePath, string $prefix, string $content): string {
-//            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-//                return $content;
-//            }
-//
-//            // remove alias to class have origina PHP names - fix in
-//            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-//
-//            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-//        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
+        //        // remove namespace frompoly fill stubs
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            // remove alias to class have origina PHP names - fix in
+        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
 
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
@@ -101,26 +101,26 @@ return [
             return $content;
         },
 
-//        // fixes https://github.com/symplify/symplify/issues/3102
-//        function (string $filePath, string $prefix, string $content): string {
-//            if (! str_contains($filePath, 'vendor/')) {
-//                return $content;
-//            }
-//
-//            // @see https://regex101.com/r/lBV8IO/2
-//            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-//            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-//
-//            if (! $matches) {
-//                return $content;
-//            }
-//
-//            foreach ($matches as $match) {
-//                $content = str_replace($match[0], $match[2], $content);
-//            }
-//
-//            return $content;
-//        },
+        //        // fixes https://github.com/symplify/symplify/issues/3102
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! str_contains($filePath, 'vendor/')) {
+        //                return $content;
+        //            }
+        //
+        //            // @see https://regex101.com/r/lBV8IO/2
+        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
+        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
+        //
+        //            if (! $matches) {
+        //                return $content;
+        //            }
+        //
+        //            foreach ($matches as $match) {
+        //                $content = str_replace($match[0], $match[2], $content);
+        //            }
+        //
+        //            return $content;
+        //        },
 
         // fixes https://github.com/symplify/symplify/issues/3205
         function (string $filePath, string $prefix, string $content): string {
@@ -150,12 +150,12 @@ return [
         },
 
         // unprefixed ContainerConfigurator
-//        function (string $filePath, string $prefix, string $content): string {
-//            return Strings::replace(
-//                $content,
-//                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-//                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-//            );
-//        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            return Strings::replace(
+        //                $content,
+        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
+        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
+        //            );
+        //        },
     ],
 ];

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -7,39 +7,20 @@ use Symplify\EasyCodingStandard\Application\Version\StaticVersionResolver;
 
 require __DIR__ . '/vendor/autoload.php';
 
-///**
-// * @see https://regex101.com/r/LMDq0p/1
-// * @var string
-// */
-//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-
-///**
-// * @see https://regex101.com/r/RBZ0bN/1
-// * @var string
-// */
-//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
-
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'ECSPrefix' . $timestamp,
-    //    'files-whitelist' => [
-    //
-    //        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
-    //    ],
 
-    //    'whitelist' => [
-    //        // needed for autoload, that is not prefixed, since it's in bin/* file
-    //
-    //    ],
-    'exclude-namespaces' => [
+    // excluded
+    'excluded-namespaces' => [
         '#^Symplify\EasyCodingStandard#',
         '#^Symplify\CodingStandardx',
         '#^PhpCsFixer#',
         '#^PHP_CodeSniffer#',
     ],
-    'exclude-files' => [
+    'excluded-files' => [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
@@ -50,6 +31,7 @@ return [
         'vendor/symfony/polyfill-php80/Resources/stubs/UnhandledMatchError.php',
     ],
 
+    // expose
     'expose-classes' => [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
@@ -57,27 +39,6 @@ return [
     ],
 
     'patchers' => [
-        // unprefix polyfill functions
-        // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-        //        // remove namespace frompoly fill stubs
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            // remove alias to class have origina PHP names - fix in
-        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
             if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
@@ -100,27 +61,6 @@ return [
 
             return $content;
         },
-
-        //        // fixes https://github.com/symplify/symplify/issues/3102
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! str_contains($filePath, 'vendor/')) {
-        //                return $content;
-        //            }
-        //
-        //            // @see https://regex101.com/r/lBV8IO/2
-        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-        //
-        //            if (! $matches) {
-        //                return $content;
-        //            }
-        //
-        //            foreach ($matches as $match) {
-        //                $content = str_replace($match[0], $match[2], $content);
-        //            }
-        //
-        //            return $content;
-        //        },
 
         // fixes https://github.com/symplify/symplify/issues/3205
         function (string $filePath, string $prefix, string $content): string {
@@ -148,14 +88,5 @@ return [
                 '@release_date@' => $releaseDateTime->format('Y-m-d H:i:s'),
             ]);
         },
-
-        // unprefixed ContainerConfigurator
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            return Strings::replace(
-        //                $content,
-        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-        //            );
-        //        },
     ],
 ];

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -24,6 +24,11 @@ return [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+        'vendor/symfony/polyfill-php80/bootstrap.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -7,61 +7,76 @@ use Symplify\EasyCodingStandard\Application\Version\StaticVersionResolver;
 
 require __DIR__ . '/vendor/autoload.php';
 
-/**
- * @see https://regex101.com/r/LMDq0p/1
- * @var string
- */
-const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
+///**
+// * @see https://regex101.com/r/LMDq0p/1
+// * @var string
+// */
+//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
 
-/**
- * @see https://regex101.com/r/RBZ0bN/1
- * @var string
- */
-const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
+///**
+// * @see https://regex101.com/r/RBZ0bN/1
+// * @var string
+// */
+//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
 
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'ECSPrefix' . $timestamp,
-    'files-whitelist' => [
+//    'files-whitelist' => [
+//
+//        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
+//    ],
+
+//    'whitelist' => [
+//        // needed for autoload, that is not prefixed, since it's in bin/* file
+//
+//    ],
+    'exclude-namespaces' => [
+        '#^Symplify\EasyCodingStandard#',
+        '#^Symplify\CodingStandardx',
+        '#^PhpCsFixer#',
+        '#^PHP_CodeSniffer#',
+    ],
+    'exclude-files' => [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
-        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
+        'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/ValueError.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/UnhandledMatchError.php',
     ],
 
-    'whitelist' => [
-        // needed for autoload, that is not prefixed, since it's in bin/* file
-        'Symplify\EasyCodingStandard\*',
-        'Symplify\CodingStandard\*',
-        'PhpCsFixer\*',
-        'PHP_CodeSniffer\*',
+    'expose-classes' => [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
         'Symplify\SmartFileSystem\SmartFileInfo',
     ],
+
     'patchers' => [
         // unprefix polyfill functions
         // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-                return $content;
-            }
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
-        // remove namespace frompoly fill stubs
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-                return $content;
-            }
-
-            // remove alias to class have origina PHP names - fix in
-            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
+//        function (string $filePath, string $prefix, string $content): string {
+//            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
+//                return $content;
+//            }
+//
+//            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+//        },
+//        // remove namespace frompoly fill stubs
+//        function (string $filePath, string $prefix, string $content): string {
+//            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
+//                return $content;
+//            }
+//
+//            // remove alias to class have origina PHP names - fix in
+//            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
+//
+//            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+//        },
 
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
@@ -86,26 +101,26 @@ return [
             return $content;
         },
 
-        // fixes https://github.com/symplify/symplify/issues/3102
-        function (string $filePath, string $prefix, string $content): string {
-            if (! str_contains($filePath, 'vendor/')) {
-                return $content;
-            }
-
-            // @see https://regex101.com/r/lBV8IO/2
-            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-
-            if (! $matches) {
-                return $content;
-            }
-
-            foreach ($matches as $match) {
-                $content = str_replace($match[0], $match[2], $content);
-            }
-
-            return $content;
-        },
+//        // fixes https://github.com/symplify/symplify/issues/3102
+//        function (string $filePath, string $prefix, string $content): string {
+//            if (! str_contains($filePath, 'vendor/')) {
+//                return $content;
+//            }
+//
+//            // @see https://regex101.com/r/lBV8IO/2
+//            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
+//            $matches = Strings::matchAll($content, $fqcnReservedPattern);
+//
+//            if (! $matches) {
+//                return $content;
+//            }
+//
+//            foreach ($matches as $match) {
+//                $content = str_replace($match[0], $match[2], $content);
+//            }
+//
+//            return $content;
+//        },
 
         // fixes https://github.com/symplify/symplify/issues/3205
         function (string $filePath, string $prefix, string $content): string {
@@ -135,12 +150,12 @@ return [
         },
 
         // unprefixed ContainerConfigurator
-        function (string $filePath, string $prefix, string $content): string {
-            return Strings::replace(
-                $content,
-                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-            );
-        },
+//        function (string $filePath, string $prefix, string $content): string {
+//            return Strings::replace(
+//                $content,
+//                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
+//                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
+//            );
+//        },
     ],
 ];

--- a/packages/easy-coding-standard/src/Exception/DeprecatedException.php
+++ b/packages/easy-coding-standard/src/Exception/DeprecatedException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Symplify\EasyCodingStandard\Exception;
 
-final class DeprecatedException extends \Exception
+use Exception;
+
+final class DeprecatedException extends Exception
 {
 }

--- a/packages/monorepo-builder/build/build-monorepo-builder-scoped.sh
+++ b/packages/monorepo-builder/build/build-monorepo-builder-scoped.sh
@@ -31,7 +31,7 @@ note "Starts"
 
 # 2. scope it
 note "Running scoper with '$RESULT_DIRECTORY' output directory"
-wget https://github.com/humbug/php-scoper/releases/download/0.14.0/php-scoper.phar -N --no-verbose
+wget https://github.com/humbug/php-scoper/releases/download/0.17.2/php-scoper.phar -N --no-verbose
 
 # create directory
 mkdir "$RESULT_DIRECTORY" -p

--- a/packages/monorepo-builder/scoper.php
+++ b/packages/monorepo-builder/scoper.php
@@ -14,6 +14,11 @@ return [
     'excluded-files' => [
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap.php',
+        'vendor/symfony/polyfill-intl-normalizer/bootstrap80.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap.php',
+        'vendor/symfony/polyfill-mbstring/bootstrap80.php',
+        'vendor/symfony/polyfill-php80/bootstrap.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
         'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',

--- a/packages/monorepo-builder/scoper.php
+++ b/packages/monorepo-builder/scoper.php
@@ -6,30 +6,21 @@ use Nette\Utils\Strings;
 
 require __DIR__ . '/vendor/autoload.php';
 
-///**
-// * @see https://regex101.com/r/LMDq0p/1
-// * @var string
-// */
-//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-//
-///**
-// * @see https://regex101.com/r/RBZ0bN/1
-// * @var string
-// */
-//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
-
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'MonorepoBuilder' . $timestamp,
     'excluded-files' => [
-        // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
-        // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
+        'vendor/symfony/polyfill-php80/Resources/stubs/Attribute.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/ValueError.php',
+        'vendor/symfony/polyfill-php80/Resources/stubs/UnhandledMatchError.php',
     ],
-    'exclude-namespaces' => [
+    'excluded-namespaces' => [
         // needed for autoload, that is not prefixed, since it's in bin/* file
         '#^Symplify\MonorepoBuilder\*#',
         // part of public API in \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface
@@ -42,16 +33,6 @@ return [
         'Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection',
     ],
     'patchers' => [
-        // unprefix polyfill functions
-        // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
             if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
@@ -70,39 +51,6 @@ return [
             return $content;
         },
 
-        // remove namespace frompoly fill stubs
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-        //                return $content;
-        //            }
-        //
-        //            // remove alias to class have original PHP names - fix in
-        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-        //
-        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        //        },
-
-        // fixes https://github.com/symplify/symplify/issues/3102
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            if (! Strings::contains($filePath, 'vendor/')) {
-        //                return $content;
-        //            }
-        //
-        //            // @see https://regex101.com/r/lBV8IO/2
-        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-        //
-        //            if (! $matches) {
-        //                return $content;
-        //            }
-        //
-        //            foreach ($matches as $match) {
-        //                $content = str_replace($match[0], $match[2], $content);
-        //            }
-        //
-        //            return $content;
-        //        },
-
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
             if (! Strings::match($filePath, '#(packages|config|services)\.php$#')) {
@@ -116,23 +64,5 @@ return [
                 'load(\'' . 'Symplify\\MonorepoBuilder',
             );
         },
-
-        // unprefixed ContainerConfigurator
-        //        function (string $filePath, string $prefix, string $content): string {
-        //            // keep vendor prefixed the prefixed file loading; not part of public API
-        //            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
-        //            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
-        //                $filePath,
-        //                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
-        //            )) {
-        //                return $content;
-        //            }
-        //
-        //            return Strings::replace(
-        //                $content,
-        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-        //            );
-        //        },
     ],
 ];

--- a/packages/monorepo-builder/scoper.php
+++ b/packages/monorepo-builder/scoper.php
@@ -6,49 +6,51 @@ use Nette\Utils\Strings;
 
 require __DIR__ . '/vendor/autoload.php';
 
-/**
- * @see https://regex101.com/r/LMDq0p/1
- * @var string
- */
-const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
-
-/**
- * @see https://regex101.com/r/RBZ0bN/1
- * @var string
- */
-const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
+///**
+// * @see https://regex101.com/r/LMDq0p/1
+// * @var string
+// */
+//const POLYFILL_FILE_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/bootstrap(.*?)\.php#';
+//
+///**
+// * @see https://regex101.com/r/RBZ0bN/1
+// * @var string
+// */
+//const POLYFILL_STUBS_NAME_REGEX = '#vendor\/symfony\/polyfill\-(.*)\/Resources\/stubs#';
 
 $timestamp = (new DateTime('now'))->format('Ymd');
 
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'MonorepoBuilder' . $timestamp,
-    'files-whitelist' => [
+    'excluded-files' => [
         // do not prefix "trigger_deprecation" from symfony - https://github.com/symfony/symfony/commit/0032b2a2893d3be592d4312b7b098fb9d71aca03
         // these paths are relative to this file location, so it should be in the root directory
         'vendor/symfony/deprecation-contracts/function.php',
         // for package versions - https://github.com/symplify/easy-coding-standard-prefixed/runs/2176047833
     ],
-    'whitelist' => [
+    'exclude-namespaces' => [
+        // needed for autoload, that is not prefixed, since it's in bin/* file
+        '#^Symplify\MonorepoBuilder\*#',
+        // part of public API in \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface
+        '#^PharIo\Version\*#',
+        // needed by the monorepo-builder command (avoid failing with a "class not found" error)
+    ],
+    'expose-classes' => [
         // part of public interface of configs.php
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
-        // needed for autoload, that is not prefixed, since it's in bin/* file
-        'Symplify\MonorepoBuilder\*',
-        // part of public API in \Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface
-        'PharIo\Version\*',
-        // needed by the monorepo-builder command (avoid failing with a "class not found" error)
         'Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection',
     ],
     'patchers' => [
         // unprefix polyfill functions
         // @see https://github.com/humbug/php-scoper/issues/440#issuecomment-795160132
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
-                return $content;
-            }
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_FILE_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
 
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
@@ -69,37 +71,37 @@ return [
         },
 
         // remove namespace frompoly fill stubs
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
-                return $content;
-            }
-
-            // remove alias to class have original PHP names - fix in
-            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
-
-            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::match($filePath, POLYFILL_STUBS_NAME_REGEX)) {
+        //                return $content;
+        //            }
+        //
+        //            // remove alias to class have original PHP names - fix in
+        //            $content = Strings::replace($content, '#\\\\class_alias(.*?);#', '');
+        //
+        //            return Strings::replace($content, '#namespace ' . $prefix . ';#', '');
+        //        },
 
         // fixes https://github.com/symplify/symplify/issues/3102
-        function (string $filePath, string $prefix, string $content): string {
-            if (! Strings::contains($filePath, 'vendor/')) {
-                return $content;
-            }
-
-            // @see https://regex101.com/r/lBV8IO/2
-            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
-            $matches = Strings::matchAll($content, $fqcnReservedPattern);
-
-            if (! $matches) {
-                return $content;
-            }
-
-            foreach ($matches as $match) {
-                $content = str_replace($match[0], $match[2], $content);
-            }
-
-            return $content;
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            if (! Strings::contains($filePath, 'vendor/')) {
+        //                return $content;
+        //            }
+        //
+        //            // @see https://regex101.com/r/lBV8IO/2
+        //            $fqcnReservedPattern = sprintf('#(\\\\)?%s\\\\(parent|self|static)#m', $prefix);
+        //            $matches = Strings::matchAll($content, $fqcnReservedPattern);
+        //
+        //            if (! $matches) {
+        //                return $content;
+        //            }
+        //
+        //            foreach ($matches as $match) {
+        //                $content = str_replace($match[0], $match[2], $content);
+        //            }
+        //
+        //            return $content;
+        //        },
 
         // scope symfony configs
         function (string $filePath, string $prefix, string $content): string {
@@ -116,21 +118,21 @@ return [
         },
 
         // unprefixed ContainerConfigurator
-        function (string $filePath, string $prefix, string $content): string {
-            // keep vendor prefixed the prefixed file loading; not part of public API
-            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
-            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
-                $filePath,
-                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
-            )) {
-                return $content;
-            }
-
-            return Strings::replace(
-                $content,
-                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
-                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
-            );
-        },
+        //        function (string $filePath, string $prefix, string $content): string {
+        //            // keep vendor prefixed the prefixed file loading; not part of public API
+        //            // except @see https://github.com/symfony/symfony/commit/460b46f7302ec7319b8334a43809523363bfef39#diff-1cd56b329433fc34d950d6eeab9600752aa84a76cbe0693d3fab57fed0f547d3R110
+        //            if (str_contains($filePath, 'vendor/symfony') && ! str_ends_with(
+        //                $filePath,
+        //                'vendor/symfony/dependency-injection/Loader/PhpFileLoader.php'
+        //            )) {
+        //                return $content;
+        //            }
+        //
+        //            return Strings::replace(
+        //                $content,
+        //                '#' . $prefix . '\\\\Symfony\\\\Component\\\\DependencyInjection\\\\Loader\\\\Configurator\\\\ContainerConfigurator#',
+        //                'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator'
+        //            );
+        //        },
     ],
 ];


### PR DESCRIPTION
This version brings:

* PHP 8.1 support
* "parent" false-prefixing fix
* easier polyfil skipping

See https://github.com/humbug/php-scoper/releases/tag/0.17.2