### PR TITLE
[PHPStanRules] Add AssignedToPropertyNodeVisitor, to make NoNetteTemplateVariableReadRule work without parents

### DIFF
--- a/easy-ci.php
+++ b/easy-ci.php
@@ -54,5 +54,6 @@ return static function (EasyCIConfig $easyCIConfig): void {
         CodeSampleInterface::class,
         TagResolverInterface::class,
         \Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator::class,
+        \PhpParser\NodeVisitorAbstract::class,
     ]);
 };

--- a/packages/astral/src/ValueObject/AttributeKey.php
+++ b/packages/astral/src/ValueObject/AttributeKey.php
@@ -73,4 +73,9 @@ final class AttributeKey
      * @var string
      */
     public const PHPSTAN_CACHE_PRINTER = 'phpstan_cache_printer';
+
+    /**
+     * @var string
+     */
+    public const ASSIGNED_TO = 'assigned_to';
 }

--- a/packages/phpstan-rules/config/services/services.neon
+++ b/packages/phpstan-rules/config/services/services.neon
@@ -8,3 +8,8 @@ services:
     - Symplify\PackageBuilder\Matcher\ArrayStringAndFnMatcher
     - Symplify\PackageBuilder\Reflection\PrivatesCaller
     - Symplify\PackageBuilder\Reflection\ClassLikeExistenceChecker
+
+    -
+        class: Symplify\PHPStanRules\NodeVisitor\AssignedToPropertyNodeVisitor
+        tags:
+            - phpstan.parser.richParserNodeVisitor

--- a/packages/phpstan-rules/packages/nette/tests/Rules/NoNetteTemplateVariableReadRule/Fixture/AvoidUnset.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/NoNetteTemplateVariableReadRule/Fixture/AvoidUnset.php
@@ -6,7 +6,7 @@ namespace Symplify\PHPStanRules\Nette\Tests\Rules\NoNetteTemplateVariableReadRul
 
 use Nette\Application\UI\Control;
 
-final class SkipUnset extends Control
+final class AvoidUnset extends Control
 {
     public function run()
     {

--- a/packages/phpstan-rules/packages/nette/tests/Rules/NoNetteTemplateVariableReadRule/Fixture/SkipPayloadAjaxFullJuggling.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/NoNetteTemplateVariableReadRule/Fixture/SkipPayloadAjaxFullJuggling.php
@@ -6,10 +6,10 @@ namespace Symplify\PHPStanRules\Nette\Tests\Rules\NoNetteTemplateVariableReadRul
 
 use Nette\Application\UI\Presenter;
 
-abstract class SkipPayloadAjaxJuggling extends Presenter
+abstract class SkipPayloadAjaxFullJuggling extends Presenter
 {
     public function render()
     {
-        $this->payload->key = $this->template->key;
+        $this->payload = $this->template;
     }
 }

--- a/packages/phpstan-rules/packages/nette/tests/Rules/NoNetteTemplateVariableReadRule/NoNetteTemplateVariableReadRuleTest.php
+++ b/packages/phpstan-rules/packages/nette/tests/Rules/NoNetteTemplateVariableReadRule/NoNetteTemplateVariableReadRuleTest.php
@@ -28,10 +28,14 @@ final class NoNetteTemplateVariableReadRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SkipAssign.php', []];
         yield [__DIR__ . '/Fixture/SkipNoControl.php', []];
         yield [__DIR__ . '/Fixture/SkipFlashes.php', []];
-        yield [__DIR__ . '/Fixture/SkipUnset.php', []];
         yield [__DIR__ . '/Fixture/SkipPayloadAjaxJuggling.php', []];
+        yield [__DIR__ . '/Fixture/SkipPayloadAjaxFullJuggling.php', []];
 
-        yield [__DIR__ . '/Fixture/ReadUsage.php', [[NoNetteTemplateVariableReadRule::ERROR_MESSAGE, 13]]];
+        $errorMessage = sprintf(NoNetteTemplateVariableReadRule::ERROR_MESSAGE, 'whatever', 'whatever');
+        yield [__DIR__ . '/Fixture/AvoidUnset.php', [[$errorMessage, 13]]];
+
+        $errorMessage = sprintf(NoNetteTemplateVariableReadRule::ERROR_MESSAGE, 'value', 'value');
+        yield [__DIR__ . '/Fixture/ReadUsage.php', [[$errorMessage, 13]]];
     }
 
     /**

--- a/packages/phpstan-rules/src/NodeVisitor/AssignedToPropertyNodeVisitor.php
+++ b/packages/phpstan-rules/src/NodeVisitor/AssignedToPropertyNodeVisitor.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\NodeVisitorAbstract;
+use Symplify\Astral\ValueObject\AttributeKey;
+
+/**
+ * Inspired by https://github.com/phpstan/phpstan-src/blob/1.7.x/src/Parser/NewAssignedToPropertyVisitor.php
+ */
+final class AssignedToPropertyNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof Assign) {
+            return null;
+        }
+
+        $node->expr->setAttribute(AttributeKey::ASSIGNED_TO, $node->var);
+        return null;
+    }
+}

--- a/packages/phpstan-rules/src/Rules/Explicit/ExplicitMethodCallOverMagicGetSetRule.php
+++ b/packages/phpstan-rules/src/Rules/Explicit/ExplicitMethodCallOverMagicGetSetRule.php
@@ -6,7 +6,6 @@ namespace Symplify\PHPStanRules\Rules\Explicit;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\Analyser\Scope;
@@ -130,8 +129,7 @@ CODE_SAMPLE
             return [];
         }
 
-        $parent = $node->getAttribute(AttributeKey::PARENT);
-        if ($parent instanceof Assign && $parent->var === $node) {
+        if ($scope->isInExpressionAssign($node)) {
             return $this->processSetterMethodCall($node, $callerClassReflection, $propertyName);
         }
 

--- a/packages/phpstan-rules/src/Rules/NoMultiArrayAssignRule.php
+++ b/packages/phpstan-rules/src/Rules/NoMultiArrayAssignRule.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules;
 
-use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayDimFetch;
 use PhpParser\Node\Expr\Assign;
 use PhpParser\Node\Expr\Closure;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Function_;

--- a/packages/phpstan-rules/tests/Rules/Explicit/ExplicitMethodCallOverMagicGetSetRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/tests/Rules/Explicit/ExplicitMethodCallOverMagicGetSetRule/config/configured_rule.neon
@@ -1,7 +1,5 @@
 includes:
     - ../../../../config/included_services.neon
 
-services:
-    -
-        class: Symplify\PHPStanRules\Rules\Explicit\ExplicitMethodCallOverMagicGetSetRule
-        tags: [phpstan.rules.rule]
+rules:
+    - Symplify\PHPStanRules\Rules\Explicit\ExplicitMethodCallOverMagicGetSetRule


### PR DESCRIPTION
- [PHPStanRules] Remove parent from ExplicitMethodCallOverMagicGetSetRule
- [PHPStanRules] Add AssignedToPropertyNodeVisitor, to make NoNetteTemplateVariableReadRule work without parents
