### PR TITLE
[PHPStanRules] Restore nullsafe check in NoChainMethodCallRule

### DIFF
--- a/packages/astral/src/ValueObject/AttributeKey.php
+++ b/packages/astral/src/ValueObject/AttributeKey.php
@@ -78,4 +78,9 @@ final class AttributeKey
      * @var string
      */
     public const ASSIGNED_TO = 'assigned_to';
+
+    /**
+     * @var string
+     */
+    public const NULLSAFE_CHECKED = 'nullsafe_checked';
 }

--- a/packages/phpstan-rules/config/services/services.neon
+++ b/packages/phpstan-rules/config/services/services.neon
@@ -13,3 +13,7 @@ services:
         class: Symplify\PHPStanRules\NodeVisitor\AssignedToPropertyNodeVisitor
         tags:
             - phpstan.parser.richParserNodeVisitor
+    -
+        class: Symplify\PHPStanRules\ObjectCalisthenics\NodeVisitor\NullsafeCheckedNodeVisitor
+        tags:
+            - phpstan.parser.richParserNodeVisitor

--- a/packages/phpstan-rules/packages/object-calisthenics/src/NodeVisitor/NullsafeCheckedNodeVisitor.php
+++ b/packages/phpstan-rules/packages/object-calisthenics/src/NodeVisitor/NullsafeCheckedNodeVisitor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ObjectCalisthenics\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\NodeVisitorAbstract;
+use Symplify\Astral\ValueObject\AttributeKey;
+
+final class NullsafeCheckedNodeVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node)
+    {
+        if (! $node instanceof NullsafeMethodCall) {
+            return null;
+        }
+
+        $node->var->setAttribute(AttributeKey::NULLSAFE_CHECKED, true);
+        return null;
+    }
+}

--- a/packages/phpstan-rules/packages/object-calisthenics/src/Rules/NoChainMethodCallRule.php
+++ b/packages/phpstan-rules/packages/object-calisthenics/src/Rules/NoChainMethodCallRule.php
@@ -109,7 +109,7 @@ final class NoChainMethodCallRule implements Rule, DocumentedRuleinterface, Conf
 
         // skip nullsafe chain
         $isNullsafeChecked = (bool) $node->var->getAttribute(AttributeKey::NULLSAFE_CHECKED);
-        if ($isNullsafeChecked === true) {
+        if ($isNullsafeChecked) {
             return [];
         }
 

--- a/packages/phpstan-rules/packages/object-calisthenics/src/Rules/NoChainMethodCallRule.php
+++ b/packages/phpstan-rules/packages/object-calisthenics/src/Rules/NoChainMethodCallRule.php
@@ -23,6 +23,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Routing\Loader\Configurator\RouteConfigurator;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\String\AbstractString;
+use Symplify\Astral\ValueObject\AttributeKey;
 use Symplify\PHPStanRules\Matcher\ObjectTypeMatcher;
 use Symplify\RuleDocGenerator\Contract\ConfigurableRuleInterface;
 use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
@@ -103,6 +104,12 @@ final class NoChainMethodCallRule implements Rule, DocumentedRuleinterface, Conf
     public function processNode(Node $node, Scope $scope): array
     {
         if (! $node->var instanceof MethodCall) {
+            return [];
+        }
+
+        // skip nullsafe chain
+        $isNullsafeChecked = (bool) $node->var->getAttribute(AttributeKey::NULLSAFE_CHECKED);
+        if ($isNullsafeChecked === true) {
             return [];
         }
 

--- a/packages/phpstan-rules/packages/object-calisthenics/tests/Rules/NoChainMethodCallRule/Fixture/SkipNullsafeCalls.php
+++ b/packages/phpstan-rules/packages/object-calisthenics/tests/Rules/NoChainMethodCallRule/Fixture/SkipNullsafeCalls.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\ObjectCalisthenics\Tests\Rules\NoChainMethodCallRule\Fixture;
+
+use PHPStan\Analyser\Scope;
+
+final class SkipNullsafeCalls
+{
+    public function run(Scope $scope)
+    {
+        return $scope->getClassReflection()?->getName();
+    }
+}

--- a/packages/phpstan-rules/packages/object-calisthenics/tests/Rules/NoChainMethodCallRule/NoChainMethodCallRuleTest.php
+++ b/packages/phpstan-rules/packages/object-calisthenics/tests/Rules/NoChainMethodCallRule/NoChainMethodCallRuleTest.php
@@ -29,6 +29,7 @@ final class NoChainMethodCallRuleTest extends RuleTestCase
         yield [__DIR__ . '/Fixture/SkipSymfonyConfig.php', []];
         yield [__DIR__ . '/Fixture/SkipExtraAllowedClass.php', []];
         yield [__DIR__ . '/Fixture/SkipTrinaryLogic.php', []];
+        yield [__DIR__ . '/Fixture/SkipNullsafeCalls.php', []];
     }
 
     /**


### PR DESCRIPTION
Fixing follow up to https://github.com/symplify/symplify/pull/4133