### PR TITLE
[ECS] Fix Normalizer class not found on scoped ecs

### DIFF
--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -66,7 +66,6 @@
     "replace": {
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-intl-grapheme": "*",
-        "symfony/polyfill-intl-normalizer": "*",
         "symfony/polyfill-mbstring": "*"
     },
     "conflict": {

--- a/packages/easy-coding-standard/scoper.php
+++ b/packages/easy-coding-standard/scoper.php
@@ -62,6 +62,7 @@ return [
 
     // expose
     'expose-classes' => [
+        'Normalizer',
         // part of public interface of configs.php
         'Symplify\SmartFileSystem\SmartFileInfo',
     ],


### PR DESCRIPTION
Fixes https://github.com/symplify/symplify/issues/4211