### PR TITLE
[PHPStanRules] Skip equal union type passed on NarrowPublicClassMethodParamTypeByCallerTypeRule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "composer/semver": "^3.3",
         "composer/xdebug-handler": "^3.0",
         "cweagans/composer-patches": "^1.7",
-        "friendsofphp/php-cs-fixer": "^3.9.3",
+        "friendsofphp/php-cs-fixer": "^3.9.4",
         "j7mbo/twitter-api-php": "^1.0.6",
         "latte/latte": "^2.11",
         "myclabs/php-enum": "^1.8",

--- a/packages/coding-standard/composer.json
+++ b/packages/coding-standard/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=8.0",
         "nette/utils": "^3.2",
-        "friendsofphp/php-cs-fixer": "^3.9.3",
+        "friendsofphp/php-cs-fixer": "^3.9.4",
         "symplify/symplify-kernel": "^11.1",
         "symplify/package-builder": "^11.1",
         "symplify/autowire-array-parameter": "^11.1",

--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=8.0",
         "composer/xdebug-handler": "^3.0",
-        "friendsofphp/php-cs-fixer": "^3.9.3",
+        "friendsofphp/php-cs-fixer": "^3.9.4",
         "nette/utils": "^3.2",
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/config": "^6.0",

--- a/packages/easy-coding-standard/tests/Set/Psr12/Fixture/fixture2.php.inc
+++ b/packages/easy-coding-standard/tests/Set/Psr12/Fixture/fixture2.php.inc
@@ -144,9 +144,9 @@ if ($simple == true) {
     $doSomething = true;
 }
 if ($expr1) {
-// if body
+    // if body
 } elseif ($expr2) {
-// elseif body
+    // elseif body
 } else {
     // else body
 }
@@ -154,7 +154,7 @@ if (
     $expr1
     && $expr2
 ) {
-// if body
+    // if body
 } elseif (
     $expr3
     && $expr4

--- a/packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php
+++ b/packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php
@@ -73,12 +73,24 @@ final class CollectorMetadataPrinter
             }
 
             $printedParamType = $this->printerStandard->prettyPrint([$paramType]);
-            $printedParamType = ltrim($printedParamType, '\\');
+            $printedParamType = $this->resolvePrintedFullyQualifiedType($printedParamType);
 
             $printedParamTypes[] = $printedParamType;
         }
 
         return implode('|', $printedParamTypes);
+    }
+
+    private function resolvePrintedFullyQualifiedType(string $printedParamType): string
+    {
+        $pipedType = explode('|', $printedParamType);
+        $newPrintedParamType = '';
+
+        foreach ($pipedType as $singlePipedType) {
+            $newPrintedParamType .=  ltrim($singlePipedType, '\\') . '|';
+        }
+
+        return rtrim($newPrintedParamType, '|');
     }
 
     private function printTypeToString(Type $type): string

--- a/packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php
+++ b/packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php
@@ -73,24 +73,13 @@ final class CollectorMetadataPrinter
             }
 
             $printedParamType = $this->printerStandard->prettyPrint([$paramType]);
-            $printedParamType = $this->resolvePrintedFullyQualifiedType($printedParamType);
+            $printedParamType = ltrim($printedParamType, '\\');
+            $printedParamType = str_replace('|\\', '|', $printedParamType);
 
             $printedParamTypes[] = $printedParamType;
         }
 
         return implode('|', $printedParamTypes);
-    }
-
-    private function resolvePrintedFullyQualifiedType(string $printedParamType): string
-    {
-        $pipedType = explode('|', $printedParamType);
-        $newPrintedParamType = '';
-
-        foreach ($pipedType as $singlePipedType) {
-            $newPrintedParamType .=  ltrim($singlePipedType, '\\') . '|';
-        }
-
-        return rtrim($newPrintedParamType, '|');
     }
 
     private function printTypeToString(Type $type): string

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Fixture/SkipEqualUnionType.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Fixture/SkipEqualUnionType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Fixture;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+
+final class SkipEqualUnionType
+{
+    public function run(MethodCall|StaticCall $obj)
+    {
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/NarrowPublicClassMethodParamTypeByCallerTypeRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/NarrowPublicClassMethodParamTypeByCallerTypeRuleTest.php
@@ -79,6 +79,18 @@ final class NarrowPublicClassMethodParamTypeByCallerTypeRuleTest extends RuleTes
             __DIR__ . '/Source/ExpectedNodeApi/CallWithProperty.php',
         ], []];
 
+        // skip equal union type
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionType.php',
+        ], []];
+
+        // skip equal union type
+        yield [[
+            __DIR__ . '/Fixture/SkipEqualUnionType.php',
+            __DIR__ . '/Source/ExpectedUnion/CallUnionTypeFlipped.php',
+        ], []];
+
         $argErrorMessage = sprintf(NarrowPublicClassMethodParamTypeByCallerTypeRule::ERROR_MESSAGE, 'int');
         yield [[
             __DIR__ . '/Fixture/PublicDoubleShot.php',

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionType.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Source\ExpectedNodeApi;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionType
+{
+    /**
+     * @param MethodCall[]|StaticCall[] $data
+     */
+    public function run(SkipEqualUnionType $skipFlippedUnionType, array $data): void
+    {
+        foreach ($data as $value) {
+            $skipFlippedUnionType->run($value);
+        }
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionType.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionType.php
@@ -13,10 +13,10 @@ final class CallUnionType
     /**
      * @param MethodCall[]|StaticCall[] $data
      */
-    public function run(SkipEqualUnionType $skipFlippedUnionType, array $data): void
+    public function run(SkipEqualUnionType $skipEqualUnionType, array $data): void
     {
         foreach ($data as $value) {
-            $skipFlippedUnionType->run($value);
+            $skipEqualUnionType->run($value);
         }
     }
 }

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionTypeFlipped.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionTypeFlipped.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Source\ExpectedNodeApi;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Fixture\SkipEqualUnionType;
+
+final class CallUnionTypeFlipped
+{
+    /**
+     * @param StaticCall[]|MethodCall[] $data
+     */
+    public function run(SkipEqualUnionType $skipFlippedUnionType, array $data): void
+    {
+        foreach ($data as $value) {
+            $skipFlippedUnionType->run($value);
+        }
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionTypeFlipped.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedUnion/CallUnionTypeFlipped.php
@@ -13,10 +13,10 @@ final class CallUnionTypeFlipped
     /**
      * @param StaticCall[]|MethodCall[] $data
      */
-    public function run(SkipEqualUnionType $skipFlippedUnionType, array $data): void
+    public function run(SkipEqualUnionType $skipEqualUnionType, array $data): void
     {
         foreach ($data as $value) {
-            $skipFlippedUnionType->run($value);
+            $skipEqualUnionType->run($value);
         }
     }
 }

--- a/packages/rule-doc-generator/composer.json
+++ b/packages/rule-doc-generator/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "friendsofphp/php-cs-fixer": "^3.9.3",
+        "friendsofphp/php-cs-fixer": "^3.9.4",
         "phpstan/phpstan": "^1.8.1"
     },
     "autoload": {


### PR DESCRIPTION
This test verify equal union type passed for both ordered or non-ordered type.