### PR TITLE
[PHPStanRules] Skip used in internal class for second type on Union type on NarrowPublicClassMethodParamTypeByCallerTypeRule

### DIFF
--- a/packages/phpstan-rules/src/Collector/ClassMethod/MethodCallCollector.php
+++ b/packages/phpstan-rules/src/Collector/ClassMethod/MethodCallCollector.php
@@ -39,7 +39,7 @@ final class MethodCallCollector implements Collector
             return null;
         }
 
-        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope);
+        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope, false);
         if (! $classMethodCallReference instanceof MethodCallReference) {
             return null;
         }

--- a/packages/phpstan-rules/src/Collector/MethodCall/MethodCallArgTypesCollector.php
+++ b/packages/phpstan-rules/src/Collector/MethodCall/MethodCallArgTypesCollector.php
@@ -38,7 +38,7 @@ final class MethodCallArgTypesCollector implements Collector
             return null;
         }
 
-        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope);
+        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope, true);
         if (! $classMethodCallReference instanceof MethodCallReference) {
             return null;
         }

--- a/packages/phpstan-rules/src/Matcher/ClassMethodCallReferenceResolver.php
+++ b/packages/phpstan-rules/src/Matcher/ClassMethodCallReferenceResolver.php
@@ -7,7 +7,6 @@ namespace Symplify\PHPStanRules\Matcher;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\Type\ThisType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeWithClassName;
 use Symplify\PHPStanRules\ValueObject\MethodCallReference;
@@ -25,11 +24,6 @@ final class ClassMethodCallReferenceResolver
         // remove optional nullable type
         if (TypeCombinator::containsNull($callerType)) {
             $callerType = TypeCombinator::removeNull($callerType);
-        }
-
-        // skip self calls, as external is needed to make the method public
-        if ($callerType instanceof ThisType) {
-            return null;
         }
 
         if (! $callerType instanceof TypeWithClassName) {

--- a/packages/phpstan-rules/src/Matcher/ClassMethodCallReferenceResolver.php
+++ b/packages/phpstan-rules/src/Matcher/ClassMethodCallReferenceResolver.php
@@ -7,13 +7,14 @@ namespace Symplify\PHPStanRules\Matcher;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeWithClassName;
 use Symplify\PHPStanRules\ValueObject\MethodCallReference;
 
 final class ClassMethodCallReferenceResolver
 {
-    public function resolve(MethodCall $methodCall, Scope $scope): ?MethodCallReference
+    public function resolve(MethodCall $methodCall, Scope $scope, bool $allowThisType): ?MethodCallReference
     {
         if ($methodCall->name instanceof Expr) {
             return null;
@@ -24,6 +25,10 @@ final class ClassMethodCallReferenceResolver
         // remove optional nullable type
         if (TypeCombinator::containsNull($callerType)) {
             $callerType = TypeCombinator::removeNull($callerType);
+        }
+
+        if (! $allowThisType && $callerType instanceof ThisType) {
+            return null;
         }
 
         if (! $callerType instanceof TypeWithClassName) {

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Fixture/SkipUsedInternallyForSecondType.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Fixture/SkipUsedInternallyForSecondType.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Fixture;
+
+use DateTime;
+use stdClass;
+
+final class SkipUsedInternallyForSecondType
+{
+    public function run(stdClass|DateTime $obj)
+    {
+    }
+
+    public function execute()
+    {
+        $this->run(new DateTime('now'));
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/NarrowPublicClassMethodParamTypeByCallerTypeRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/NarrowPublicClassMethodParamTypeByCallerTypeRuleTest.php
@@ -116,6 +116,12 @@ final class NarrowPublicClassMethodParamTypeByCallerTypeRuleTest extends RuleTes
             __DIR__ . '/Source/ExpectedThisType/CallByThis.php',
         ], []];
 
+        // skip used internally for second type
+        yield [[
+            __DIR__ . '/Fixture/SkipUsedInternallyForSecondType.php',
+            __DIR__ . '/Source/ExpectedType/OnlyFirstTypeCalledOutside.php',
+        ], []];
+
         $argErrorMessage = sprintf(NarrowPublicClassMethodParamTypeByCallerTypeRule::ERROR_MESSAGE, 'int');
         yield [[
             __DIR__ . '/Fixture/PublicDoubleShot.php',

--- a/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedType/OnlyFirstTypeCalledOutside.php
+++ b/packages/phpstan-rules/tests/Rules/NarrowType/NarrowPublicClassMethodParamTypeByCallerTypeRule/Source/ExpectedType/OnlyFirstTypeCalledOutside.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Source\ExpectedType;
+
+use stdClass;
+use Symplify\PHPStanRules\Tests\Rules\NarrowType\NarrowPublicClassMethodParamTypeByCallerTypeRule\Fixture\SkipUsedInternallyForSecondType;
+
+final class OnlyFirstTypeCalledOutside
+{
+    public function run(SkipUsedInternallyForSecondType $skipUsedInternallyForSecondType)
+    {
+        $skipUsedInternallyForSecondType->run(new stdClass());
+    }
+}


### PR DESCRIPTION
- first type called outside class
- second type called inside class itself