### PR TITLE
[ConfigTransformer] Add suport for autowiring types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -155,6 +155,7 @@
     "extra": {
         "patches": {
             "symfony/dependency-injection": [
+                "patches/symfony-dependency-injection-definition-php.patch",
                 "patches/symfony-dependency-injection-loader-yamlfileloader-php.patch",
                 "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
             ],

--- a/composer.json
+++ b/composer.json
@@ -154,11 +154,12 @@
     },
     "extra": {
         "patches": {
+            "symfony/dependency-injection": [
+                "patches/symfony-dependency-injection-loader-yamlfileloader-php.patch",
+                "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
+            ],
             "squizlabs/php_codesniffer": [
                 "patches/squizlabs-php-codesniffer-tests-standards-abstractsniffunittest-php.patch"
-            ],
-            "symfony/dependency-injection": [
-                "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
             ]
         },
         "enable-patching": true

--- a/packages/config-transformer/composer.json
+++ b/packages/config-transformer/composer.json
@@ -46,7 +46,8 @@
         },
         "patches": {
             "symfony/dependency-injection": [
-                "patches/symfony-dependency-injection-loader-yamlfileloader-php.patch"
+                "patches/symfony-dependency-injection-loader-yamlfileloader-php.patch",
+                "patches/symfony-dependency-injection-definition-php.patch"
             ]
         },
         "enable-patching": true

--- a/packages/config-transformer/composer.json
+++ b/packages/config-transformer/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.21",
         "symfony/framework-bundle": "^6.0.10",
-        "symplify/easy-testing": "^11.1"
+        "symplify/easy-testing": "^11.1",
+        "cweagans/composer-patches": "^1.7"
     },
     "autoload": {
         "psr-4": {
@@ -42,7 +43,13 @@
     "extra": {
         "branch-alias": {
             "dev-main": "11.1-dev"
-        }
+        },
+        "patches": {
+            "symfony/dependency-injection": [
+                "patches/symfony-dependency-injection-loader-yamlfileloader-php.patch"
+            ]
+        },
+        "enable-patching": true
     },
     "conflict": {
         "symplify/astral": "<11.0.8",

--- a/packages/config-transformer/patches/symfony-dependency-injection-definition-php.patch
+++ b/packages/config-transformer/patches/symfony-dependency-injection-definition-php.patch
@@ -1,0 +1,59 @@
+--- /dev/null
++++ ../Definition.php
+@@ -44,6 +44,7 @@
+     private array $changes = [];
+     private array $bindings = [];
+     private array $errors = [];
++    private $autowiringTypes = array();
+
+     protected $arguments = [];
+
+@@ -714,6 +715,48 @@
+     public function getConfigurator(): string|array|null
+     {
+         return $this->configurator;
++    }
++
++    /**
++     * Sets types that will default to this definition.
++     *
++     * @param string[] $types
++     *
++     * @return $this
++     */
++    public function setAutowiringTypes(array $types)
++    {
++        $this->autowiringTypes = array();
++
++        foreach ($types as $type) {
++            $this->autowiringTypes[$type] = true;
++        }
++
++        return $this;
++    }
++
++    /**
++     * Gets autowiring types that will default to this definition.
++     *
++     * @return string[]
++     */
++    public function getAutowiringTypes()
++    {
++        return array_keys($this->autowiringTypes);
++    }
++
++    /**
++     * Adds a type that will default to this definition.
++     *
++     * @param string $type
++     *
++     * @return $this
++     */
++    public function addAutowiringType($type)
++    {
++        $this->autowiringTypes[$type] = true;
++
++        return $this;
+     }
+
+     /**

--- a/packages/config-transformer/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
+++ b/packages/config-transformer/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ ../Loader/YamlFileLoader.php
+@@ -63,6 +63,7 @@
+         'autowire' => 'autowire',
+         'autoconfigure' => 'autoconfigure',
+         'bind' => 'bind',
++        'autowiring_types' => 'autowiring_types',
+     ];
+
+     private const PROTOTYPE_KEYWORDS = [

--- a/packages/config-transformer/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
+++ b/packages/config-transformer/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
@@ -8,3 +8,28 @@
      ];
 
      private const PROTOTYPE_KEYWORDS = [
+@@ -466,6 +467,24 @@
+         }
+         if (isset($defaults['autoconfigure'])) {
+             $definition->setAutoconfigured($defaults['autoconfigure']);
++        }
++
++        if (isset($service['autowiring_types'])) {
++            if (is_string($service['autowiring_types'])) {
++                $definition->addAutowiringType($service['autowiring_types']);
++            } else {
++                if (!is_array($service['autowiring_types'])) {
++                    throw new InvalidArgumentException(sprintf('Parameter "autowiring_types" must be a string or an array for service "%s" in %s. Check your YAML syntax.', $id, $file));
++                }
++
++                foreach ($service['autowiring_types'] as $autowiringType) {
++                    if (!is_string($autowiringType)) {
++                        throw new InvalidArgumentException(sprintf('A "autowiring_types" attribute must be of type string for service "%s" in %s. Check your YAML syntax.', $id, $file));
++                    }
++
++                    $definition->addAutowiringType($autowiringType);
++                }
++            }
+         }
+
+         $definition->setChanges([]);

--- a/packages/config-transformer/src/ConfigLoader.php
+++ b/packages/config-transformer/src/ConfigLoader.php
@@ -53,7 +53,7 @@ final class ConfigLoader
             $content = Strings::replace(
                 $content,
                 self::PHP_CONST_REGEX,
-                fn ($match): string => '"%const('.str_replace('\\', '\\\\', $match[1]).')%"'.$match[2]
+                fn ($match): string => '"%const(' . str_replace('\\', '\\\\', $match[1]) . ')%"' . $match[2]
             );
             if ($content !== $smartFileInfo->getContents()) {
                 $fileRealPath = sys_get_temp_dir() . '/_migrify_config_tranformer_clean_yaml/' . $smartFileInfo->getFilename();

--- a/packages/config-transformer/src/ConfigLoader.php
+++ b/packages/config-transformer/src/ConfigLoader.php
@@ -53,7 +53,7 @@ final class ConfigLoader
             $content = Strings::replace(
                 $content,
                 self::PHP_CONST_REGEX,
-                fn ($match): string => '"%const(' . str_replace('\\', '\\\\', $match[1]) . ')%"' . $match[2]
+                static fn ($match): string => '"%const(' . str_replace('\\', '\\\\', $match[1]) . ')%"' . $match[2]
             );
             if ($content !== $smartFileInfo->getContents()) {
                 $fileRealPath = sys_get_temp_dir() . '/_migrify_config_tranformer_clean_yaml/' . $smartFileInfo->getFilename();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/autowired_type.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/autowired_type.yaml
@@ -9,11 +9,11 @@ services:
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeGuzzle;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set('some_class', \Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService::class)
-        ->autowiringTypes(\Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService);
+    $services->set('some_class', SomeService::class)
+        ->autowiringTypes(SomeService::class);
 };

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/autowired_type.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/autowired_type.yaml
@@ -15,5 +15,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set('some_class', SomeService::class)
-        ->autowiringTypes(SomeService::class);
+        ->addAutowiringType(SomeService::class);
 };

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/autowired_type.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/autowired_type.yaml
@@ -1,0 +1,19 @@
+# symfony 2.8 feature
+services:
+    some_class:
+        class: Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService
+        autowiring_types: Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\FakeGuzzle;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set('some_class', \Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService::class)
+        ->autowiringTypes(\Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source\SomeService);
+};

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Source/SomeService.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Source/SomeService.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\Source;
+
+final class SomeService
+{
+
+}

--- a/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
+++ b/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
@@ -16,7 +16,6 @@ use Symplify\Astral\ValueObject\AttributeKey;
 use Symplify\PhpConfigPrinter\NodeFactory\CommonNodeFactory;
 use Symplify\PhpConfigPrinter\NodeFactory\ConstantNodeFactory;
 use Symplify\PhpConfigPrinter\ValueObject\FunctionName;
-use function str_contains;
 use function str_starts_with;
 
 final class StringExprResolver
@@ -67,14 +66,18 @@ final class StringExprResolver
         }
 
         // is service reference
-        if (str_starts_with($value, '@') && !$this->isFilePath($value)) {
+        if (str_starts_with($value, '@') && ! $this->isFilePath($value)) {
             return $this->resolveServiceReferenceExpr($value, $skipServiceReference, FunctionName::SERVICE);
         }
 
         return BuilderHelpers::normalizeValue($value);
     }
 
-    private function resolveExpr(string $value, bool $skipServiceReference, bool $skipClassesToConstantReference): FuncCall
+    private function resolveExpr(
+        string $value,
+        bool $skipServiceReference,
+        bool $skipClassesToConstantReference
+    ): FuncCall
     {
         $value = ltrim($value, '@=');
         $expr = $this->resolve($value, $skipServiceReference, $skipClassesToConstantReference);

--- a/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
+++ b/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
@@ -46,9 +46,9 @@ final class StringExprResolver
             return $this->constantNodeFactory->createConstant($const);
         }
 
-        $ret = $this->constantNodeFactory->createClassConstantIfValue($value);
-        if ($ret) {
-            return $ret;
+        $classConstFetch = $this->constantNodeFactory->createClassConstantIfValue($value);
+        if ($classConstFetch instanceof ClassConstFetch) {
+            return $classConstFetch;
         }
 
         // do not print "\n" as empty space, but use string value instead

--- a/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
+++ b/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
@@ -77,8 +77,7 @@ final class StringExprResolver
         string $value,
         bool $skipServiceReference,
         bool $skipClassesToConstantReference
-    ): FuncCall
-    {
+    ): FuncCall {
         $value = ltrim($value, '@=');
         $expr = $this->resolve($value, $skipServiceReference, $skipClassesToConstantReference);
         $args = [new Arg($expr)];

--- a/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
@@ -43,7 +43,7 @@ final class ConstantNodeFactory
     public function createConstant(string $value): ConstFetch|ClassConstFetch
     {
         $classConstFetch = $this->createClassConstantIfValue($value, false);
-        if ($classConstFetch !== null) {
+        if ($classConstFetch instanceof ClassConstFetch) {
             return $classConstFetch;
         }
 

--- a/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
@@ -23,11 +23,12 @@ final class ConstantNodeFactory
      */
     private const CLASS_CONST_FETCH_REGEX = '#(.*?)::[A-Za-z_]#';
 
-    public function createClassConstantIfValue(string $value, bool $checkExistence = true): ?ClassConstFetch {
+    public function createClassConstantIfValue(string $value, bool $checkExistence = true): ?ClassConstFetch
+    {
         $match = Strings::match($value, self::CLASS_CONST_FETCH_REGEX);
         if ($match !== null) {
             [$class, $constant] = explode('::', $value);
-            if (!$checkExistence) {
+            if (! $checkExistence) {
                 return new ClassConstFetch(new FullyQualified($class), $constant);
             }
 

--- a/packages/php-config-printer/src/ServiceOptionConverter/AutowiringTypesOptionKeyYamlToPhpFactory.php
+++ b/packages/php-config-printer/src/ServiceOptionConverter/AutowiringTypesOptionKeyYamlToPhpFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PhpConfigPrinter\ServiceOptionConverter;
+
+use PhpParser\Node\Expr\MethodCall;
+use Symplify\PhpConfigPrinter\Contract\Converter\ServiceOptionsKeyYamlToPhpFactoryInterface;
+use Symplify\PhpConfigPrinter\NodeFactory\ArgsNodeFactory;
+
+final class AutowiringTypesOptionKeyYamlToPhpFactory implements ServiceOptionsKeyYamlToPhpFactoryInterface
+{
+    public function __construct(
+        private ArgsNodeFactory $argsNodeFactory,
+    ) {
+    }
+
+    public function decorateServiceMethodCall(
+        mixed $key,
+        mixed $yaml,
+        mixed $values,
+        MethodCall $methodCall
+    ): MethodCall {
+        $args = $this->argsNodeFactory->createFromValues($yaml);
+        return new MethodCall($methodCall, 'addAutowiringType', $args);
+    }
+
+    public function isMatch(mixed $key, mixed $values): bool
+    {
+        return $key === 'autowiring_types';
+    }
+}

--- a/packages/php-config-printer/src/Yaml/CheckerServiceParametersShifter.php
+++ b/packages/php-config-printer/src/Yaml/CheckerServiceParametersShifter.php
@@ -68,6 +68,7 @@ final class CheckerServiceParametersShifter
         'autowire',
         'autoconfigure',
         'bind',
+        'autowiring_types',
     ];
 
     private StringFormatConverter $stringFormatConverter;

--- a/packages/php-config-printer/tests/NodeFactory/ConstantNodeFactoryTest.php
+++ b/packages/php-config-printer/tests/NodeFactory/ConstantNodeFactoryTest.php
@@ -20,7 +20,6 @@ final class ConstantNodeFactoryTest extends TestCase
         $this->constantNodeFactory = new ConstantNodeFactory();
     }
 
-
     public function testConstantFetchNode(): void
     {
         $constFetch = $this->constantNodeFactory->createConstant('PHP_VERSION');

--- a/patches/symfony-dependency-injection-definition-php.patch
+++ b/patches/symfony-dependency-injection-definition-php.patch
@@ -1,0 +1,59 @@
+--- /dev/null
++++ ../Definition.php
+@@ -44,6 +44,7 @@
+     private array $changes = [];
+     private array $bindings = [];
+     private array $errors = [];
++    private $autowiringTypes = array();
+ 
+     protected $arguments = [];
+ 
+@@ -714,6 +715,48 @@
+     public function getConfigurator(): string|array|null
+     {
+         return $this->configurator;
++    }
++
++    /**
++     * Sets types that will default to this definition.
++     *
++     * @param string[] $types
++     *
++     * @return $this
++     */
++    public function setAutowiringTypes(array $types)
++    {
++        $this->autowiringTypes = array();
++
++        foreach ($types as $type) {
++            $this->autowiringTypes[$type] = true;
++        }
++
++        return $this;
++    }
++
++    /**
++     * Gets autowiring types that will default to this definition.
++     *
++     * @return string[]
++     */
++    public function getAutowiringTypes()
++    {
++        return array_keys($this->autowiringTypes);
++    }
++
++    /**
++     * Adds a type that will default to this definition.
++     *
++     * @param string $type
++     *
++     * @return $this
++     */
++    public function addAutowiringType($type)
++    {
++        $this->autowiringTypes[$type] = true;
++
++        return $this;
+     }
+ 
+     /**

--- a/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
+++ b/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ ../Loader/YamlFileLoader.php
+@@ -63,6 +63,7 @@
+         'autowire' => 'autowire',
+         'autoconfigure' => 'autoconfigure',
+         'bind' => 'bind',
++        'autowiring_types' => 'autowiring_types',
+     ];
+ 
+     private const PROTOTYPE_KEYWORDS = [

--- a/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
+++ b/patches/symfony-dependency-injection-loader-yamlfileloader-php.patch
@@ -8,3 +8,28 @@
      ];
  
      private const PROTOTYPE_KEYWORDS = [
+@@ -466,6 +467,24 @@
+         }
+         if (isset($defaults['autoconfigure'])) {
+             $definition->setAutoconfigured($defaults['autoconfigure']);
++        }
++
++        if (isset($service['autowiring_types'])) {
++            if (is_string($service['autowiring_types'])) {
++                $definition->addAutowiringType($service['autowiring_types']);
++            } else {
++                if (!is_array($service['autowiring_types'])) {
++                    throw new InvalidArgumentException(sprintf('Parameter "autowiring_types" must be a string or an array for service "%s" in %s. Check your YAML syntax.', $id, $file));
++                }
++
++                foreach ($service['autowiring_types'] as $autowiringType) {
++                    if (!is_string($autowiringType)) {
++                        throw new InvalidArgumentException(sprintf('A "autowiring_types" attribute must be of type string for service "%s" in %s. Check your YAML syntax.', $id, $file));
++                    }
++
++                    $definition->addAutowiringType($autowiringType);
++                }
++            }
+         }
+ 
+         $definition->setChanges([]);


### PR DESCRIPTION
This adds feature removed in Symfony 4: https://github.com/symfony/symfony/pull/21494,
so it can be easily converted :)