### PR TITLE
Add reproducer for routing bundle file import

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/routing/bundle_import.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/routing/bundle_import.yaml
@@ -1,0 +1,13 @@
+bazinga_js_translation:
+    resource: "@BazingaJsTranslationBundle/Resources/config/routing/routing.yml"
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (RoutingConfigurator $routingConfigurator): void {
+    $routingConfigurator->import('@BazingaJsTranslationBundle/Resources/config/routing/routing.yml');
+};


### PR DESCRIPTION
This is a reproducer for bundle import file which is currently detected as a service.