### PR TITLE
Proper yield types for `StaticFixtureFinder`

### DIFF
--- a/packages/easy-testing/src/DataProvider/StaticFixtureFinder.php
+++ b/packages/easy-testing/src/DataProvider/StaticFixtureFinder.php
@@ -39,7 +39,7 @@ final class StaticFixtureFinder
     }
 
     /**
-     * @return Iterator<string, array<int, SplFileInfo>>
+     * @return Iterator<string, array<int, SmartFileInfo>>
      */
     public static function yieldDirectoryWithRelativePathname(string $directory, string $suffix = '*.php.inc'): Iterator
     {
@@ -49,7 +49,7 @@ final class StaticFixtureFinder
     }
 
     /**
-     * @return Iterator<string, array<int, SplFileInfo>>
+     * @return Iterator<string, array<int, SmartFileInfo>>
      */
     public static function yieldDirectoryExclusivelyWithRelativePathname(
         string $directory,
@@ -77,7 +77,7 @@ final class StaticFixtureFinder
 
     /**
      * @param SplFileInfo[] $fileInfos
-     * @return Iterator<string, array<int, SplFileInfo>>
+     * @return Iterator<string, array<int, SmartFileInfo>>
      */
     private static function yieldFileInfosWithRelativePathname(array $fileInfos): Iterator
     {


### PR DESCRIPTION
`StaticFixtureFinder:: yieldFileInfosWithRelativePathname()` maps `SplFileInfo` from arguments to `SmartFileInfo`, but phpDocs were too narrow. This change is required for Rector (MR incoming).