### PR TITLE
Monorepo-builder: Documentation update to ensure code matches example

### DIFF
--- a/packages/monorepo-builder/README.md
+++ b/packages/monorepo-builder/README.md
@@ -51,6 +51,7 @@ Typical location for packages is `/packages`. But what if you have different nam
 ```php
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
 use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\ValueObject\Option;
 
 return static function (MBConfig $mbConfig): void {
     // where are the packages located?


### PR DESCRIPTION
First of all, thanks for all your heard work. It's really appreciated and helped me out a ton!

Just thought I'd update the documentation while I was using it if that makes sense at all.

For ease of copy pasting we can add `Symplify\MonorepoBuilder\ValueObject\Option`, as this is used in the `dataToRemove` example.

```
    $mbConfig->dataToRemove([
        ComposerJsonSection::REQUIRE => [
            // the line is removed by key, so version is irrelevant, thus *
            'phpunit/phpunit' => '*',
        ],
        ComposerJsonSection::REPOSITORIES => [
            // this will remove all repositories
            Option::REMOVE_COMPLETELY,
        ],
    ]);
```    