### PR TITLE
[ConfigTransformer] Fix converting sniff class in case of missing PHP_CodeSniffer

### DIFF
--- a/packages/config-transformer/.gitignore
+++ b/packages/config-transformer/.gitignore
@@ -1,1 +1,2 @@
 composer.lock
+/vendor

--- a/packages/config-transformer/phpunit.xml
+++ b/packages/config-transformer/phpunit.xml
@@ -7,7 +7,7 @@
 >
     <testsuites>
         <testsuite name="unit">
-            <directory>packages/*/tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/packages/config-transformer/src/ConfigLoader.php
+++ b/packages/config-transformer/src/ConfigLoader.php
@@ -80,8 +80,9 @@ final class ConfigLoader
 
         try {
             $delegatingLoader->load($fileRealPath);
-        } catch (LoaderLoadException $e) {
-            // ignore exception for maybe imported none existing files
+        } catch (LoaderLoadException) {
+            // ignore exception for maybe import of non-existing files
+            // usefull in gradual upgrade of configs
         }
 
         return new ContainerBuilderAndFileContent($containerBuilder, $content);

--- a/packages/config-transformer/src/ConfigLoader.php
+++ b/packages/config-transformer/src/ConfigLoader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\ConfigTransformer;
 
 use Nette\Utils\Strings;
+use Symfony\Component\Config\Exception\LoaderLoadException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\Loader;
@@ -77,7 +78,11 @@ final class ConfigLoader
             $this->extensionFaker->fakeInContainerBuilder($containerBuilder, $content);
         }
 
-        $delegatingLoader->load($fileRealPath);
+        try {
+            $delegatingLoader->load($fileRealPath);
+        } catch (LoaderLoadException $e) {
+            // ignore exception for maybe imported none existing files
+        }
 
         return new ContainerBuilderAndFileContent($containerBuilder, $content);
     }

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/hautelook_alice.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/hautelook_alice.yaml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: ../dev/hautelook_alice.yaml }
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/../dev/hautelook_alice.yaml');
+};

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/import_already_converted.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/import_already_converted.php
@@ -1,6 +1,3 @@
-imports:
-    - { resource: ../dev/hautelook_alice.yaml }
------
 <?php
 
 declare(strict_types=1);
@@ -8,5 +5,7 @@ declare(strict_types=1);
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/../dev/hautelook_alice.yaml');
+    $containerConfigurator->extension('hautelook_alice', [
+        'fixtures_path' => 'fixtures',
+    ]);
 };

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/import_already_converted_test.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/import_already_converted_test.yaml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: import_already_converted.yaml }
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(__DIR__ . '/import_already_converted.php');
+};

--- a/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
+++ b/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
@@ -116,9 +116,11 @@ final class StringExprResolver
         if (! ctype_upper($value[0])) {
             return false;
         }
-
         // to avoid autoload in case of missing code sniffer dependency
-        if (str_ends_with($value, 'Sniff') || str_ends_with($value, 'Fixer')) {
+        if (str_ends_with($value, 'Sniff')) {
+            return true;
+        }
+        if (str_ends_with($value, 'Fixer')) {
             return true;
         }
 

--- a/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
+++ b/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
@@ -116,10 +116,12 @@ final class StringExprResolver
         if (! ctype_upper($value[0])) {
             return false;
         }
+
         // to avoid autoload in case of missing code sniffer dependency
         if (str_ends_with($value, 'Sniff')) {
             return true;
         }
+
         if (str_ends_with($value, 'Fixer')) {
             return true;
         }

--- a/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
+++ b/packages/php-config-printer/src/ExprResolver/StringExprResolver.php
@@ -117,6 +117,11 @@ final class StringExprResolver
             return false;
         }
 
+        // to avoid autoload in case of missing code sniffer dependency
+        if (str_ends_with($value, 'Sniff') || str_ends_with($value, 'Fixer')) {
+            return true;
+        }
+
         if (class_exists($value)) {
             return true;
         }


### PR DESCRIPTION
Follow up to https://github.com/symplify/symplify/pull/4288