### PR TITLE
[SymfonyStaticDumper] Add --public-directory and --output-directory to allow customize the io directories

### DIFF
--- a/packages/symfony-static-dumper/README.md
+++ b/packages/symfony-static-dumper/README.md
@@ -15,9 +15,10 @@ Add config to `config/config.php`:
 
 ```php
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\SymfonyStaticDumper\ValueObject\SymfonyStaticDumperConfig;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(\Symplify\SymfonyStaticDumper\ValueObject\SymfonyStaticDumperConfig::FILE_PATH);
+    $containerConfigurator->import(SymfonyStaticDumperConfig::FILE_PATH);
 };
 ```
 
@@ -110,10 +111,18 @@ final class PostController extends AbstractController
 ## Use
 
 ```bash
-bin/console dump-static-site
+vendor/bin/console dump-static-site
 ```
 
 The website will be generated to `/output` directory in your root project.
+
+Do you want to modify the `/public` directory yourself?
+
+```bash
+vendor/bin/console dump-static-site --public-directory another-public --output-directory custom-output
+```
+
+<br>
 
 To see the website, just run local server:
 

--- a/packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
+++ b/packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
@@ -7,21 +7,15 @@ namespace Symplify\SymfonyStaticDumper\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\SymfonyStaticDumper\Application\SymfonyStaticDumperApplication;
 use Symplify\SymfonyStaticDumper\Enum\Option;
 
 final class DumpStaticSiteCommand extends AbstractSymplifyCommand
 {
-    private string $projectDir;
-
     public function __construct(
         private SymfonyStaticDumperApplication $symfonyStaticDumperApplication,
-        ParameterBagInterface $parameterBag
     ) {
-        $this->projectDir = (string) $parameterBag->get('kernel.project_dir');
-
         parent::__construct();
     }
 
@@ -36,7 +30,7 @@ final class DumpStaticSiteCommand extends AbstractSymplifyCommand
             null,
             InputOption::VALUE_REQUIRED,
             'Define the input public directory',
-            $this->projectDir . '/public'
+            getcwd() . '/public'
         );
 
         $this->addOption(

--- a/packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
+++ b/packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\SymfonyStaticDumper\Command;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
@@ -12,32 +13,47 @@ use Symplify\SymfonyStaticDumper\Application\SymfonyStaticDumperApplication;
 
 final class DumpStaticSiteCommand extends AbstractSymplifyCommand
 {
-    private string $publicDirectory;
-
-    private string $outputDirectory;
+    private string $projectDir;
 
     public function __construct(
         private SymfonyStaticDumperApplication $symfonyStaticDumperApplication,
         ParameterBagInterface $parameterBag
     ) {
+        $this->projectDir = (string) $parameterBag->get('kernel.project_dir');
+
         parent::__construct();
-
-        $projectDir = (string) $parameterBag->get('kernel.project_dir');
-
-        $this->publicDirectory = $projectDir . '/public';
-        $this->outputDirectory = getcwd() . '/output';
     }
 
     protected function configure(): void
     {
         $this->setName('dump-static-site');
         $this->setDescription('Dump website to static HTML and CSS in the output directory');
+
+        // Adding arguments options for the main command
+        $this->addOption(
+            'public-directory',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Define the input public directory',
+            $this->projectDir . '/public'
+        );
+
+        $this->addOption(
+            'output-directory',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Define the output directory for generated static content',
+            getcwd() . '/output'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->symfonyStyle->section('Dumping static website');
-        $this->symfonyStaticDumperApplication->run($this->publicDirectory, $this->outputDirectory);
+
+        $publicDirectory = $input->getOption('public-directory');
+        $outputDirectory = $input->getOption('output-directory');
+        $this->symfonyStaticDumperApplication->run($publicDirectory, $outputDirectory);
 
         $this->symfonyStyle->note('Run local server to see the output: "php -S localhost:8001 -t output"');
 

--- a/packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
+++ b/packages/symfony-static-dumper/src/Command/DumpStaticSiteCommand.php
@@ -10,6 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
 use Symplify\SymfonyStaticDumper\Application\SymfonyStaticDumperApplication;
+use Symplify\SymfonyStaticDumper\Enum\Option;
 
 final class DumpStaticSiteCommand extends AbstractSymplifyCommand
 {
@@ -31,7 +32,7 @@ final class DumpStaticSiteCommand extends AbstractSymplifyCommand
 
         // Adding arguments options for the main command
         $this->addOption(
-            'public-directory',
+            Option::PUBLIC_DIRECTORY,
             null,
             InputOption::VALUE_REQUIRED,
             'Define the input public directory',
@@ -39,7 +40,7 @@ final class DumpStaticSiteCommand extends AbstractSymplifyCommand
         );
 
         $this->addOption(
-            'output-directory',
+            Option::OUTPUT_DIRECTORY,
             null,
             InputOption::VALUE_REQUIRED,
             'Define the output directory for generated static content',
@@ -51,8 +52,8 @@ final class DumpStaticSiteCommand extends AbstractSymplifyCommand
     {
         $this->symfonyStyle->section('Dumping static website');
 
-        $publicDirectory = $input->getOption('public-directory');
-        $outputDirectory = $input->getOption('output-directory');
+        $publicDirectory = $input->getOption(Option::PUBLIC_DIRECTORY);
+        $outputDirectory = $input->getOption(Option::OUTPUT_DIRECTORY);
         $this->symfonyStaticDumperApplication->run($publicDirectory, $outputDirectory);
 
         $this->symfonyStyle->note('Run local server to see the output: "php -S localhost:8001 -t output"');

--- a/packages/symfony-static-dumper/src/Enum/Option.php
+++ b/packages/symfony-static-dumper/src/Enum/Option.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\SymfonyStaticDumper\Enum;
+
+final class Option
+{
+    /**
+     * @var string
+     */
+    public const PUBLIC_DIRECTORY = 'public-directory';
+
+    /**
+     * @var string
+     */
+    public const OUTPUT_DIRECTORY = 'output-directory';
+}


### PR DESCRIPTION
* Closes https://github.com/symplify/symplify/pull/4210
* Closes https://github.com/symplify/symplify/pull/4244

<br>

@JWBrownie Thanks for the feature proposal :+1:  The input and output directories are no configurable ↓

 <br>

These 2 command are equal in functionality:

```bash
vendor/bin/console dump-static-site

vendor/bin/console dump-static-site --public-directory public --output-directory output
```