### PR TITLE
[ConfigTransformer] Reproducer Expected to find class AppTestsBehatDemoContext in file

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_ignore_none_exist_resource.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_ignore_none_exist_resource.yaml
@@ -19,5 +19,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire()
         ->autoconfigure();
 
-    $services->load('    App\\Some\\', __DIR__.'/../src/NotExistingDir/*');
+-    $services->load('    App\\Some\\', __DIR__.'/../src/NotExistingDir/*');
++    $services->load('App\\Some\\', __DIR__.'/../src/NotExistingDir/*');
 };

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_ignore_none_exist_resource.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_ignore_none_exist_resource.yaml
@@ -1,0 +1,23 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    App\Some\:
+        resource: '../src/NotExistingDir/*'
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('    App\\Some\\', __DIR__.'/../src/NotExistingDir/*');
+};

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_test.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/services_test.yaml
@@ -1,0 +1,23 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    App\Tests\Behat\:
+        resource: 'tests/Behat/*'
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+    $services->load('App\\Tests\\Behat\\', __DIR__.'/tests/Behat/*');
+};

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/tests/Behat/DemoContext.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/tests/Behat/DemoContext.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Behat;
+
+use Behat\Behat\Context\Context;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * This context class contains the definitions of the steps used by the demo
+ * feature file. Learn how to get started with Behat and BDD on Behat's website.
+ *
+ * @see http://behat.org/en/latest/quick_start.html
+ */
+final class DemoContext implements Context
+{
+    /** @var KernelInterface */
+    private $kernel;
+
+    /** @var Response|null */
+    private $response;
+
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * @When a demo scenario sends a request to :path
+     */
+    public function aDemoScenarioSendsARequestTo(string $path): void
+    {
+        $this->response = $this->kernel->handle(Request::create($path, 'GET'));
+    }
+
+    /**
+     * @Then the response should be received
+     */
+    public function theResponseShouldBeReceived(): void
+    {
+        if ($this->response === null) {
+            throw new \RuntimeException('No response received');
+        }
+    }
+}


### PR DESCRIPTION
The following package is currently failing:

https://github.com/symfony/recipes-contrib/tree/main/friends-of-behat/symfony-extension/2.0

With the error:

> friends-of-behat/symfony-extension/2.0/config .................................................................................................................................................................................... FAILED
    The command "'/opt/homebrew/Cellar/php/8.1.8/bin/php' '/Users/tmp/Documents/Projects/symfony-php-recipes-contrib/vendor/bin/config-transformer' 'switch-format' '/Users/tmp/Documents/Projects/symfony-php-recipes-contrib/friends-of-behat/symfony-extension/2.0/config'" failed. Exit Code: 1(General error) Working directory: /Users/tmp/Documents/Projects/symfony-php-recipes-contrib Output: ================ Error Output: ================ In FileLoader.php line 196: Expected to find class "App\Tests\Behat\DemoContext" in file "/Users/alexan derschranz/Documents/Projects/symfony-php-recipes-contrib/friends-of-behat/ symfony-extension/2.0/tests/Behat/DemoContext.php" while importing services from resource "../tests/Behat/*", but it was not found! Check the namespac e prefix used with the resource. switch-format [-n|--dry-run] [-c|--config CONFIG] [--]
