### PR TITLE
[ConfigTransformer] Reproducer to ignore dist files

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/behat.yml.dist
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/behat.yml.dist
@@ -1,0 +1,8 @@
+default:
+    suites:
+        default:
+            contexts:
+                - App\Tests\Behat\DemoContext
+
+    extensions:
+        FriendsOfBehat\SymfonyExtension: null

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/ignore-dist.yaml.dist
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/ignore-dist.yaml.dist
@@ -1,0 +1,2 @@
+package:
+    key: value

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/ignore-dist.yaml.dist
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/ignore-dist.yaml.dist
@@ -1,2 +1,3 @@
+# not worse the struggle to convert also dist.yml files
 package:
     key: value

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/ignore-dist.yaml.dist
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/ignore/ignore-dist.yaml.dist
@@ -1,3 +1,4 @@
-# not worse the struggle to convert also dist.yml files
+# edge case (dist.yaml) which should just be ignored: https://github.com/symfony/recipes-contrib/blob/main/pasaiakoudala/authbundle/0.1/config/packages/security.yaml.dist
+# so the behat.yml.dist still works and is kept untouched
 package:
     key: value

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/YamlToPhpTest.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/YamlToPhpTest.php
@@ -31,6 +31,7 @@ final class YamlToPhpTest extends AbstractConfigFormatConverterTest
 
     /**
      * @dataProvider provideData()
+     * @dataProvider provideDataIgnore()
      * @dataProvider provideDataWithPhpImported()
      */
     public function testNormal(SmartFileInfo $fixtureFileInfo): void
@@ -110,6 +111,14 @@ final class YamlToPhpTest extends AbstractConfigFormatConverterTest
     public function provideData(): Iterator
     {
         return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture/normal', '*.yaml');
+    }
+
+    /**
+     * @return Iterator<mixed, SmartFileInfo[]>
+     */
+    public function provideDataIgnore(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture/ignore', '*');
     }
 
     /**


### PR DESCRIPTION
Reproducer for: #4337

There is currently an example file `security.yaml.dist` which fails as we have no config loader for `dist` file. 

It is really an edge case and we should just "ignore" the dist files. As there are example other `dist` files like behat.yml.dist which should not be converted. I currently did only see one package in all recipes yet having a yaml.dist. So would ignore just that and keep in untouched.

Edgecase which we can keep untouched: https://github.com/symfony/recipes-contrib/blob/main/pasaiakoudala/authbundle/0.1/config/packages/security.yaml.dist

Should be kept Untouched: https://github.com/symfony/recipes-contrib/blob/main/friends-of-behat/symfony-extension/2.0/behat.yml.dist
