### PR TITLE
[PHPStanRules] Add NoConstructorSymfonyFormObjectRule

### DIFF
--- a/packages/phpstan-rules/docs/symfony_overview.md
+++ b/packages/phpstan-rules/docs/symfony_overview.md
@@ -1,4 +1,76 @@
-# 5 Rules Overview
+# 6 Rules Overview
+
+## NoConstructorSymfonyFormObjectRule
+
+This object is used in a Symfony form, that uses magic setters/getters, so it cannot have required constructor
+
+- class: [`Symplify\PHPStanRules\Symfony\Rules\NoConstructorSymfonyFormObjectRule`](../packages/Symfony/Rules/NoConstructorSymfonyFormObjectRule.php)
+
+```php
+final class Ticket
+{
+    public function __construct(private int $price)
+    {
+    }
+}
+
+---
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use App\Entity\Ticket;
+
+final class TicketFormType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Ticket::class,
+        ]);
+    }
+}
+```
+
+:x:
+
+<br>
+
+```php
+final class Ticket
+{
+    private ?int $price = null;
+
+    public function setPrice(int $price): void
+    {
+        $this->price = $price;
+    }
+
+    public function getPrice(): ?int
+    {
+        return $this->price;
+    }
+}
+
+---
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use App\Entity\Ticket;
+
+final class TicketFormType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Ticket::class,
+        ]);
+    }
+}
+```
+
+:+1:
+
+<br>
 
 ## PreventDoubleSetParameterRule
 

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Fixture/ClassUsedInSymfonyFormButWithConstructor.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Fixture/ClassUsedInSymfonyFormButWithConstructor.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Fixture;
+
+final class ClassUsedInSymfonyFormButWithConstructor
+{
+    private int $requiredValue;
+
+    public function __construct($requiredValue)
+    {
+        $this->requiredValue = $requiredValue;
+    }
+}

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Fixture/SkipClassUsedInSymfonyFormWithoutConstructor.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Fixture/SkipClassUsedInSymfonyFormWithoutConstructor.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Fixture;
+
+final class SkipClassUsedInSymfonyFormWithoutConstructor
+{
+    private int $onlyOptionalValue;
+
+    public function __construct()
+    {
+        $this->onlyOptionalValue = 100;
+    }
+}

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/NoConstructorSymfonyFormObjectRuleTest.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/NoConstructorSymfonyFormObjectRuleTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule;
+
+use Iterator;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Symplify\PHPStanRules\Collector\ClassMethod\FormTypeClassCollector;
+use Symplify\PHPStanRules\Symfony\Rules\NoConstructorSymfonyFormObjectRule;
+
+/**
+ * @extends RuleTestCase<NoConstructorSymfonyFormObjectRule>
+ */
+final class NoConstructorSymfonyFormObjectRuleTest extends RuleTestCase
+{
+    /**
+     * @dataProvider provideData()
+     *
+     * @param string[] $filePaths
+     * @param mixed[] $expectedErrorMessagesWithLines
+     */
+    public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse($filePaths, $expectedErrorMessagesWithLines);
+    }
+
+    public function provideData(): Iterator
+    {
+        yield [
+            [
+                __DIR__ . '/Fixture/SkipClassUsedInSymfonyFormWithoutConstructor.php',
+                __DIR__ . '/Source/SymfonyFormUsingFirstObject.php',
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/ClassUsedInSymfonyFormButWithConstructor.php',
+                __DIR__ . '/Source/SymfonyFormUsingSecondObject.php',
+            ],
+            [[NoConstructorSymfonyFormObjectRule::ERROR_MESSAGE, 6]],
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    /**
+     * @return Collector[]
+     */
+    protected function getCollectors(): array
+    {
+        $formTypeClassCollector = self::getContainer()->getByType(FormTypeClassCollector::class);
+
+        return [$formTypeClassCollector];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(NoConstructorSymfonyFormObjectRule::class);
+    }
+}

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Source/SymfonyFormUsingFirstObject.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Source/SymfonyFormUsingFirstObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Source;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Fixture\SkipClassUsedInSymfonyFormWithoutConstructor;
+
+final class SymfonyFormUsingFirstObject extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => SkipClassUsedInSymfonyFormWithoutConstructor::class,
+        ]);
+    }
+}

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Source/SymfonyFormUsingSecondObject.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Source/SymfonyFormUsingSecondObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Source;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Fixture\ClassUsedInSymfonyFormButWithConstructor;
+
+final class SymfonyFormUsingSecondObject extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => ClassUsedInSymfonyFormButWithConstructor::class,
+        ]);
+    }
+}

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/config/configured_rule.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../../../tests/config/included_services.neon
+
+rules:
+    - Symplify\PHPStanRules\Symfony\Rules\NoConstructorSymfonyFormObjectRule
+
+services:
+    -
+        class: Symplify\PHPStanRules\Collector\ClassMethod\FormTypeClassCollector
+        tags: [phpstan.collector]

--- a/packages/phpstan-rules/packages/Symfony/Rules/NoConstructorSymfonyFormObjectRule.php
+++ b/packages/phpstan-rules/packages/Symfony/Rules/NoConstructorSymfonyFormObjectRule.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Symfony\Rules;
+
+use Nette\Utils\Arrays;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Reflection\Php\PhpParameterReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symplify\PHPStanRules\Collector\ClassMethod\FormTypeClassCollector;
+
+/**
+ * @implements Rule<CollectedDataNode>
+ *
+ * @see \Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\NoConstructorSymfonyFormObjectRuleTest
+ */
+final class NoConstructorSymfonyFormObjectRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'This object is used in a Symfony form, that uses magic setters/getters, so it cannot have required constructor';
+
+    public function __construct(
+        private ReflectionProvider $reflectionProvider
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @return RuleError[]
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $formTypeClassesCollector = $node->get(FormTypeClassCollector::class);
+        $formTypeClasses = Arrays::flatten($formTypeClassesCollector);
+
+        $ruleErrors = [];
+
+        foreach ($formTypeClasses as $formTypeClass) {
+            if (! $this->reflectionProvider->hasClass($formTypeClass)) {
+                continue;
+            }
+
+            $formTypeClassReflection = $this->reflectionProvider->getClass($formTypeClass);
+
+            // no constructor, we can skip
+            $constructorClassReflection = $formTypeClassReflection->getConstructor();
+            if (! $constructorClassReflection instanceof PhpMethodReflection) {
+                continue;
+            }
+
+            if (! $this->hasClassMethodRequiredParameter($constructorClassReflection)) {
+                continue;
+            }
+
+            $nativeClassReflection = $formTypeClassReflection->getNativeReflection();
+            $classLine = $nativeClassReflection->getStartLine();
+
+            $ruleErrorBuilder = RuleErrorBuilder::message(self::ERROR_MESSAGE);
+            $fileName = $formTypeClassReflection->getFileName();
+            if (is_string($fileName)) {
+                $ruleErrorBuilder->file($fileName);
+            }
+
+            if (is_int($classLine)) {
+                $ruleErrorBuilder->line($classLine);
+            }
+
+            $ruleErrors[] = $ruleErrorBuilder->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    private function hasClassMethodRequiredParameter(PhpMethodReflection $phpMethodReflection): bool
+    {
+        $parametersAcceptor = ParametersAcceptorSelector::selectSingle($phpMethodReflection->getVariants());
+
+        // no parameters in constructor → we can skip
+        if ($parametersAcceptor->getParameters() === []) {
+            return false;
+        }
+
+        foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
+            /** @var PhpParameterReflection $parameterReflection */
+            if ($parameterReflection->isOptional()) {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/packages/phpstan-rules/packages/Symfony/Rules/NoConstructorSymfonyFormObjectRule.php
+++ b/packages/phpstan-rules/packages/Symfony/Rules/NoConstructorSymfonyFormObjectRule.php
@@ -165,9 +165,9 @@ CODE_SAMPLE
             return false;
         }
 
-        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $parameterReflection) {
-            /** @var PhpParameterReflection $parameterReflection */
-            if ($parameterReflection->isOptional()) {
+        foreach ($parametersAcceptorWithPhpDocs->getParameters() as $parameterReflectionWithPhpDoc) {
+            /** @var PhpParameterReflection $parameterReflectionWithPhpDoc */
+            if ($parameterReflectionWithPhpDoc->isOptional()) {
                 continue;
             }
 

--- a/packages/phpstan-rules/stubs/Symfony/Component/Form/AbstractType.php
+++ b/packages/phpstan-rules/stubs/Symfony/Component/Form/AbstractType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Form;
 
-if (class_exists('Symfony\Component\Form\AbstractType')) {
+if (class_exists(\Symfony\Component\Form\AbstractType::class)) {
     return;
 }
 

--- a/packages/phpstan-rules/stubs/Symfony/Component/Form/AbstractType.php
+++ b/packages/phpstan-rules/stubs/Symfony/Component/Form/AbstractType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Form;
+
+if (class_exists('Symfony\Component\Form\AbstractType')) {
+    return;
+}
+
+abstract class AbstractType
+{
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -580,6 +580,7 @@ parameters:
         # phpstan collector data
         - '#Cognitive complexity for "Symplify\\PHPStanRules\\Rules\\Domain\\ForbiddenAlwaysSetterCallRule\:\:createGrouppedCallsByClass\(\)" is 10, keep it under 8#'
         - '#Cognitive complexity for "Symplify\\PHPStanRules\\Collector\\ClassMethod\\NewAndSetterCallsCollector\:\:processNode\(\)" is 17, keep it under 8#'
+        - '#Calling PHPStan\\Reflection\\Php\\PhpParameterReflection\:\:isOptional\(\) is not covered by backward compatibility promise\. The method might change in a minor PHPStan version#'
 
         # 2 different packages
         - '#The "(INPUT_SUFFIX_REGEX|CONFIG_SUFFIXES_REGEX)" constant contains duplicated regex "\#\\\.\(yml\|yaml\|xml\)\$\#"\. Instead of duplicated regexes, extract domain regexes together to save maintenance#'

--- a/stubs/Symfony/Component/Form/AbstractType.php
+++ b/stubs/Symfony/Component/Form/AbstractType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Symfony\Component\Form;
 
-if (class_exists('Symfony\Component\Form\AbstractType')) {
+if (class_exists(\Symfony\Component\Form\AbstractType::class)) {
     return;
 }
 

--- a/stubs/Symfony/Component/Form/AbstractType.php
+++ b/stubs/Symfony/Component/Form/AbstractType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Form;
+
+if (class_exists('Symfony\Component\Form\AbstractType')) {
+    return;
+}
+
+abstract class AbstractType
+{
+}


### PR DESCRIPTION
Using constructor value in Symfony Form objects of any kinds is breaking the forms.
See https://stackoverflow.com/a/43962930/1348344

We don't want to think about while upgrading, right?


This can be easily prevent by a PHPStan rule that checks there is no required parmaeter in the constructor of such used class :+1: :wink: 
