### PR TITLE
[PHPStanRules] Include the setDeault() in NoConstructorSymfonyFormObjectRule

### DIFF
--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/NoConstructorSymfonyFormObjectRuleTest.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/NoConstructorSymfonyFormObjectRuleTest.php
@@ -44,6 +44,14 @@ final class NoConstructorSymfonyFormObjectRuleTest extends RuleTestCase
             ],
             [[NoConstructorSymfonyFormObjectRule::ERROR_MESSAGE, 6]],
         ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/ClassUsedInSymfonyFormButWithConstructor.php',
+                __DIR__ . '/Source/SymfonyFormSetDefault.php',
+            ],
+            [[NoConstructorSymfonyFormObjectRule::ERROR_MESSAGE, 6]],
+        ];
     }
 
     /**

--- a/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Source/SymfonyFormSetDefault.php
+++ b/packages/phpstan-rules/packages-tests/Symfony/Rules/NoConstructorSymfonyFormObjectRule/Source/SymfonyFormSetDefault.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Source;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symplify\PHPStanRules\Tests\Symfony\Rules\NoConstructorSymfonyFormObjectRule\Fixture\ClassUsedInSymfonyFormButWithConstructor;
+
+final class SymfonyFormSetDefault extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefault('data_class',  ClassUsedInSymfonyFormButWithConstructor::class);
+    }
+}

--- a/packages/phpstan-rules/src/Collector/ClassMethod/FormTypeClassCollector.php
+++ b/packages/phpstan-rules/src/Collector/ClassMethod/FormTypeClassCollector.php
@@ -6,6 +6,8 @@ namespace Symplify\PHPStanRules\Collector\ClassMethod;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
@@ -34,17 +36,44 @@ final class FormTypeClassCollector implements Collector
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
-        if ($node->isMagic()) {
-            return null;
-        }
-
         $methodName = $node->name->toString();
         if ($methodName !== 'configureOptions') {
             return null;
         }
 
+        $stmts = $node->stmts;
+        if (! is_array($stmts)) {
+            return null;
+        }
+
+        /** @var MethodCall[] $methodCalls */
+        $methodCalls = $this->nodeFinder->findInstanceOf($stmts, MethodCall::class);
+
+        foreach ($methodCalls as $methodCall) {
+            if (! $methodCall->name instanceof Identifier) {
+                continue;
+            }
+
+            $methodCallName = $methodCall->name->toString();
+            if ($methodCallName === 'setDefaults') {
+                return $this->resolveDataClassFromSetDefaults($methodCall, $scope);
+            }
+
+            if ($methodCallName === 'setDefault') {
+                return $this->resolveDataClassFromSetDefault($methodCall, $scope);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    private function resolveDataClassFromSetDefaults(MethodCall $methodCall, Scope $scope): ?array
+    {
         /** @var ArrayItem[] $arrayItems */
-        $arrayItems = $this->nodeFinder->findInstanceOf((array) $node->stmts, ArrayItem::class);
+        $arrayItems = $this->nodeFinder->findInstanceOf($methodCall->args, ArrayItem::class);
 
         foreach ($arrayItems as $arrayItem) {
             if (! $arrayItem->key instanceof String_) {
@@ -65,5 +94,33 @@ final class FormTypeClassCollector implements Collector
         }
 
         return null;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    private function resolveDataClassFromSetDefault(MethodCall $methodCall, Scope $scope): ?array
+    {
+        $args = $methodCall->getArgs();
+        if (count($args) !== 2) {
+            return null;
+        }
+
+        $firstArgValue = $args[0]->value;
+        if (! $firstArgValue instanceof String_) {
+            return null;
+        }
+
+        if ($firstArgValue->value !== 'data_class') {
+            return null;
+        }
+
+        $secondArgValue = $args[1]->value;
+        $secondArgType = $scope->getType($secondArgValue);
+        if (! $secondArgType instanceof ConstantStringType) {
+            return null;
+        }
+
+        return [$secondArgType->getValue()];
     }
 }


### PR DESCRIPTION
Covers:

```php
    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefault('data_class',  ClassUsedInSymfonyFormButWithConstructor::class);
    }
```