### PR TITLE
[PHPStanRules] Remove complexity by type in ClassLikeCognitiveComplexityRule, too much overengeneering

### DIFF
--- a/packages/phpstan-rules/docs/cognitive_complexity_rules_overview.md
+++ b/packages/phpstan-rules/docs/cognitive_complexity_rules_overview.md
@@ -68,64 +68,6 @@ class SomeClass
 
 <br>
 
-```yaml
-services:
-    -
-        class: Symplify\PHPStanRules\CognitiveComplexity\Rules\ClassLikeCognitiveComplexityRule
-        tags: [phpstan.rules.rule]
-        arguments:
-            limitsByTypes:
-                Symfony\Component\Console\Command\Command: 5
-```
-
-↓
-
-```php
-use Symfony\Component\Console\Command\Command;
-
-class SomeCommand extends Command
-{
-    public function configure()
-    {
-        $this->setName('...');
-    }
-
-    public function execute()
-    {
-        if (...) {
-            // ...
-        } else {
-            // ...
-        }
-    }
-}
-```
-
-:x:
-
-<br>
-
-```php
-use Symfony\Component\Console\Command\Command;
-
-class SomeCommand extends Command
-{
-    public function configure()
-    {
-        $this->setName('...');
-    }
-
-    public function execute()
-    {
-        return $this->externalService->resolve(...);
-    }
-}
-```
-
-:+1:
-
-<br>
-
 ## FunctionLikeCognitiveComplexityRule
 
 Cognitive complexity of function/method must be under specific limit

--- a/packages/phpstan-rules/packages-tests/CognitiveComplexity/Rules/ClassLikeCognitiveComplexityRule/config/configured_composition_rule.neon
+++ b/packages/phpstan-rules/packages-tests/CognitiveComplexity/Rules/ClassLikeCognitiveComplexityRule/config/configured_composition_rule.neon
@@ -9,5 +9,4 @@ services:
         arguments:
             maxClassCognitiveComplexity: 50
             scoreCompositionOverInheritance: true
-            limitsByTypes:
-                Symfony\Component\Console\Command\Command: 5
+

--- a/packages/phpstan-rules/packages-tests/CognitiveComplexity/Rules/ClassLikeCognitiveComplexityRule/config/configured_rule.neon
+++ b/packages/phpstan-rules/packages-tests/CognitiveComplexity/Rules/ClassLikeCognitiveComplexityRule/config/configured_rule.neon
@@ -8,5 +8,3 @@ services:
         tags: [phpstan.rules.rule]
         arguments:
             maxClassCognitiveComplexity: 50
-            limitsByTypes:
-                Symfony\Component\Console\Command\Command: 5

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,9 +20,6 @@ services:
         tags: [phpstan.rules.rule]
         arguments:
             maxClassCognitiveComplexity: 25
-            limitsByTypes:
-                PHPStan\Rules\Rule: 18
-                Symplify\CodingStandard\Fixer\AbstractSymplifyFixer: 18
 
 parameters:
     level: 8
@@ -190,7 +187,6 @@ parameters:
                  # traversing is complex operatoin
                  - packages/astral/src/PhpDocParser/PhpDocNodeTraverser.php
                  - packages/php-config-printer/src/NodeFactory/ArgsNodeFactory.php
-                 - packages/phpstan-rules/packages/Nette/Rules/NoNetteDoubleTemplateAssignRule.php
 
         - '#Method Symplify\\PHPStanRules\\Rules\\RequireStringRegexMatchKeyRule\:\:findVariableArrayDimFetches\(\) should return array<PhpParser\\Node\\Expr\\ArrayDimFetch\> but returns array<PhpParser\\Node\>#'
 


### PR DESCRIPTION
Based on practical use... or rather non-use :) having class cognitive complexity is good enough :+1: 