### PR TITLE
Proper support for invokable factories/configurators

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/Source/InvokableFactory.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/Source/InvokableFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source;
+
+/**
+ * @see https://symfony.com/doc/current/service_container/factories.html#invokable-factories
+ */
+final class InvokableFactory
+{
+    public function __invoke(): ExistingClass
+    {
+        return new ExistingClass();
+    }
+}

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_configurator.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_configurator.yaml
@@ -21,5 +21,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->factory([service(SecondFakeClass::class), 'configure']);
 
     $services->set(SecondFakeClass::class)
-        ->factory([service(FakeClass::class)]);
+        ->factory(service(FakeClass::class));
 };

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_factory.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/maker-bundle/services_factory.yaml
@@ -24,7 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set('string_service_factory', FakeClass::class)
-        ->factory([service('factory_service_invokable')]);
+        ->factory(service('factory_service_invokable'));
 
     $services->set('array_service_factory', FakeClass::class)
         ->factory([service('factory_service'), 'constructFoo']);

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/factory/invokable_factory.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/factory/invokable_factory.yaml
@@ -1,0 +1,23 @@
+services:
+    Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\InvokableFactory: ~
+    Foo:
+        class: Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\ExistingClass
+        factory: '@Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\InvokableFactory'
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\ExistingClass;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\InvokableFactory;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(InvokableFactory::class);
+
+    $services->set('Foo', ExistingClass::class)
+        ->factory(service(InvokableFactory::class));
+};

--- a/packages/php-config-printer/src/ServiceOptionConverter/FactoryConfiguratorServiceOptionKeyYamlToPhpFactory.php
+++ b/packages/php-config-printer/src/ServiceOptionConverter/FactoryConfiguratorServiceOptionKeyYamlToPhpFactory.php
@@ -24,7 +24,9 @@ final class FactoryConfiguratorServiceOptionKeyYamlToPhpFactory implements Servi
         mixed $values,
         MethodCall $methodCall
     ): MethodCall {
-        $args = $this->argsNodeFactory->createFromValuesAndWrapInArray($yaml);
+        $args = (is_array($yaml) || strpos($yaml, ':') !== false)
+            ? $this->argsNodeFactory->createFromValuesAndWrapInArray($yaml)
+            : $this->argsNodeFactory->createFromValues($yaml);
 
         $this->singleFactoryReferenceNodeModifier->modifyArgs($args);
 


### PR DESCRIPTION
Fixes #4369 

As you can see in Symfony docs for [factories](https://symfony.com/doc/current/service_container/factories.html#invokable-factories) and [configurators](https://symfony.com/doc/current/service_container/configurators.html#using-the-configurator), when class is invokable `service(...)` reference must NOT be wrapped with array.