### PR TITLE
[ConfigTransformer] Support for `FQCN::method` format in factories

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/Source/StaticFactory.php
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/Source/StaticFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source;
+
+/**
+ * @see https://symfony.com/doc/current/service_container/factories.html#static-factories
+ */
+final class StaticFactory
+{
+    public function create(): ExistingClass
+    {
+        return new ExistingClass();
+    }
+}

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/factory/split_factory.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/factory/split_factory.yaml
@@ -1,12 +1,15 @@
 services:
     SomeClass:
         factory: "some_name:createMethod"
+    ExistingClass:
+        factory: 'Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\StaticFactory::create'
 -----
 <?php
 
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\Source\StaticFactory;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
@@ -14,4 +17,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set('SomeClass')
         ->factory([service('some_name'), 'createMethod']);
+
+    $services->set('ExistingClass')
+        ->factory([StaticFactory::class, 'create']);
 };

--- a/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
@@ -28,6 +28,12 @@ final class ConstantNodeFactory
         $match = Strings::match($value, self::CLASS_CONST_FETCH_REGEX);
         if ($match !== null) {
             [$class, $constant] = explode('::', $value);
+
+            // Ignore static factories (FQCN::method)
+            if (method_exists($class, $constant)) {
+                return null;
+            }
+
             if (! $checkExistence) {
                 return new ClassConstFetch(new FullyQualified($class), $constant);
             }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -166,6 +166,7 @@ parameters:
                 - packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
                 # PHPUnit 9/10 compat
                 - packages/symfony-static-dumper/tests/FileSystem/AssetsCopierTest.php
+                - packages/php-config-printer/src/NodeFactory/ConstantNodeFactory.php
 
         -
             message: '#Function "property_exists\(\)" cannot be used/left in the code#'


### PR DESCRIPTION
Fixes #4368

I was able to reproduce the problem, but I need help with fixing it 🙂 Could you point me where to look at just to be able to handle splitting by `::` and dumping proper factory with `::class` usage?

FYI: It can be tested locally with `vendor/bin/phpunit --testdox packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/YamlToPhpTest.php --filter=testNormal#39` (runs only failing fixture).