### PR TITLE
Require intl extension in composer.json

### DIFF
--- a/packages/monorepo-builder/composer.json
+++ b/packages/monorepo-builder/composer.json
@@ -7,6 +7,7 @@
     ],
     "require": {
         "php": ">=8.0",
+        "ext-intl": "*",
         "nette/utils": "^3.2",
         "phar-io/version": "^3.2",
         "symfony/finder": "^6.0",


### PR DESCRIPTION
Official docker images does not have intl extension enabled and monorepo builder fails hard on missing class. 

```
root@b19bba9b15b0:/code# vendor/bin/monorepo-builder init


PHP Fatal error:  Uncaught Error: Class 'Normalizer' not found in /code/vendor/symplify/monorepo-builder/vendor/symfony/console/Helper/Helper.php:45
Stack trace:
#0 /code/vendor/symplify/monorepo-builder/vendor/symfony/console/Style/SymfonyStyle.php(401): MonorepoBuilder202209\Symfony\Component\Console\Helper\Helper::width(' ')
#1 /code/vendor/symplify/monorepo-builder/vendor/symfony/console/Style/SymfonyStyle.php(64): MonorepoBuilder202209\Symfony\Component\Console\Style\SymfonyStyle->createBlock(Array, 'ERROR', 'fg=white;bg=red', ' ', true, true)
#2 /code/vendor/symplify/monorepo-builder/vendor/symfony/console/Style/SymfonyStyle.php(131): MonorepoBuilder202209\Symfony\Component\Console\Style\SymfonyStyle->block(Array, 'ERROR', 'fg=white;bg=red', ' ', true)
#3 /code/vendor/symplify/monorepo-builder/vendor/symplify/symplify-kernel/src/ValueObject/KernelBootAndApplicationRun.php(44): MonorepoBuilder202209\Symfony\Component\Console\Style\SymfonyStyle->error('Class 'Normaliz...')
#4 /code/vendor/symplify/monorepo-builder/bin/mono in /code/vendor/symplify/monorepo-builder/vendor/symfony/console/Helper/Helper.php on line 45
```