### PR TITLE
[MB] Fix Normalizer class not found on scoped Monorepo builder

### DIFF
--- a/packages/monorepo-builder/composer.json
+++ b/packages/monorepo-builder/composer.json
@@ -7,7 +7,6 @@
     ],
     "require": {
         "php": ">=8.0",
-        "ext-intl": "*",
         "nette/utils": "^3.2",
         "phar-io/version": "^3.2",
         "symfony/finder": "^6.0",
@@ -59,7 +58,6 @@
     "replace": {
         "symfony/polyfill-ctype": "*",
         "symfony/polyfill-intl-grapheme": "*",
-        "symfony/polyfill-intl-normalizer": "*",
         "symfony/polyfill-mbstring": "*"
     },
     "conflict": {

--- a/packages/monorepo-builder/scoper.php
+++ b/packages/monorepo-builder/scoper.php
@@ -50,6 +50,7 @@ return [
     ],
     'exclude-constants' => ['#^SYMFONY\_[\p{L}_]+$#'],
     'expose-classes' => [
+        'Normalizer',
         // part of public interface of configs.php
         'Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonSection',
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',


### PR DESCRIPTION
Ref https://github.com/symplify/symplify/pull/4385?notification_referrer_id=NT_kwDOAAcDgLE0MzIxMDQ5NzIzOjQ1OTY0OA#issuecomment-1235294375