### PR TITLE
Add reproduction for broken package ignore

### DIFF
--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -14,6 +14,9 @@ use Symplify\MonorepoBuilder\Release\ReleaseWorker\UpdateReplaceReleaseWorker;
 
 return static function (MBConfig $mbConfig): void {
     $mbConfig->packageDirectories([__DIR__ . '/packages']);
+    // This is a test to ensure monorepo-builder can ignore paths. It may not be in `test`
+    // because monorepo-builder ignores `test` folders outside of PHPUnit.
+    $mbConfig->packageDirectoriesExcludes([__DIR__ . '/packages/monorepo-builder/ignore']);
     $mbConfig->defaultBranch('main');
 
     $mbConfig->dataToRemove([

--- a/packages/monorepo-builder/ignore/composer.json
+++ b/packages/monorepo-builder/ignore/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "monorepo-builder/ignore-test",
+    "description": "This package should be ignored by the monorepo builder.",
+    "type": "library",
+    "require": {
+      "thisisaninvalidpackagethatshouldntgetmerged": "*"
+    }
+}


### PR DESCRIPTION
The monorepo-builder configuration should ignore the package at
`packages/monorepo-builder/ignore/composer.json` but the ExcludeFile
iterator will only match against a sub-path.

Running `composer merge` demonstrates that the invalid package contained
in the test composer.json ends up in our root composer.json which is
undesirable.

Similarly using a relative path as argument to
`packageDirectoriesExcludes` would not work either because the
validation in that function requires the file to exist and it won't be
able to properly resolve a relative file path.

Reproduces #4389