### PR TITLE
Add possibility to limit most recent tag resolver's scope to the recent branch

### DIFF
--- a/packages/monorepo-builder/config/config.php
+++ b/packages/monorepo-builder/config/config.php
@@ -25,6 +25,7 @@ return static function (MBConfig $mbConfig): void {
 
     $parameters->set(Option::IS_STAGE_REQUIRED, false);
     $parameters->set(Option::STAGES_TO_ALLOW_EXISTING_TAG, []);
+    $parameters->set(Option::LIMIT_RECENT_TAG_RESOLVING_SCOPE_TO_CURRENT_BRANCH, false);
 
     // for back compatibility, better switch to "main"
     $mbConfig->defaultBranch('master');

--- a/packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
+++ b/packages/monorepo-builder/packages/Release/Process/ProcessRunner.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-final class ProcessRunner
+final class ProcessRunner implements ProcessRunnerInterface
 {
     /**
      * Reasonable timeout to report hang off: 10 minutes

--- a/packages/monorepo-builder/packages/Release/Process/ProcessRunnerInterface.php
+++ b/packages/monorepo-builder/packages/Release/Process/ProcessRunnerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Release\Process;
+
+interface ProcessRunnerInterface
+{
+    /**
+     * @param string|string[] $commandLine
+     */
+    public function run(string|array $commandLine, ?string $cwd = null): string;
+}

--- a/packages/monorepo-builder/packages/Release/Version/VersionFactory.php
+++ b/packages/monorepo-builder/packages/Release/Version/VersionFactory.php
@@ -37,6 +37,7 @@ final class VersionFactory
     {
         // get current version
         $mostRecentVersionString = $this->tagResolver->resolve(getcwd());
+
         if ($mostRecentVersionString === null) {
             // the very first tag
             return new Version('v0.1.0');

--- a/packages/monorepo-builder/src/DependencyInjection/RecentTagResolverScopeCompilerPass.php
+++ b/packages/monorepo-builder/src/DependencyInjection/RecentTagResolverScopeCompilerPass.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
+use Symplify\MonorepoBuilder\Git\MostRecentTagForCurrentBranchResolver;
+use Symplify\MonorepoBuilder\Git\MostRecentTagResolver;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+
+final class RecentTagResolverScopeCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $isTagResolverScopeLimitedToCurrentBranch = $container->getParameter(Option::LIMIT_RECENT_TAG_RESOLVING_SCOPE_TO_CURRENT_BRANCH);
+
+        if (! $isTagResolverScopeLimitedToCurrentBranch) {
+            $container->setAlias(TagResolverInterface::class, MostRecentTagResolver::class)->setPublic(true);
+            return;
+        }
+
+        $container->setAlias(TagResolverInterface::class, MostRecentTagForCurrentBranchResolver::class)->setPublic(true);
+    }
+}

--- a/packages/monorepo-builder/src/Git/MostRecentTagForCurrentBranchResolver.php
+++ b/packages/monorepo-builder/src/Git/MostRecentTagForCurrentBranchResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Git;
+
+use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
+use Symplify\MonorepoBuilder\Release\Process\ProcessRunnerInterface;
+
+final class MostRecentTagForCurrentBranchResolver implements TagResolverInterface
+{
+    public const COMMAND = ['git', 'describe', '--tags', '--abbrev=0'];
+
+    public function __construct(
+        private ProcessRunnerInterface $processRunner,
+    ) {
+    }
+
+    public function resolve(string $gitDirectory): ?string
+    {
+        $newestTagForCurrentBranch = trim($this->processRunner->run(self::COMMAND, $gitDirectory));
+
+        if ("" === $newestTagForCurrentBranch) {
+            return null;
+        }
+
+        return $newestTagForCurrentBranch;
+    }
+}

--- a/packages/monorepo-builder/src/Kernel/MonorepoBuilderKernel.php
+++ b/packages/monorepo-builder/src/Kernel/MonorepoBuilderKernel.php
@@ -6,6 +6,7 @@ namespace Symplify\MonorepoBuilder\Kernel;
 
 use Psr\Container\ContainerInterface;
 use Symplify\ComposerJsonManipulator\ValueObject\ComposerJsonManipulatorConfig;
+use Symplify\MonorepoBuilder\DependencyInjection\RecentTagResolverScopeCompilerPass;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\PackageBuilder\DependencyInjection\CompilerPass\AutowireInterfacesCompilerPass;
 use Symplify\PackageBuilder\ValueObject\ConsoleColorDiffConfig;
@@ -22,8 +23,10 @@ final class MonorepoBuilderKernel extends AbstractSymplifyKernel
         $configFiles[] = ComposerJsonManipulatorConfig::FILE_PATH;
         $configFiles[] = ConsoleColorDiffConfig::FILE_PATH;
 
-        $autowireInterfacesCompilerPass = new AutowireInterfacesCompilerPass([ReleaseWorkerInterface::class]);
-        $compilerPasses = [$autowireInterfacesCompilerPass];
+        $compilerPasses = [
+            new AutowireInterfacesCompilerPass([ReleaseWorkerInterface::class]),
+            new RecentTagResolverScopeCompilerPass(),
+        ];
 
         return $this->create($configFiles, $compilerPasses, []);
     }

--- a/packages/monorepo-builder/src/ValueObject/Option.php
+++ b/packages/monorepo-builder/src/ValueObject/Option.php
@@ -120,4 +120,10 @@ final class Option
      * @var string
      */
     public const REMOVE_COMPLETELY = 'remove_completely';
+
+    /**
+     * @api
+     * @var string
+     */
+    public const LIMIT_RECENT_TAG_RESOLVING_SCOPE_TO_CURRENT_BRANCH = 'limit_recent_tag_resolving_scope_to_current_branch';
 }

--- a/packages/monorepo-builder/tests/DependencyInjection/RecentTagResolverScopeCompilerPassTest.php
+++ b/packages/monorepo-builder/tests/DependencyInjection/RecentTagResolverScopeCompilerPassTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
+use Symplify\MonorepoBuilder\Git\MostRecentTagForCurrentBranchResolver;
+use Symplify\MonorepoBuilder\Git\MostRecentTagResolver;
+use Symplify\MonorepoBuilder\Kernel\MonorepoBuilderKernel;
+use Symplify\PackageBuilder\Exception\MissingServiceException;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
+
+final class RecentTagResolverScopeCompilerPassTest extends AbstractKernelTestCase
+{
+    /**
+     * @throws ShouldNotHappenException
+     * @throws MissingServiceException
+     */
+    public function testReturnRecentTagResolverForCurrentBranchWhenLimitedScopeIsEnabled(): void
+    {
+        $this->bootKernelWithConfigs(
+            MonorepoBuilderKernel::class,
+            [
+                __DIR__ . '/config/enabled_limited_recent_tag_resolving_scope.php',
+            ]
+        );
+
+        self::assertInstanceOf(
+            MostRecentTagForCurrentBranchResolver::class,
+            $this->getService(TagResolverInterface::class)
+        );
+    }
+
+    /**
+     * @throws ShouldNotHappenException
+     * @throws MissingServiceException
+     */
+    public function testReturnDefaultRecentTagResolverWhenLimitedScopeIsDisabled(): void
+    {
+        $this->bootKernelWithConfigs(
+            MonorepoBuilderKernel::class,
+            [
+                __DIR__ . '/config/disabled_limited_recent_tag_resolving_scope.php',
+            ]
+        );
+
+        self::assertInstanceOf(
+            MostRecentTagResolver::class,
+            $this->getService(TagResolverInterface::class)
+        );
+    }
+
+    /**
+     * @throws ShouldNotHappenException
+     * @throws MissingServiceException
+     */
+    public function testReturnDefaultRecentTagResolverWhenLimitedScopeIsNotExplicitlyDefined(): void
+    {
+        $this->bootKernelWithConfigs(
+            MonorepoBuilderKernel::class,
+            [
+                __DIR__ . '/config/not_explicitly_defined_limited_recent_tag_resolving_scope.php',
+            ]
+        );
+
+        self::assertInstanceOf(
+            MostRecentTagResolver::class,
+            $this->getService(TagResolverInterface::class)
+        );
+    }
+}

--- a/packages/monorepo-builder/tests/DependencyInjection/config/disabled_limited_recent_tag_resolving_scope.php
+++ b/packages/monorepo-builder/tests/DependencyInjection/config/disabled_limited_recent_tag_resolving_scope.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::LIMIT_RECENT_TAG_RESOLVING_SCOPE_TO_CURRENT_BRANCH, false);
+};

--- a/packages/monorepo-builder/tests/DependencyInjection/config/enabled_limited_recent_tag_resolving_scope.php
+++ b/packages/monorepo-builder/tests/DependencyInjection/config/enabled_limited_recent_tag_resolving_scope.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::LIMIT_RECENT_TAG_RESOLVING_SCOPE_TO_CURRENT_BRANCH, true);
+};

--- a/packages/monorepo-builder/tests/DependencyInjection/config/not_explicitly_defined_limited_recent_tag_resolving_scope.php
+++ b/packages/monorepo-builder/tests/DependencyInjection/config/not_explicitly_defined_limited_recent_tag_resolving_scope.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\MonorepoBuilder\ValueObject\Option;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+};

--- a/packages/monorepo-builder/tests/Git/MostRecentTagForCurrentBranchResolverTest.php
+++ b/packages/monorepo-builder/tests/Git/MostRecentTagForCurrentBranchResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Git;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symplify\MonorepoBuilder\Git\MostRecentTagForCurrentBranchResolver;
+use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
+use Symplify\MonorepoBuilder\Release\Process\ProcessRunnerInterface;
+
+final class MostRecentTagForCurrentBranchResolverTest extends TestCase
+{
+    private ProcessRunner|MockObject $processRunner;
+
+    protected function setUp(): void
+    {
+        $this->processRunner = $this->createMock(ProcessRunnerInterface::class);
+    }
+
+    public function testReturnMostRecentTagStringWithoutNewlineCharacters(): void
+    {
+        $this->processRunner
+            ->method('run')
+            ->with(MostRecentTagForCurrentBranchResolver::COMMAND, 'git-directory')
+            ->willReturn("\r1.0.0\r\n")
+        ;
+
+        $mostRecentTagForCurrentBranchResolver = new MostRecentTagForCurrentBranchResolver($this->processRunner);
+
+        $result = $mostRecentTagForCurrentBranchResolver->resolve('git-directory');
+
+        self::assertSame('1.0.0', $result);
+    }
+
+    public function testReturnZeroWhenEmptyStringIsReturnedFromProcessRun(): void
+    {
+        $this->processRunner
+            ->method('run')
+            ->with(MostRecentTagForCurrentBranchResolver::COMMAND, 'git-directory')
+            ->willReturn('')
+        ;
+
+        $mostRecentTagForCurrentBranchResolver = new MostRecentTagForCurrentBranchResolver($this->processRunner);
+
+        $result = $mostRecentTagForCurrentBranchResolver->resolve('git-directory');
+
+        self::assertNull($result);
+    }
+
+    private function createMostRecentTagForCurrentBranchResolver(): MostRecentTagForCurrentBranchResolver
+    {
+        return new MostRecentTagForCurrentBranchResolver($this->processRunner);
+    }
+}


### PR DESCRIPTION
Hello 👋🏼!

I'm actively working to be able to support multiple branches (so you can support e.g. both `1.x` and `2.x` version of your software) using `monorepo-builder` and [monorepo-split-github-action](https://github.com/symplify/monorepo-split-github-action).

This is a first PR of X (as I don't know how many PRs are required to achieve my goal 😅).

This PR provides the possibility to limit resolving the most recent tag to the current branch. By default we're using `git tag -l --sort=committerdate` command which returns the most recent tag from the whole repository. I've added `limit_recent_tag_resolving_scope_to_current_branch` parameter which aliases `TagResolverInterface` to the new `MostRecentTagForCurrentBranchResolver` service using `git describe --tags --abbrev=0` command which limits the scope of tags to the most recent on the current branch. Of course, by default this option is set to false to keep backward compatibility.

Here are the results:

1. Current (and the default) behavior
![CleanShot 2022-09-08 at 20 57 31](https://user-images.githubusercontent.com/80641364/189203779-f9b7d7aa-f30b-4421-9c1e-61d9d8ebe75e.png)

2. The behavior after setting `limit_recent_tag_resolving_scope_to_current_branch` to true
![CleanShot 2022-09-08 at 20 58 11](https://user-images.githubusercontent.com/80641364/189203857-3b12ae7c-6bc8-475b-bbb2-d2c571421fea.png)

On the second screen we can see I'm on main branch which has the latest tag `2.0.2` and after checking out to `5.x` branch I get `5.0.0`. Previously on every branch I was getting `5.0.0` :).

