### PR TITLE
[ECS] Loop SkipVotter until verified skipped on Skipper

### DIFF
--- a/packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/SkipperTest.php
+++ b/packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/SkipperTest.php
@@ -41,6 +41,7 @@ final class SkipperTest extends AbstractKernelTestCase
     {
         yield [__DIR__ . '/Fixture/SomeRandom/file.txt', false];
         yield [__DIR__ . '/Fixture/SomeSkipped/any.txt', true];
+        yield ['packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/Fixture/SomeSkipped/any.txt', true];
     }
 
     /**

--- a/packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/SkipperTest.php
+++ b/packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/SkipperTest.php
@@ -41,7 +41,15 @@ final class SkipperTest extends AbstractKernelTestCase
     {
         yield [__DIR__ . '/Fixture/SomeRandom/file.txt', false];
         yield [__DIR__ . '/Fixture/SomeSkipped/any.txt', true];
-        yield ['packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/Fixture/SomeSkipped/any.txt', true];
+
+        $basenameCwd = basename(getcwd());
+        if ($basenameCwd === 'easy-coding-standard') {
+            // split test inside packages/easy-coding-standard
+            yield ['packages-tests/Skipper/Skipper/Skipper/Fixture/SomeSkipped/any.txt', true];
+        } else {
+            // from root symplify
+            yield ['packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/Fixture/SomeSkipped/any.txt', true];
+        }
     }
 
     /**

--- a/packages/easy-coding-standard/packages/Skipper/Skipper/Skipper.php
+++ b/packages/easy-coding-standard/packages/Skipper/Skipper/Skipper.php
@@ -44,7 +44,11 @@ final class Skipper
                 continue;
             }
 
-            return $skipVoter->shouldSkip($element, $smartFileInfo);
+            if (! $skipVoter->shouldSkip($element, $smartFileInfo)) {
+                continue;
+            }
+
+            return true;
         }
 
         return false;

--- a/packages/symplify-kernel/src/ValueObject/KernelBootAndApplicationRun.php
+++ b/packages/symplify-kernel/src/ValueObject/KernelBootAndApplicationRun.php
@@ -73,7 +73,7 @@ final class KernelBootAndApplicationRun
         $inputDefinition = $application->getDefinition();
 
         $options = $inputDefinition->getOptions();
-        $options = array_filter($options, static fn ($option) => $option->getName() !== 'no-interaction');
+        $options = array_filter($options, static fn ($option): bool => $option->getName() !== 'no-interaction');
 
         $inputDefinition->setOptions($options);
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -439,6 +439,7 @@ parameters:
                 - packages/monorepo-builder/src/ValueObject/File.php
                 - packages/easy-ci/packages/Testing/Command/DetectUnitTestsCommand.php
                 - packages/easy-ci/packages-tests/Psr4/ValueObjectFactory/Psr4NamespaceToPathFactory/Psr4NamespaceToPathFactoryTest.php
+                - packages/easy-coding-standard/packages-tests/Skipper/Skipper/Skipper/SkipperTest.php
 
         - '#Parameter \#(.*?) \$(.*?) of method (.*?) expects array<class\-string>, array<string> given#'
 


### PR DESCRIPTION
Like in rector-src's Loop SkipVotter classes hande https://github.com/rectorphp/rector-src/pull/2921/files#diff-3ae415e78c60375cb710124ff66aaacd50a22e34ca69287cb3db14931de3c69c , the loop should not be stopped until it verified that it skipped, as direct return may return false early.