### PR TITLE
Fix typo in README

### DIFF
--- a/packages/easy-coding-standard/README.md
+++ b/packages/easy-coding-standard/README.md
@@ -51,7 +51,7 @@ return static function (ECSConfig $ecsConfig): void {
 
 #### Full Sets before Standalone Rules
 
-It is highly recommended to imports sets (A) first, then add standalone rules (B).
+It is highly recommended to import sets (A) first, then add standalone rules (B).
 
 The reason for this is that some settings are configured in the full sets too, and will therefore overwrite your standalone rules, if not configured first.
 
@@ -114,7 +114,7 @@ return static function (ECSConfig $ecsConfig): void {
         'Cognitive complexity for method "addAction" is 13 but has to be less than or equal to 8.',
     ]);
 
-    // scan other file extendsions; [default: [php]]
+    // scan other file extensions; [default: [php]]
     $ecsConfig->fileExtensions(['php', 'phpt']);
 
     // configure cache paths & namespace - useful for Gitlab CI caching, where getcwd() produces always different path


### PR DESCRIPTION
I was reading the docs/readme and I couldn't resist creating a PR fixing `extendsions`. 

>**Note**: And after that I couldn't resist putting this meme 👇🏼  🤣 

<img width="493" alt="Screenshot 2022-09-25 at 16 56 28" src="https://user-images.githubusercontent.com/5256287/192150191-82d8baeb-5a13-4eb8-a074-af41abd0e8fe.png">
