### PR TITLE
[PHPStanRules] Skip MockObject on NoMixedMethodCallerRule

### DIFF
--- a/packages/phpstan-rules/src/Rules/Explicit/NoMixedMethodCallerRule.php
+++ b/packages/phpstan-rules/src/Rules/Explicit/NoMixedMethodCallerRule.php
@@ -48,6 +48,10 @@ final class NoMixedMethodCallerRule implements Rule, DocumentedRuleInterface
             return [];
         }
 
+        if ($callerType instanceof \PHPStan\Type\ErrorType) {
+            return [];
+        }
+
         $printedMethodCall = $this->printerStandard->prettyPrintExpr($node->var);
 
         return [sprintf(self::ERROR_MESSAGE, $printedMethodCall)];

--- a/packages/phpstan-rules/src/Rules/Explicit/NoMixedMethodCallerRule.php
+++ b/packages/phpstan-rules/src/Rules/Explicit/NoMixedMethodCallerRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\PHPStanRules\Rules\Explicit;
 
+use PHPStan\Type\ErrorType;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\PrettyPrinter\Standard;
@@ -48,7 +49,7 @@ final class NoMixedMethodCallerRule implements Rule, DocumentedRuleInterface
             return [];
         }
 
-        if ($callerType instanceof \PHPStan\Type\ErrorType) {
+        if ($callerType instanceof ErrorType) {
             return [];
         }
 

--- a/packages/phpstan-rules/tests/Rules/Explicit/NoMixedMethodCallerRule/Fixture/SkipMockObject.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/NoMixedMethodCallerRule/Fixture/SkipMockObject.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\PHPStanRules\Tests\Rules\Explicit\NoMixedMethodCallerRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipMockObject extends TestCase
+{
+    public function test()
+    {
+        $mock = $this->createMock(MagicMethodName::class);
+
+        $mock
+            ->method('run')
+            ->willReturn(true);
+    }
+}

--- a/packages/phpstan-rules/tests/Rules/Explicit/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/Explicit/NoMixedMethodCallerRule/NoMixedMethodCallerRuleTest.php
@@ -26,6 +26,7 @@ final class NoMixedMethodCallerRuleTest extends RuleTestCase
     public function provideData(): Iterator
     {
         yield [__DIR__ . '/Fixture/SkipKnownCallerType.php', []];
+        yield [__DIR__ . '/Fixture/SkipMockObject.php', []];
 
         $errorMessage = sprintf(NoMixedMethodCallerRule::ERROR_MESSAGE, '$someType');
         yield [__DIR__ . '/Fixture/MagicMethodName.php', [[$errorMessage, 11]]];


### PR DESCRIPTION
Given the following code on test:

```php
$mock = $this->createMock(MagicMethodName::class);
```

It seems it detected as `PHPStan\Type\ErrorType`, it should be skipped.