### PR TITLE
Fix parallel processing on Windows

### DIFF
--- a/packages/easy-parallel/src/ValueObject/ParallelProcess.php
+++ b/packages/easy-parallel/src/ValueObject/ParallelProcess.php
@@ -116,8 +116,6 @@ final class ParallelProcess
         }
 
         $this->encoder->end();
-
-        $this->process->terminate();
     }
 
     public function bindConnection(Decoder $decoder, Encoder $encoder): void


### PR DESCRIPTION
Windows don't like processes being terminated like that - it leads to child process error (https://github.com/phpstan/phpstan-src/actions/runs/3144712914/jobs/5111071107).

Fortunately this line isn't needed at all. I fixed a similar problem in PHPStan a few years ago (https://github.com/phpstan/phpstan-src/commit/54eb9ce142a546f7ee3ccd1bd88c01368ab33941).

I tested it using a Composer patch in PHPStan and it works for Rector too (https://github.com/phpstan/phpstan-src/commit/37c643cd4d4c65837f1d42252b8bbc5f5d9c9a71).