### PR TITLE
add example with constant as key

### DIFF
--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/workflow-constant.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/workflow-constant.yaml
@@ -1,0 +1,14 @@
+transitions:
+    !php/const App\Entity\Plant::TRANSITION_PLANT:
+        from: seed
+        to:   planted
+-----
+<?php
+
+    declare(strict_types=1);
+
+    use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('transitions', [\App\Entity\Plant::class => ['from' => 'seed', 'to' => 'planted']]);
+};


### PR DESCRIPTION
This is a shorter example.  I think the issue is using a constant as the key, or maybe it's using a class constant rather than a PHP constant.  Likely this test can be merged with constant.yaml.

Addresses #4436