### PR TITLE
[AutowireArrayParameter] Fix @noRector tag usage on AutowireArrayParameterCompilerPass

### DIFF
--- a/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
+++ b/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
@@ -33,7 +33,8 @@ final class AutowireArrayParameterCompilerPass implements CompilerPassInterface
      * Classes that create circular dependencies
      *
      * @var string[]
-     * @noRector
+     * @noRector \Rector\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector
+     * @noRector \Rector\Php55\Rector\String_\StringClassNameToClassConstantRector
      */
     private array $excludedFatalClasses = [
         'Symfony\Component\Form\FormExtensionInterface',


### PR DESCRIPTION
The `@noRector` only make it can't run any Rector rules, see downgrade Rector error on https://github.com/rectorphp/rector-src/actions/runs/3333691682/jobs/5515884678#step:14:69

```bash

Parse error: rector-prefixed-downgraded/vendor/symplify/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php:35
    33|      * @noRector
    34|      */
  > 35|     private array $excludedFatalClasses = ['RectorPrefix202210\\Symfony\\Component\\Form\\FormExtensionInterface', 'RectorPrefix202210\\Symfony\\Component\\Asset\\PackageInterface', 'RectorPrefix202210\\Symfony\\Component\\Config\\Loader\\LoaderInterface', 'RectorPrefix202210\\Symfony\\Component\\VarDumper\\Dumper\\ContextProvider\\ContextProviderInterface', 'RectorPrefix202210\\EasyCorp\\Bundle\\EasyAdminBundle\\Form\\Type\\Configurator\\TypeConfiguratorInterface', 'RectorPrefix202210\\Sonata\\CoreBundle\\Model\\Adapter\\AdapterInterface', 'RectorPrefix202210\\Sonata\\Doctrine\\Adapter\\AdapterChain', 'RectorPrefix202210\\Sonata\\Twig\\Extension\\TemplateExtension', 'RectorPrefix202210\\Symfony\\Component\\HttpKernel\\KernelInterface'];
    36|     /**
    37|      * @var \Symplify\AutowireArrayParameter\DependencyInjection\DefinitionFinder
Unexpected 'array' (T_ARRAY), expecting function (T_FUNCTION) or const (T_CONST) in rector-prefixed-downgraded/vendor/symplify/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php on line 35
```

This PR update to define `@noRector` with specific rules that should not be applied only:

```php
     * @noRector \Rector\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector
     * @noRector \Rector\Php55\Rector\String_\StringClassNameToClassConstantRector
```