### PR TITLE
Adds rulesWithConfiguration in ECSConfig.

### DIFF
--- a/packages/easy-coding-standard/src/Config/ECSConfig.php
+++ b/packages/easy-coding-standard/src/Config/ECSConfig.php
@@ -102,6 +102,18 @@ final class ECSConfig extends ContainerConfigurator
     }
 
     /**
+     * @param array<class-string<Sniff|FixerInterface>, mixed[]> $rulesWithConfiguration
+     */
+    public function rulesWithConfiguration(array $rulesWithConfiguration): void
+    {
+        Assert::allIsArray($rulesWithConfiguration);
+
+        foreach ($rulesWithConfiguration as $checkerClass => $configuration) {
+            $this->ruleWithConfiguration($checkerClass, $configuration);
+        }
+    }
+
+    /**
      * @param Option::INDENTATION_* $indentation
      */
     public function indentation(string $indentation): void


### PR DESCRIPTION
I would love to do that:

```php
return static function (ECSConfig $ecsConfig): void {
    $ecsConfig->rulesWithConfiguration([
        AlignMultilineCommentFixer::class => [
            'comment_type' => 'phpdocs_like',
        ],
        ArraySyntaxFixer::class => [
            'syntax' => 'short',
        ],
    ]);
}
```