### PR TITLE
Sea-Level collectors: don't collect empty data

### DIFF
--- a/packages/phpstan-rules/src/Collector/FunctionLike/ParamTypeSeaLevelCollector.php
+++ b/packages/phpstan-rules/src/Collector/FunctionLike/ParamTypeSeaLevelCollector.php
@@ -32,7 +32,7 @@ final class ParamTypeSeaLevelCollector implements Collector
      * @param FunctionLike $node
      * @return array{int, int, string}
      */
-    public function processNode(Node $node, Scope $scope): array
+    public function processNode(Node $node, Scope $scope): ?array
     {
         if ($this->shouldSkipFunctionLike($node)) {
             return null;

--- a/packages/phpstan-rules/src/Collector/FunctionLike/ParamTypeSeaLevelCollector.php
+++ b/packages/phpstan-rules/src/Collector/FunctionLike/ParamTypeSeaLevelCollector.php
@@ -35,7 +35,7 @@ final class ParamTypeSeaLevelCollector implements Collector
     public function processNode(Node $node, Scope $scope): array
     {
         if ($this->shouldSkipFunctionLike($node)) {
-            return [0, 0, ''];
+            return null;
         }
 
         $paramCount = count($node->getParams());

--- a/packages/phpstan-rules/src/Collector/FunctionLike/ParamTypeSeaLevelCollector.php
+++ b/packages/phpstan-rules/src/Collector/FunctionLike/ParamTypeSeaLevelCollector.php
@@ -30,7 +30,7 @@ final class ParamTypeSeaLevelCollector implements Collector
 
     /**
      * @param FunctionLike $node
-     * @return array{int, int, string}
+     * @return array{int, int, string}|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {

--- a/packages/phpstan-rules/src/Collector/FunctionLike/ReturnTypeSeaLevelCollector.php
+++ b/packages/phpstan-rules/src/Collector/FunctionLike/ReturnTypeSeaLevelCollector.php
@@ -29,7 +29,7 @@ final class ReturnTypeSeaLevelCollector implements Collector
 
     /**
      * @param ClassMethod $node
-     * @return array{int, int, string}
+     * @return array{int, int, string}|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {

--- a/packages/phpstan-rules/src/Collector/FunctionLike/ReturnTypeSeaLevelCollector.php
+++ b/packages/phpstan-rules/src/Collector/FunctionLike/ReturnTypeSeaLevelCollector.php
@@ -31,11 +31,11 @@ final class ReturnTypeSeaLevelCollector implements Collector
      * @param ClassMethod $node
      * @return array{int, int, string}
      */
-    public function processNode(Node $node, Scope $scope): array
+    public function processNode(Node $node, Scope $scope): ?array
     {
         // skip magic
         if ($node->isMagic()) {
-            return [0, 0, ''];
+            return null;
         }
 
         if ($node->returnType instanceof Node) {


### PR DESCRIPTION
I wondered, why the collectors return empty arrays. when debugging I can see the phpstan workers shuffling arround huge arrays, which mostly contain of empty data.