### PR TITLE
[PHPStan] Fix PHPStan notice IntersectionType inside UnionType to string

### DIFF
--- a/packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php
+++ b/packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php
@@ -6,6 +6,7 @@ namespace Symplify\PHPStanRules\Printer;
 
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType as NodeIntersectionType;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\UnionType;
@@ -98,6 +99,14 @@ final class CollectorMetadataPrinter
         $typeNames = [];
 
         foreach ($unionType->types as $type) {
+            if ($type instanceof NodeIntersectionType) {
+                foreach ($type->types as $intersectionType) {
+                    $typeNames[] = (string) $intersectionType;
+                }
+
+                continue;
+            }
+
             $typeNames[] = (string) $type;
         }
 


### PR DESCRIPTION
Fix the following PHPStan notice:

```bash
Note: Using configuration file /Users/samsonasik/www/symplify/phpstan.neon.
 1211/1211 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  packages/phpstan-rules/src/Printer/CollectorMetadataPrinter.php:108
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  - '#Cannot cast PhpParser\\Node\\Identifier\|PhpParser\\Node\\IntersectionType\|PhpParser\\Node\\Name to string#'
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


                                                                                                                        
 [ERROR] Found 1 errors                                                                                                                                                                                                                  
```

Ref https://github.com/symplify/symplify/actions/runs/3457568970/jobs/5771289181#step:5:20