### PR TITLE
[ECS] Update array comma rule

### DIFF
--- a/packages/easy-coding-standard/config/set/common/array.php
+++ b/packages/easy-coding-standard/config/set/common/array.php
@@ -25,6 +25,10 @@ return static function (ECSConfig $ecsConfig): void {
     ]);
 
     // commas
+    $ecsConfig->ruleWithConfiguration(\PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer::class, [
+        'elements' => ['arguments', 'array_destructuring', 'array', 'group_import'],
+    ]);
+
     $ecsConfig->ruleWithConfiguration(TrailingCommaInMultilineFixer::class, [
         'elements' => [TrailingCommaInMultilineFixer::ELEMENTS_ARRAYS],
     ]);

--- a/packages/easy-coding-standard/config/set/common/array.php
+++ b/packages/easy-coding-standard/config/set/common/array.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
@@ -25,7 +26,7 @@ return static function (ECSConfig $ecsConfig): void {
     ]);
 
     // commas
-    $ecsConfig->ruleWithConfiguration(\PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer::class, [
+    $ecsConfig->ruleWithConfiguration(NoTrailingCommaInSinglelineFixer::class, [
         'elements' => ['arguments', 'array_destructuring', 'array', 'group_import'],
     ]);
 

--- a/packages/easy-coding-standard/config/set/common/array.php
+++ b/packages/easy-coding-standard/config/set/common/array.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
-use PhpCsFixer\Fixer\ArrayNotation\NoTrailingCommaInSinglelineArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
@@ -23,7 +22,6 @@ return static function (ECSConfig $ecsConfig): void {
         WhitespaceAfterCommaInArrayFixer::class,
         ArrayListItemNewlineFixer::class,
         StandaloneLineInMultilineArrayFixer::class,
-        NoTrailingCommaInSinglelineArrayFixer::class,
     ]);
 
     // commas

--- a/packages/php-config-printer/src/CaseConverter/ImportCaseConverter.php
+++ b/packages/php-config-printer/src/CaseConverter/ImportCaseConverter.php
@@ -134,9 +134,9 @@ final class ImportCaseConverter implements CaseConverterInterface
 
     private function resolveExpr(mixed $value): Expr
     {
-        $normalizedValue = $this->processNormalizedValue($value);
-        if ($normalizedValue instanceof Expr) {
-            return $normalizedValue;
+        $expr = $this->processNormalizedValue($value);
+        if ($expr instanceof Expr) {
+            return $expr;
         }
 
         if ($value === 'not_found') {
@@ -148,13 +148,13 @@ final class ImportCaseConverter implements CaseConverterInterface
             return new ClassConstFetch(new FullyQualified($className), $constantName);
         }
 
-        if (is_string($value) && \str_starts_with($value, '@') !== \false) {
+        if (is_string($value) && \str_starts_with($value, '@')) {
             return new String_($value);
         }
 
         $value = $this->replaceImportedFileSuffix($value);
 
-        if (is_string($value) && \str_starts_with($value, '%') !== \false) {
+        if (is_string($value) && \str_starts_with($value, '%')) {
             return new String_($value);
         }
 

--- a/packages/phpstan-extensions/tests/ErrorFormatter/SymplifyErrorFormatterTest.php
+++ b/packages/phpstan-extensions/tests/ErrorFormatter/SymplifyErrorFormatterTest.php
@@ -26,7 +26,7 @@ final class SymplifyErrorFormatterTest extends ErrorFormatterTestCase
         $symplifyErrorFormatter = self::getContainer()->getByType(SymplifyErrorFormatter::class);
 
         $analysisResult = $this->getAnalysisResult($numFileErrors, $numGenericErrors);
-        $resultCode = $symplifyErrorFormatter->formatErrors($analysisResult, $this->getOutput(),);
+        $resultCode = $symplifyErrorFormatter->formatErrors($analysisResult, $this->getOutput());
 
         $this->assertSame($expectedExitCode, $resultCode);
 

--- a/packages/phpstan-rules/tests/Rules/Complexity/NoAbstractRule/NoAbstractRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/Complexity/NoAbstractRule/NoAbstractRuleTest.php
@@ -42,6 +42,6 @@ final class NoAbstractRuleTest extends RuleTestCase
 
     protected function getRule(): Rule
     {
-        return self::getContainer()->getByType(NoAbstractRule::class,);
+        return self::getContainer()->getByType(NoAbstractRule::class);
     }
 }


### PR DESCRIPTION
- remove deprecated rule
- make use of new trialing comma args rules
