### PR TITLE
Improve ConfigLoader::PHP_CONST_REGEX

### DIFF
--- a/packages/config-transformer/src/ConfigLoader.php
+++ b/packages/config-transformer/src/ConfigLoader.php
@@ -28,10 +28,10 @@ use Symplify\SmartFileSystem\SmartFileSystem;
 final class ConfigLoader
 {
     /**
-     * @see https://regex101.com/r/4Uanps/2
+     * @see https://regex101.com/r/4Uanps/4
      * @var string
      */
-    private const PHP_CONST_REGEX = '#!php/const[:\s]\s*(.*)(\s*)#';
+    private const PHP_CONST_REGEX = '#!php/const:?\s*([a-zA-Z0-9_\\\\]+(::[a-zA-Z0-9_]+)?)+(:\s*(.*))?#';
 
     /**
      * @see https://regex101.com/r/spi4ir/1
@@ -68,7 +68,7 @@ final class ConfigLoader
             $content = Strings::replace(
                 $content,
                 self::PHP_CONST_REGEX,
-                static fn ($match): string => '"%const(' . str_replace('\\', '\\\\', $match[1]) . ')%"' . $match[2]
+                static fn ($match): string => '"%const(' . str_replace('\\', '\\\\', $match[1]) . ')%"' . ($match[3] ?? '')
             );
             if ($content !== $smartFileInfo->getContents()) {
                 $fileRealPath = sys_get_temp_dir() . '/__symplify_config_tranformer_clean_yaml/' . $smartFileInfo->getFilename();

--- a/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/class_constant.yaml
+++ b/packages/config-transformer/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/class_constant.yaml
@@ -1,6 +1,9 @@
 parameters:
     class_constant: !php/const Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::TEST
+    class_constant_with_numbers: !php/const Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::TEST123
+    class_constant_legacy_colon: !php/const:Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::TEST
     class: !php/const Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::class
+    class_legacy_colon: !php/const:Symplify\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::class
     unexisting_constant: !php/const SomeClass::Constant
 -----
 <?php
@@ -15,7 +18,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $parameters->set('class_constant', YamlToPhpTest::TEST);
 
+    $parameters->set('class_constant_with_numbers', YamlToPhpTest::TEST123);
+
+    $parameters->set('class_constant_legacy_colon', YamlToPhpTest::TEST);
+
     $parameters->set('class', YamlToPhpTest::class);
+
+    $parameters->set('class_legacy_colon', YamlToPhpTest::class);
 
     $parameters->set('unexisting_constant', SomeClass::Constant);
 };


### PR DESCRIPTION
Continuation from #4441 🙂 

Differences between [proposed regex](https://github.com/symplify/symplify/pull/4441#issuecomment-1325862399) and actual change in the PR:
- added support for numbers in constants
- instead of `\\` in first group I had to do `\\\\` because somehow tests were failing: class' FQCN was not properly caught and was causing syntax issues, e.g.:
  > Symfony\Component\Yaml\Exception\ParseException: Unexpected characters near "\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::TEST" at line 2 (near "class_constant: "%const(Symplify)%"\ConfigTransformer\Tests\Converter\ConfigFormatConverter\YamlToPhp\YamlToPhpTest::TEST").

Regex URL was updated, but currently it does not contain `\\\\` change (works without it).