### PR TITLE
Move @noRector usage to rectorConfig->skip()

### DIFF
--- a/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
+++ b/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
@@ -33,8 +33,6 @@ final class AutowireArrayParameterCompilerPass implements CompilerPassInterface
      * Classes that create circular dependencies
      *
      * @var string[]
-     * @noRector \Rector\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector
-     * @noRector \Rector\Php55\Rector\String_\StringClassNameToClassConstantRector
      */
     private array $excludedFatalClasses = [
         'Symfony\Component\Form\FormExtensionInterface',

--- a/packages/easy-testing/src/ValueObject/ExpectedAndOutputFileInfoPair.php
+++ b/packages/easy-testing/src/ValueObject/ExpectedAndOutputFileInfoPair.php
@@ -15,17 +15,11 @@ final class ExpectedAndOutputFileInfoPair
     ) {
     }
 
-    /**
-     * @noRector \Rector\Privatization\Rector\ClassMethod\PrivatizeLocalOnlyMethodRector
-     */
     public function getExpectedFileContent(): string
     {
         return $this->expectedFileInfo->getContents();
     }
 
-    /**
-     * @noRector \Rector\Privatization\Rector\ClassMethod\PrivatizeLocalOnlyMethodRector
-     */
     public function getOutputFileContent(): string
     {
         if (! $this->outputFileInfo instanceof SmartFileInfo) {
@@ -35,9 +29,6 @@ final class ExpectedAndOutputFileInfoPair
         return $this->outputFileInfo->getContents();
     }
 
-    /**
-     * @noRector \Rector\Privatization\Rector\ClassMethod\PrivatizeLocalOnlyMethodRector
-     */
     public function doesOutputFileExist(): bool
     {
         return $this->outputFileInfo !== null;

--- a/packages/rule-doc-generator/src/RuleCodeSamplePrinter/ECSRuleCodeSamplePrinter.php
+++ b/packages/rule-doc-generator/src/RuleCodeSamplePrinter/ECSRuleCodeSamplePrinter.php
@@ -24,7 +24,6 @@ final class ECSRuleCodeSamplePrinter implements RuleCodeSamplePrinterInterface
 
     public function isMatch(string $class): bool
     {
-        /** @noRector */
         if (is_a($class, 'PHP_CodeSniffer\Sniffs\Sniff', true)) {
             return true;
         }

--- a/packages/rule-doc-generator/src/RuleCodeSamplePrinter/PHPStanRuleCodeSamplePrinter.php
+++ b/packages/rule-doc-generator/src/RuleCodeSamplePrinter/PHPStanRuleCodeSamplePrinter.php
@@ -23,7 +23,6 @@ final class PHPStanRuleCodeSamplePrinter implements RuleCodeSamplePrinterInterfa
 
     public function isMatch(string $class): bool
     {
-        /** @noRector */
         return is_a($class, 'PHPStan\Rules\Rule', true);
     }
 

--- a/packages/rule-doc-generator/src/RuleCodeSamplePrinter/RectorRuleCodeSamplePrinter.php
+++ b/packages/rule-doc-generator/src/RuleCodeSamplePrinter/RectorRuleCodeSamplePrinter.php
@@ -26,7 +26,6 @@ final class RectorRuleCodeSamplePrinter implements RuleCodeSamplePrinterInterfac
 
     public function isMatch(string $class): bool
     {
-        /** @noRector */
         return is_a($class, 'Rector\Core\Contract\Rector\RectorInterface', true);
     }
 

--- a/rector.php
+++ b/rector.php
@@ -82,9 +82,5 @@ return static function (RectorConfig $rectorConfig): void {
         \Rector\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector::class => [
             __DIR__ . '/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php',
         ],
-
-        \Rector\Privatization\Rector\ClassMethod\PrivatizeLocalOnlyMethodRector::class => [
-            __DIR__ . '/packages/easy-testing/src/ValueObject/ExpectedAndOutputFileInfoPair.php',
-        ],
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -69,13 +69,22 @@ return static function (RectorConfig $rectorConfig): void {
             __DIR__ . '/packages/php-config-printer/src/RoutingCaseConverter/ImportRoutingCaseConverter.php',
         ],
 
-        // keep classes utouched, to avoid prefixing and renames
+        // keep classes untouched, to avoid prefixing and renames
         StringClassNameToClassConstantRector::class => [
             __DIR__ . '/packages/phpstan-rules/src/NodeAnalyzer/MethodCall/AllowedChainCallSkipper.php',
+            __DIR__ . '/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php',
         ],
 
         \Rector\Naming\Rector\Foreach_\RenameForeachValueVariableToMatchExprVariableRector::class => [
             __DIR__ . '/packages/phpstan-rules/src/Rules/Domain/ForbiddenAlwaysSetterCallRule.php',
+        ],
+
+        \Rector\Privatization\Rector\Property\ChangeReadOnlyPropertyWithDefaultValueToConstantRector::class => [
+            __DIR__ . '/packages/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php',
+        ],
+
+        \Rector\Privatization\Rector\ClassMethod\PrivatizeLocalOnlyMethodRector::class => [
+            __DIR__ . '/packages/easy-testing/src/ValueObject/ExpectedAndOutputFileInfoPair.php',
         ],
     ]);
 };


### PR DESCRIPTION
The `@noRector` removal on rector-src PR:

- https://github.com/rectorphp/rector-src/pull/3148

cause downgrade build error, ref https://github.com/rectorphp/rector-src/actions/runs/3609550282/jobs/6082808356#step:10:22

This PR move to skip to make downgrade build on rector-src work.

Note: it require release the symplify components as rector-src require tagged versions of symplify components.