### PR TITLE
Down all packages to use symfony-dependency-injection 6.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/expression-language": "^6.2",
         "symfony/filesystem": "^6.2",
         "symfony/finder": "^6.2",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "phpunit/phpunit": "^9.5.26",
         "psr/log": "^1.1.4",
         "rector/rector": "dev-main",
-        "symfony/framework-bundle": "^6.2",
+        "symfony/framework-bundle": "^6.1",
         "symfony/twig-bundle": "^6.2",
         "tracy/tracy": "^2.9.4"
     },

--- a/packages/autowire-array-parameter/composer.json
+++ b/packages/autowire-array-parameter/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=8.1",
         "nette/utils": "^3.2",
-        "symfony/dependency-injection": "^6.2"
+        "symfony/dependency-injection": "6.1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.26",

--- a/packages/coding-standard/composer.json
+++ b/packages/coding-standard/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "symplify/symplify-kernel": "^11.2",
         "symplify/smart-file-system": "^11.2",
-        "symfony/framework-bundle": "^6.2",
+        "symfony/framework-bundle": "^6.1",
         "symplify/easy-coding-standard": "^11.2",
         "phpunit/phpunit": "^9.5.26",
         "symplify/rule-doc-generator": "^11.2",

--- a/packages/composer-json-manipulator/composer.json
+++ b/packages/composer-json-manipulator/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.1",
         "nette/utils": "^3.2",
         "symfony/config": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/filesystem": "^6.2",
         "symplify/package-builder": "^11.2",
         "symplify/symplify-kernel": "^11.2",

--- a/packages/config-transformer/composer.json
+++ b/packages/config-transformer/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "cweagans/composer-patches": "^1.7",
         "phpunit/phpunit": "^9.5.26",
-        "symfony/framework-bundle": "^6.2",
+        "symfony/framework-bundle": "^6.1",
         "symplify/easy-testing": "^11.2"
     },
     "autoload": {

--- a/packages/config-transformer/composer.json
+++ b/packages/config-transformer/composer.json
@@ -11,7 +11,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "^4.15.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/expression-language": "^6.2",
         "symfony/yaml": "^6.2",
         "symplify/php-config-printer": "^11.2",

--- a/packages/easy-ci/composer.json
+++ b/packages/easy-ci/composer.json
@@ -12,7 +12,7 @@
         "nette/utils": "^3.2",
         "nikic/php-parser": "^4.15.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symplify/package-builder": "^11.2",
         "symplify/smart-file-system": "^11.2",
         "symplify/symplify-kernel": "^11.2"

--- a/packages/easy-coding-standard/composer.json
+++ b/packages/easy-coding-standard/composer.json
@@ -13,7 +13,7 @@
         "squizlabs/php_codesniffer": "^3.7.1",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/finder": "^6.2",
         "symplify/autowire-array-parameter": "^11.2",
         "symplify/coding-standard": "^11.2",

--- a/packages/easy-testing/composer.json
+++ b/packages/easy-testing/composer.json
@@ -11,7 +11,7 @@
         "nette/utils": "^3.2",
         "symfony/finder": "^6.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symplify/package-builder": "^11.2",
         "symplify/smart-file-system": "^11.2",
         "symplify/symplify-kernel": "^11.2"

--- a/packages/monorepo-builder/composer.json
+++ b/packages/monorepo-builder/composer.json
@@ -10,7 +10,7 @@
         "nette/utils": "^3.2",
         "phar-io/version": "^3.2",
         "symfony/finder": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/console": "^6.2",
         "symfony/process": "^6.2",
         "symplify/package-builder": "^11.2",

--- a/packages/package-builder/composer.json
+++ b/packages/package-builder/composer.json
@@ -8,7 +8,7 @@
         "sebastian/diff": "^4.0|^5.0",
         "symfony/config": "^6.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/finder": "^6.2"
     },
     "require-dev": {

--- a/packages/phpstan-rules/composer.json
+++ b/packages/phpstan-rules/composer.json
@@ -18,7 +18,7 @@
         "symplify/rule-doc-generator": "^11.2",
         "phpunit/phpunit": "^9.5.26",
         "myclabs/php-enum": "^1.8",
-        "symfony/framework-bundle": "^6.2"
+        "symfony/framework-bundle": "^6.1"
     },
     "autoload": {
         "psr-4": {

--- a/packages/rule-doc-generator/composer.json
+++ b/packages/rule-doc-generator/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/console": "^6.2",
         "nette/robot-loader": "^3.4",
         "symplify/symplify-kernel": "^11.2",

--- a/packages/symfony-static-dumper/composer.json
+++ b/packages/symfony-static-dumper/composer.json
@@ -10,7 +10,7 @@
         "symfony/finder": "^6.2",
         "symfony/http-foundation": "^6.2",
         "symfony/config": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symfony/routing": "^6.2",
         "symplify/autowire-array-parameter": "^11.2",
         "symplify/package-builder": "^11.2",

--- a/packages/symfony-static-dumper/composer.json
+++ b/packages/symfony-static-dumper/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "phpstan/phpstan": "^1.9.2",
         "phpunit/phpunit": "^9.5.26",
-        "symfony/framework-bundle": "^6.2",
+        "symfony/framework-bundle": "^6.1",
         "symfony/twig-bundle": "^6.2"
     },
     "autoload": {

--- a/packages/symplify-kernel/composer.json
+++ b/packages/symplify-kernel/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=8.1",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "symplify/smart-file-system": "^11.2",
         "symplify/autowire-array-parameter": "^11.2",
         "symplify/package-builder": "^11.2",

--- a/packages/vendor-patches/composer.json
+++ b/packages/vendor-patches/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.1",
         "nette/utils": "^3.2",
         "symfony/console": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "symfony/dependency-injection": "6.1.*",
         "sebastian/diff": "^4.0|^5.0",
         "cweagans/composer-patches": "^1.7",
         "symplify/composer-json-manipulator": "^11.2",


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/actions/runs/3613189654/jobs/6088783505#step:4:34

It can't be used in latest rector-src which the `@noRector` make crash.