### PR TITLE
Integrate FidryCpuCoreCounter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "composer/semver": "^3.3",
         "composer/xdebug-handler": "^3.0",
         "cweagans/composer-patches": "^1.7",
+        "fidry/cpu-core-counter": "^0.4.0",
         "friendsofphp/php-cs-fixer": "^3.12",
         "myclabs/php-enum": "^1.8",
         "nette/neon": "^3.3",

--- a/packages/easy-parallel/composer.json
+++ b/packages/easy-parallel/composer.json
@@ -9,7 +9,7 @@
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",
         "symfony/console": "^6.2",
-        "fidry/cpu-core-counter": "^0.2.0"
+        "fidry/cpu-core-counter": "^0.4.0"
     },
     "require-dev": {
         "symplify/package-builder": "^11.2",

--- a/packages/easy-parallel/composer.json
+++ b/packages/easy-parallel/composer.json
@@ -8,7 +8,8 @@
         "react/child-process": "^0.6.5",
         "react/event-loop": "^1.3",
         "react/socket": "^1.12",
-        "symfony/console": "^6.2"
+        "symfony/console": "^6.2",
+        "fidry/cpu-core-counter": "^0.2.0"
     },
     "require-dev": {
         "symplify/package-builder": "^11.2",

--- a/packages/easy-parallel/src/CpuCoreCountProvider.php
+++ b/packages/easy-parallel/src/CpuCoreCountProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Symplify\EasyParallel;
 
-use Fidry\CpuCounter\CpuCoreCounter;
-use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
+use Fidry\CpuCoreCounter\CpuCoreCounter;
+use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 
 final class CpuCoreCountProvider
 {

--- a/packages/easy-parallel/src/CpuCoreCountProvider.php
+++ b/packages/easy-parallel/src/CpuCoreCountProvider.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace Symplify\EasyParallel;
 
-use Nette\Utils\Strings;
+use Fidry\CpuCounter\CpuCoreCounter;
+use Fidry\CpuCounter\NumberOfCpuCoreNotFound;
 
-/**
- * From https://github.com/phpstan/phpstan-src/commit/9124c66dcc55a222e21b1717ba5f60771f7dda92
- */
 final class CpuCoreCountProvider
 {
-    /**
-     * @see https://regex101.com/r/XMeAl4/1
-     * @var string
-     */
-    private const PROCESSOR_REGEX = '#^processor#m';
-
     /**
      * @var int
      */
@@ -24,52 +16,10 @@ final class CpuCoreCountProvider
 
     public function provide(): int
     {
-        // from brianium/paratest
-        $cpuInfoCount = $this->resolveFromProcCpuinfo();
-        if ($cpuInfoCount !== null) {
-            return $cpuInfoCount;
+        try {
+            return (new CpuCoreCounter())->getCount();
+        } catch (NumberOfCpuCoreNotFound) {
+            return self::DEFAULT_CORE_COUNT;
         }
-
-        $coreCount = self::DEFAULT_CORE_COUNT;
-
-        if (\DIRECTORY_SEPARATOR === '\\') {
-            // Windows
-            $process = @popen('wmic cpu get NumberOfCores', 'rb');
-            if ($process !== false) {
-                fgets($process);
-                $coreCount = (int) fgets($process);
-                pclose($process);
-            }
-
-            return $coreCount;
-        }
-
-        $process = @\popen('sysctl -n hw.ncpu', 'rb');
-        if ($process !== false) {
-            $coreCount = (int) fgets($process);
-            pclose($process);
-        }
-
-        return $coreCount;
-    }
-
-    private function resolveFromProcCpuinfo(): int|null
-    {
-        if (! is_file('/proc/cpuinfo')) {
-            return null;
-        }
-
-        // Linux (and potentially Windows with linux sub systems)
-        $cpuinfo = file_get_contents('/proc/cpuinfo');
-        if ($cpuinfo === false) {
-            return null;
-        }
-
-        $matches = Strings::matchAll($cpuinfo, self::PROCESSOR_REGEX);
-        if ($matches === []) {
-            return 0;
-        }
-
-        return count($matches);
     }
 }


### PR DESCRIPTION
See https://github.com/theofidry/cpu-core-counter/issues/11 for the motivations.

The code should be sensibly the same, the notable differences are:

- fixed the deprecated usage of `hw.ncpu`
- /proc/cpuinfo is check _last_
- nproc is checked first (before was not checked at all, it's considered to be more accurate and less convoluted than cpuinfo though)

Also note since this was analogue to PHPStan, I did the PR there too: https://github.com/phpstan/phpstan-src/pull/2047

I would also wait on 1.x before merging this if you're happy with it. Technically the current version is fine, I'm just looking for a round of feedback before publishing 1.0.

