### PR TITLE
Test rules should also support Test path as Prefix (e.g. Laravel)

### DIFF
--- a/packages/phpstan-rules/src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php
+++ b/packages/phpstan-rules/src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php
@@ -75,6 +75,20 @@ namespace App\Tests;
 class SomeTest
 {
 }
+
+// file: "AnotherTest.php
+namespace App\Tests\Features;
+
+class AnotherTest
+{
+}
+
+// file: "SomeOtherTest.php
+namespace Tests\Features;
+
+class SomeOtherTest
+{
+}
 CODE_SAMPLE
             ),
         ]);

--- a/packages/phpstan-rules/src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php
+++ b/packages/phpstan-rules/src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php
@@ -23,7 +23,7 @@ final class CheckNotTestsNamespaceOutsideTestsDirectoryRule implements Rule, Doc
     /**
      * @var string
      */
-    private const ERROR_MESSAGE = '"*Test.php" file cannot be located outside "Tests" namespace';
+    public const ERROR_MESSAGE = '"*Test.php" file cannot be located outside "Tests" namespace';
 
     /**
      * @return class-string<Node>

--- a/packages/phpstan-rules/src/ValueObject/Regex.php
+++ b/packages/phpstan-rules/src/ValueObject/Regex.php
@@ -11,7 +11,7 @@ final class Regex
      * Tests\\someName
      * someName\\Tests\\someOtherName
      *
-     * @see https://regex101.com/r/U7LxLr/3
+     * @see https://regex101.com/r/6pPP8u/2
      * @var string
      */
     public const TESTS_PART_REGEX = '#(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$)#';

--- a/packages/phpstan-rules/src/ValueObject/Regex.php
+++ b/packages/phpstan-rules/src/ValueObject/Regex.php
@@ -14,5 +14,5 @@ final class Regex
      * @see https://regex101.com/r/U7LxLr/3
      * @var string
      */
-    public const TESTS_PART_REGEX = '(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$)';
+    public const TESTS_PART_REGEX = '#(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$)#';
 }

--- a/packages/phpstan-rules/src/ValueObject/Regex.php
+++ b/packages/phpstan-rules/src/ValueObject/Regex.php
@@ -7,8 +7,12 @@ namespace Symplify\PHPStanRules\ValueObject;
 final class Regex
 {
     /**
-     * @see https://regex101.com/r/6pPP8u/1
+     * someName\\Tests
+     * Tests\\someName
+     * someName\\Tests\\someOtherName
+     *
+     * @see https://regex101.com/r/U7LxLr/3
      * @var string
      */
-    public const TESTS_PART_REGEX = '#(\\\\Tests\\\\|\\\\Tests$)#';
+    public const TESTS_PART_REGEX = '(^Tests\\\\|\\\\Tests\\\\|\\\\Tests$)';
 }

--- a/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/CheckNotTestsNamespaceOutsideTestsDirectoryRuleTest.php
+++ b/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/CheckNotTestsNamespaceOutsideTestsDirectoryRuleTest.php
@@ -28,7 +28,16 @@ final class CheckNotTestsNamespaceOutsideTestsDirectoryRuleTest extends RuleTest
      */
     public function provideData(): Iterator
     {
+        // expect error
+        yield [__DIR__ . '/Fixture/Fail/NotInTestsDirectory/FailNotInTestsDirectoryTest.php', [[CheckNotTestsNamespaceOutsideTestsDirectoryRule::ERROR_MESSAGE, 5]]];
+
+        // Skip
         yield [__DIR__ . '/Fixture/Tests/SkipTestsNamespaceInsideTestsDirectoryClass.php', []];
+
+        // Good
+        yield [__DIR__ . '/Fixture/Pass/EndWithTests/Tests/NameSpaceEndWithTestsFileTest.php', []];
+        yield [__DIR__ . '/Fixture/Pass/Tests/ContainsTestsDirectory/NameSpaceContainsTestsFileTest.php', []];
+        yield [__DIR__ . '/Fixture/Tests/InTestsDirectory/NameSpaceStarttWithTestsFileTest.php', []];
     }
 
     /**

--- a/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Fail/NotInTestsDirectory/FailNotInTestsDirectoryTest.php
+++ b/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Fail/NotInTestsDirectory/FailNotInTestsDirectoryTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fail\NotInTestsDirectory;
+
+class FailNotInTestsDirectoryTest
+{
+}

--- a/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Pass/EndWithTests/Tests/NameSpaceEndWithTestsFileTest.php
+++ b/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Pass/EndWithTests/Tests/NameSpaceEndWithTestsFileTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pass\EndWithTests\Tests;
+
+class NameSpaceEndWithTestsFileTest
+{
+}

--- a/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Pass/Tests/ContainsTestsDirectory/NameSpaceContainsTestsFileTest.php
+++ b/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Pass/Tests/ContainsTestsDirectory/NameSpaceContainsTestsFileTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pass\Tests\ContainsTestDirectory;
+
+class NameSpaceContainsTestsFileTest
+{
+}

--- a/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Tests/InTestsDirectory/NameSpaceStarttWithTestsFileTest.php
+++ b/packages/phpstan-rules/tests/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule/Fixture/Tests/InTestsDirectory/NameSpaceStarttWithTestsFileTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\InTestsDirectory;
+
+class NameSpaceStarttWithTestsFileTest
+{
+}


### PR DESCRIPTION
Projects like Laravel who wants to use this rule will get immediate complaints as their code is of the following structure:
```
- app
- tests
- vendors
```
This PR avoids such errors while maintaining the intent.

I did not see where to apply tests, please point me in the right direction if necessary.