### PR TITLE
Fix version dependency of tomasvotruba/cognitive-complexity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "rector/rector": "dev-main",
         "symfony/framework-bundle": "6.1.*",
         "symfony/twig-bundle": "6.1.*",
-        "tomasvotruba/cognitive-complexity": "^0.1.0",
+        "tomasvotruba/cognitive-complexity": "^0.0.1",
         "tomasvotruba/unused-public": "^0.0.25",
         "tracy/tracy": "^2.9.4"
     },


### PR DESCRIPTION
Fix error version 0.1.0

```
➜  symplify git:(main) composer install
No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires tomasvotruba/cognitive-complexity ^0.1.0, found tomasvotruba/cognitive-complexity[dev-main, 0.0.1, ..., 0.0.5.72] but it does not match the constraint.
```