### PR TITLE
Bump to PHPStan 1.9.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "icanhazstring/composer-unused": "^0.8.3",
         "ondram/ci-detector": "^4.1",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
-        "phpstan/phpstan": "^1.9.3",
+        "phpstan/phpstan": "^1.9.5",
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpunit/phpunit": "^9.5.26",
         "psr/log": "^1.1.4",

--- a/packages/phpstan-extensions/composer.json
+++ b/packages/phpstan-extensions/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.1",
-        "phpstan/phpstan": "^1.9.3",
+        "phpstan/phpstan": "^1.9.5",
         "symplify/package-builder": "^11.2"
     },
     "require-dev": {

--- a/packages/phpstan-rules/build/target-repository/composer.json
+++ b/packages/phpstan-rules/build/target-repository/composer.json
@@ -8,7 +8,7 @@
         "nikic/php-parser": "^4.14.0",
         "nette/utils": "^3.2",
         "phpstan/phpdoc-parser": "^1.6.3",
-        "phpstan/phpstan": "^1.8.1",
+        "phpstan/phpstan": "^1.9.5",
         "webmozart/assert": "^1.10"
     },
     "autoload": {

--- a/packages/phpstan-rules/composer.json
+++ b/packages/phpstan-rules/composer.json
@@ -11,7 +11,7 @@
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.9.3",
+        "phpstan/phpstan": "^1.9.5",
         "symplify/rule-doc-generator-contracts": "^11.2",
         "symplify/easy-testing": "^11.2",
         "symplify/phpstan-extensions": "^11.2",

--- a/packages/rule-doc-generator/composer.json
+++ b/packages/rule-doc-generator/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.26",
         "friendsofphp/php-cs-fixer": "^3.12",
-        "phpstan/phpstan": "^1.9.3"
+        "phpstan/phpstan": "^1.9.5"
     },
     "autoload": {
         "psr-4": {

--- a/packages/symfony-static-dumper/composer.json
+++ b/packages/symfony-static-dumper/composer.json
@@ -18,7 +18,7 @@
         "symplify/smart-file-system": "^11.2"
     },
     "require-dev": {
-        "phpstan/phpstan": "^1.9.3",
+        "phpstan/phpstan": "^1.9.5",
         "phpunit/phpunit": "^9.5.26",
         "symfony/framework-bundle": "6.1.*",
         "symfony/twig-bundle": "6.1.*"


### PR DESCRIPTION
PHPStan 1.9.5 released https://github.com/phpstan/phpstan/releases/tag/1.9.5

This PR bump PHPStan requirement to ^1.9.5