### PR TITLE
[CodingStandard] Make use of file path based testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "rector/rector": "dev-main",
         "symfony/framework-bundle": "6.1.*",
         "symfony/twig-bundle": "6.1.*",
-        "symplify/easy-coding-standard": "^11.1.30",
+        "symplify/easy-coding-standard": "^11.1.31",
         "tomasvotruba/cognitive-complexity": "^0.0.1",
         "tomasvotruba/unused-public": "^0.0.25",
         "tracy/tracy": "^2.9.4"

--- a/packages/coding-standard/composer.json
+++ b/packages/coding-standard/composer.json
@@ -17,7 +17,7 @@
         "symfony/framework-bundle": "6.1.*",
         "squizlabs/php_codesniffer": "^3.7.1",
         "symplify/easy-testing": "^11.2",
-        "symplify/easy-coding-standard": "^11.1.30",
+        "symplify/easy-coding-standard": "^11.1.31",
         "phpunit/phpunit": "^9.5.26",
         "symplify/rule-doc-generator": "^11.2",
         "cweagans/composer-patches": "^1.7"

--- a/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/RemovePHPStormAnnotationFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Annotation/RemovePHPStormAnnotationFixer/RemovePHPStormAnnotationFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Annotation\RemovePHPStormAnnotatio
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RemovePHPStormAnnotationFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/ArrayListItemNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayListItemNewlineFixer/ArrayListItemNewlineFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\ArrayListItemNewline
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ArrayListItemNewlineFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/ArrayOpenerAndCloserNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/ArrayOpenerAndCloserNewlineFixer/ArrayOpenerAndCloserNewlineFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\ArrayOpenerAndCloser
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ArrayOpenerAndCloserNewlineFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\StandaloneLineInMult
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class StandaloneLineInMultilineArrayFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTestPhp80Test.php
+++ b/packages/coding-standard/tests/Fixer/ArrayNotation/StandaloneLineInMultilineArrayFixer/StandaloneLineInMultilineArrayFixerTestPhp80Test.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\ArrayNotation\StandaloneLineInMult
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class StandaloneLineInMultilineArrayFixerTestPhp80Test extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixturePhp80');
+        yield self::yieldFiles(__DIR__ . '/FixturePhp80');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/ParamReturnAndVarTagMalformsFixer/ParamReturnAndVarTagMalformsFixerTest.php
@@ -6,8 +6,6 @@ namespace Symplify\CodingStandard\Tests\Fixer\Commenting\ParamReturnAndVarTagMal
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
  * @mimic https://github.com/rectorphp/rector/pull/807/files
@@ -17,17 +15,14 @@ final class ParamReturnAndVarTagMalformsFixerTest extends AbstractCheckerTestCas
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/RemoveUselessDefaultCommentFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Commenting/RemoveUselessDefaultCommentFixer/RemoveUselessDefaultCommentFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Commenting\RemoveUselessDefaultCom
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class RemoveUselessDefaultCommentFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/DocBlockLineLengthFixer/DocBlockLineLengthFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\LineLength\DocBlockLineLengthFixer
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class DocBlockLineLengthFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo[]>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ArrayLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ArrayLineLengthFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ArrayLineLengthFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureArray');
+        yield self::yieldFiles(__DIR__ . '/FixtureArray');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ConfiguredLineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/ConfiguredLineLengthFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class ConfiguredLineLengthFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureConfigured');
+        yield self::yieldFiles(__DIR__ . '/FixtureConfigured');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/LineLengthFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/LineLength/LineLengthFixer/LineLengthFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\LineLength\LineLengthFixer;
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class LineLengthFixerTest extends AbstractCheckerTestCase
 {
     /**
-     * @dataProvider provideDataForTest()
+     * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<SmartFileInfo>
-     */
-    public function provideDataForTest(): Iterator
+    public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/StandardizeHereNowDocKeywordFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Naming/StandardizeHereNowDocKeywordFixer/StandardizeHereNowDocKeywordFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Naming\StandardizeHereNowDocKeywor
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class StandardizeHereNowDocKeywordFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/MethodChainingNewlineFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/MethodChainingNewlineFixer/MethodChainingNewlineFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Spacing\MethodChainingNewlineFixer
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class MethodChainingNewlineFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/NewlineServiceDefinitionConfigFixer/NewlineServiceDefinitionConfigFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Spacing\NewlineServiceDefinitionCo
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class NewlineServiceDefinitionConfigFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/SpaceAfterCommaHereNowDocFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/SpaceAfterCommaHereNowDocFixer/SpaceAfterCommaHereNowDocFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Spacing\SpaceAfterCommaHereNowDocF
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class SpaceAfterCommaHereNowDocFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Spacing/StandaloneLineConstructorParamFixer/StandaloneLineConstructorParamFixerContraindicationsTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/StandaloneLineConstructorParamFixer/StandaloneLineConstructorParamFixerContraindicationsTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLineConstructorP
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class StandaloneLineConstructorParamFixerContraindicationsTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/FixtureContraindications');
+        yield self::yieldFiles(__DIR__ . '/FixtureContraindications');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Spacing/StandaloneLineConstructorParamFixer/StandaloneLineConstructorParamFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/StandaloneLineConstructorParamFixer/StandaloneLineConstructorParamFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLineConstructorP
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class StandaloneLineConstructorParamFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/StandaloneLinePromotedPropertyFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Spacing/StandaloneLinePromotedPropertyFixer/StandaloneLinePromotedPropertyFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Spacing\StandaloneLinePromotedProp
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class StandaloneLinePromotedPropertyFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
+++ b/packages/coding-standard/tests/Fixer/Strict/BlankLineAfterStrictTypesFixer/BlankLineAfterStrictTypesFixerTest.php
@@ -6,25 +6,20 @@ namespace Symplify\CodingStandard\Tests\Fixer\Strict\BlankLineAfterStrictTypesFi
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\EasyTesting\DataProvider\StaticFixtureFinder;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class BlankLineAfterStrictTypesFixerTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function testFix(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
-        return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture');
+        yield self::yieldFiles(__DIR__ . '/Fixture');
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Issues/InlineArrayTest.php
+++ b/packages/coding-standard/tests/Issues/InlineArrayTest.php
@@ -6,25 +6,21 @@ namespace Symplify\CodingStandard\Tests\Issues;
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class InlineArrayTest extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<SmartFileInfo[]>
-     */
     public function provideData(): Iterator
     {
-        yield [new SmartFileInfo(__DIR__ . '/Fixture/inline_array.php.inc')];
-        yield [new SmartFileInfo(__DIR__ . '/Fixture/skip_already_inlined.php.inc')];
+        yield [__DIR__ . '/Fixture/inline_array.php.inc'];
+        yield [__DIR__ . '/Fixture/skip_already_inlined.php.inc'];
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Issues/Issue896Test.php
+++ b/packages/coding-standard/tests/Issues/Issue896Test.php
@@ -6,24 +6,20 @@ namespace Symplify\CodingStandard\Tests\Issues;
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class Issue896Test extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<SmartFileInfo[]>
-     */
     public function provideData(): Iterator
     {
-        yield [new SmartFileInfo(__DIR__ . '/Fixture/correct896.php.inc')];
+        yield [__DIR__ . '/Fixture/correct896.php.inc'];
     }
 
     public function provideConfig(): string

--- a/packages/coding-standard/tests/Issues/Issue973Test.php
+++ b/packages/coding-standard/tests/Issues/Issue973Test.php
@@ -6,24 +6,20 @@ namespace Symplify\CodingStandard\Tests\Issues;
 
 use Iterator;
 use Symplify\EasyCodingStandard\Testing\PHPUnit\AbstractCheckerTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 final class Issue973Test extends AbstractCheckerTestCase
 {
     /**
      * @dataProvider provideData()
      */
-    public function test(SmartFileInfo $fileInfo): void
+    public function test(string $filePath): void
     {
-        $this->doTestFileInfo($fileInfo);
+        $this->doTestFile($filePath);
     }
 
-    /**
-     * @return Iterator<SmartFileInfo[]>
-     */
     public function provideData(): Iterator
     {
-        yield [new SmartFileInfo(__DIR__ . '/Fixture/correct973.php.inc')];
+        yield [__DIR__ . '/Fixture/correct973.php.inc'];
     }
 
     public function provideConfig(): string

--- a/packages/monorepo-builder/packages-tests/Merge/ComposerJsonMerger/ComposerJsonMergerTest.php
+++ b/packages/monorepo-builder/packages-tests/Merge/ComposerJsonMerger/ComposerJsonMergerTest.php
@@ -36,9 +36,6 @@ final class ComposerJsonMergerTest extends AbstractComposerJsonDecoratorTest
         $this->assertComposerJsonEquals($trioContent->getExpectedResult(), $mainComposerJson);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture', '*.json');

--- a/packages/monorepo-builder/packages-tests/Merge/ComposerKeyMerger/MinimalStabilityKeyMergerTest.php
+++ b/packages/monorepo-builder/packages-tests/Merge/ComposerKeyMerger/MinimalStabilityKeyMergerTest.php
@@ -30,9 +30,6 @@ final class MinimalStabilityKeyMergerTest extends AbstractComposerJsonDecoratorT
         $this->assertComposerJsonEquals($trioContent->getExpectedResult(), $mainComposerJson);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture/MinimalStability', '*.json');

--- a/packages/monorepo-builder/packages-tests/Propagate/VersionPropagator/VersionPropagaterTest.php
+++ b/packages/monorepo-builder/packages-tests/Propagate/VersionPropagator/VersionPropagaterTest.php
@@ -35,9 +35,6 @@ final class VersionPropagaterTest extends AbstractComposerJsonDecoratorTest
         $this->assertComposerJsonEquals($trioContent->getExpectedResult(), $packageComposerJson);
     }
 
-    /**
-     * @return Iterator<mixed, SmartFileInfo>
-     */
     public function provideData(): Iterator
     {
         return StaticFixtureFinder::yieldDirectoryExclusively(__DIR__ . '/Fixture', '*.json');


### PR DESCRIPTION
This will prevent conflicts with `SmartFileInfo` prefixed class:

![image](https://user-images.githubusercontent.com/924196/210363009-f92cd016-b54b-4c5a-9151-6b8a3c06437f.png)

https://github.com/symplify/symplify/actions/runs/3825967304/jobs/6509374280

