### PR TITLE
Require symfony/dependency-injection 6.1.* for symplify/coding-standard

### DIFF
--- a/packages/coding-standard/composer.json
+++ b/packages/coding-standard/composer.json
@@ -6,6 +6,7 @@
         "php": ">=8.1",
         "nette/utils": "^3.2",
         "friendsofphp/php-cs-fixer": "^3.12",
+        "symfony/dependency-injection": "6.1.*",
         "symplify/symplify-kernel": "^11.2",
         "symplify/package-builder": "^11.2",
         "symplify/autowire-array-parameter": "^11.2",


### PR DESCRIPTION
To avoid error:

```bash
  - Applying patches for symfony/dependency-injection
    https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch (0)
   Could not apply patch! Skipping. The error was: Cannot apply patch https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch
```

ref https://github.com/rectorphp/getrector.org/pull/981
closes https://github.com/rectorphp/getrector.org/pull/981